### PR TITLE
feat: run migrations at startup (prod only)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,8 @@ use Mix.Config
 
 config :arrow,
   ecto_repos: [Arrow.Repo],
-  aws_rds_mod: ExAws.RDS
+  aws_rds_mod: ExAws.RDS,
+  run_migrations_at_startup?: false
 
 # Configures the endpoint
 config :arrow, ArrowWeb.Endpoint,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -20,6 +20,9 @@ config :arrow, ArrowWeb.AuthManager, secret_key: {System, :get_env, ["ARROW_AUTH
 # Do not print debug messages in production
 config :logger, level: :info
 
+config :arrow,
+  run_migrations_at_startup?: true
+
 config :arrow, Arrow.Repo, ssl: true
 
 # ## SSL Support

--- a/lib/arrow/application.ex
+++ b/lib/arrow/application.ex
@@ -6,15 +6,18 @@ defmodule Arrow.Application do
   use Application
 
   def start(_type, _args) do
+    run_migrations_at_startup? = Application.get_env(:arrow, :run_migrations_at_startup?)
+
     # List all child processes to be supervised
-    children = [
-      # Start the Ecto repository
-      Arrow.Repo,
-      # Start the endpoint when the application starts
-      ArrowWeb.Endpoint
-      # Starts a worker by calling: Arrow.Worker.start_link(arg)
-      # {Arrow.Worker, arg},
-    ]
+    children =
+      [
+        # Start the Ecto repository
+        Arrow.Repo,
+        # Start the endpoint when the application starts
+        ArrowWeb.Endpoint
+        # Starts a worker by calling: Arrow.Worker.start_link(arg)
+        # {Arrow.Worker, arg},
+      ] ++ migrate_children(run_migrations_at_startup?)
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
@@ -27,5 +30,13 @@ defmodule Arrow.Application do
   def config_change(changed, _new, removed) do
     ArrowWeb.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  def migrate_children(true) do
+    [Arrow.Repo.Migrator]
+  end
+
+  def migrate_children(false) do
+    []
   end
 end

--- a/lib/arrow/repo/migrator.ex
+++ b/lib/arrow/repo/migrator.ex
@@ -1,0 +1,43 @@
+defmodule Arrow.Repo.Migrator do
+  @moduledoc """
+  GenServer which runs on startup to run Ecto migrations, then terminates.
+  """
+  use GenServer, restart: :transient
+  require Logger
+
+  @opts [module: Ecto.Migrator]
+
+  def start_link(opts) do
+    opts = Keyword.merge(@opts, opts)
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    {:ok, opts, {:continue, :migrate}}
+  end
+
+  @impl GenServer
+  def handle_continue(:migrate, opts) do
+    migrate!(opts[:module])
+    {:stop, :normal, opts}
+  end
+
+  defp migrate!(module) do
+    for repo <- repos() do
+      _ = Logger.info(fn -> "Migrating repo=#{repo}" end)
+
+      {time_usec, {:ok, _, _}} =
+        :timer.tc(module, :with_repo, [repo, &module.run(&1, :up, all: true)])
+
+      time_msec = System.convert_time_unit(time_usec, :microsecond, :millisecond)
+      _ = Logger.info(fn -> "Migration finished repo=#{repo} time=#{time_msec}" end)
+    end
+
+    :ok
+  end
+
+  defp repos do
+    Application.fetch_env!(:arrow, :ecto_repos)
+  end
+end

--- a/test/arrow/application_test.exs
+++ b/test/arrow/application_test.exs
@@ -1,0 +1,15 @@
+defmodule Arrow.ApplicationTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  import Arrow.Application
+
+  describe "migrate_children/1" do
+    test "starts the migrator when passed true" do
+      assert migrate_children(true) == [Arrow.Repo.Migrator]
+    end
+
+    test "starts nothing when passed false" do
+      assert migrate_children(false) == []
+    end
+  end
+end

--- a/test/arrow/repo/migrator_test.exs
+++ b/test/arrow/repo/migrator_test.exs
@@ -1,0 +1,76 @@
+defmodule FakeMigrator do
+  @moduledoc "Fake implementation of Ecto.Migrator"
+  def with_repo(repo, fun) do
+    :ok = fun.(repo)
+    {:ok, :ok, :ok}
+  end
+
+  def run(Arrow.Repo, :up, all: true) do
+    :ok
+  end
+end
+
+defmodule Arrow.Repo.MigratorTest do
+  @moduledoc false
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+
+  alias Arrow.Repo.Migrator
+
+  describe "child_spec/1" do
+    test "restart is transient" do
+      assert %{
+               restart: :transient
+             } = Migrator.child_spec([])
+    end
+  end
+
+  describe "start_link/1" do
+    test "can start the server" do
+      assert {:ok, pid} = Migrator.start_link(module: FakeMigrator)
+    end
+
+    test "logs a migration for each repo" do
+      log_level_info()
+
+      log =
+        capture_log(fn ->
+          {:ok, pid} = Migrator.start_link(module: FakeMigrator)
+          :ok = await_stopped(pid)
+        end)
+
+      assert log =~ "Migrating"
+      assert log =~ "Migration finished"
+      assert log =~ "repo=Elixir.Arrow.Repo"
+      assert log =~ "time="
+    end
+  end
+
+  defp log_level_info() do
+    old_level = Logger.level()
+
+    on_exit(fn ->
+      Logger.configure(level: old_level)
+    end)
+
+    Logger.configure(level: :info)
+
+    :ok
+  end
+
+  defp await_stopped(pid) do
+    ref = Process.monitor(pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, good_exit} when good_exit in [:normal, :noproc] ->
+        refute Process.alive?(pid)
+        :ok
+
+      {:DOWN, ^ref, :process, ^pid, exit} ->
+        {:error, exit}
+    after
+      5_000 ->
+        {:error, :timeout}
+    end
+  end
+end


### PR DESCRIPTION
We run a transient GenServer to handle the migrations, and then stop when the
migrations complete. If there's an error, the supervision tree will restart
the migration task.