### PR TITLE
feat: redirect http to https

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,6 +17,8 @@ config :arrow, ArrowWeb.Endpoint,
   render_errors: [view: ArrowWeb.ErrorView, accepts: ~w(html json)],
   pubsub: [name: Arrow.PubSub, adapter: Phoenix.PubSub.PG2]
 
+config :arrow, :redirect_http?, true
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -66,6 +66,8 @@ config :arrow, ArrowWeb.Endpoint,
     ]
   ]
 
+config :arrow, :redirect_http?, false
+
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"
 

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -13,8 +13,14 @@ defmodule ArrowWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :redirect_prod_http do
+    if Application.get_env(:arrow, :redirect_http?) do
+      plug(Plug.SSL, rewrite_on: [:x_forwarded_proto])
+    end
+  end
+
   scope "/", ArrowWeb do
-    pipe_through :browser
+    pipe_through [:redirect_prod_http, :browser]
 
     get "/", PageController, :index
   end

--- a/test/arrow_web/controllers/page_controller_test.exs
+++ b/test/arrow_web/controllers/page_controller_test.exs
@@ -5,4 +5,14 @@ defmodule ArrowWeb.PageControllerTest do
     conn = get(conn, "/")
     assert html_response(conn, 200) =~ "Welcome to Phoenix!"
   end
+
+  test "GET / with HTTP redirects to HTTPS", %{conn: conn} do
+    conn = conn |> Plug.Conn.put_req_header("x-forwarded-proto", "http") |> get("/")
+
+    location_header = Enum.find(conn.resp_headers, fn {key, _value} -> key == "location" end)
+    {"location", url} = location_header
+    assert url =~ "https"
+
+    assert response(conn, 301)
+  end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -35,6 +35,7 @@ defmodule ArrowWeb.ConnCase do
       Ecto.Adapters.SQL.Sandbox.mode(Arrow.Repo, {:shared, self()})
     end
 
-    {:ok, conn: Phoenix.ConnTest.build_conn()}
+    {:ok,
+     conn: Phoenix.ConnTest.build_conn() |> Plug.Conn.put_req_header("x-forwarded-proto", "https")}
   end
 end


### PR DESCRIPTION
Ticket: [🏹 Redirect prod requests to HTTPS](https://app.asana.com/0/584764604969369/1154773501302867/f)

This is basically the same way Signs UI does it, but I went with the default-to-secure approach here and explicitly overrode it to _not_ redirect to HTTPs in dev and test. Apparently Codecov thinks this is fine and the equivalent code in Signs UI has no tests I can find, but it would be nice to test it somehow, I'm just not sure how...