### PR TITLE
Load adjustments on startup

### DIFF
--- a/lib/arrow/adjustment.ex
+++ b/lib/arrow/adjustment.ex
@@ -33,6 +33,6 @@ defmodule Arrow.Adjustment do
     adjustment
     |> cast(attrs, [:source, :source_label, :route_id])
     |> validate_required([:source, :source_label, :route_id])
-    |> unique_constraint(:source_source_label, name: :adjustments_source_source_label)
+    |> unique_constraint(:source_label)
   end
 end

--- a/lib/arrow/adjustment_fetcher.ex
+++ b/lib/arrow/adjustment_fetcher.ex
@@ -1,0 +1,50 @@
+defmodule Arrow.AdjustmentFetcher do
+  @moduledoc """
+  Reads in information on what adjustments are present in GTFS Creator
+  and saves them to the database. Currently reads from the `priv`
+  directory once on startup, but eventually this will poll some sort
+  of API on a regular basis.
+  """
+
+  use GenServer, restart: :transient
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, [])
+  end
+
+  @impl true
+  def init(opts \\ []) do
+    :ok =
+      opts[:path]
+      |> File.read!()
+      |> Jason.decode!()
+      |> update_adjustment_data!()
+
+    :ignore
+  end
+
+  @spec update_adjustment_data!(map()) :: :ok
+  defp update_adjustment_data!(parsed_adjustments) do
+    timestamp = DateTime.truncate(DateTime.utc_now(), :second)
+
+    adjustments =
+      Enum.map(parsed_adjustments, fn parsed_adjustment ->
+        %{
+          source: "gtfs_creator",
+          source_label: parsed_adjustment["id"],
+          route_id: parsed_adjustment["attributes"]["route_id"],
+          inserted_at: timestamp,
+          updated_at: timestamp
+        }
+      end)
+
+    {_, _} =
+      Arrow.Repo.insert_all(Arrow.Adjustment, adjustments,
+        on_conflict: [set: [source: "gtfs_creator"]],
+        conflict_target: :source_label
+      )
+
+    :ok
+  end
+end

--- a/lib/arrow/application.ex
+++ b/lib/arrow/application.ex
@@ -13,6 +13,7 @@ defmodule Arrow.Application do
       [
         # Start the Ecto repository
         Arrow.Repo,
+        {Arrow.AdjustmentFetcher, path: Application.app_dir(:arrow, "priv/repo/shuttles.json")},
         # Start the endpoint when the application starts
         ArrowWeb.Endpoint
         # Starts a worker by calling: Arrow.Worker.start_link(arg)

--- a/priv/repo/migrations/20200129212636_update_adjustments_unique_index.exs
+++ b/priv/repo/migrations/20200129212636_update_adjustments_unique_index.exs
@@ -1,0 +1,9 @@
+defmodule Arrow.Repo.Migrations.UpdateAdjustmentsUniqueIndex do
+  use Ecto.Migration
+
+  def change do
+    drop index(:adjustments, [:source, :source_label], name: :adjustments_source_source_label)
+
+    create unique_index(:adjustments, [:source_label])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -30,7 +30,7 @@ adjustments =
     }
   end)
 
-Repo.insert_all(Adjustment, adjustments)
+Repo.insert_all(Adjustment, adjustments, on_conflict: :nothing)
 
 for attrs <- [
       %{

--- a/test/arrow/adjustment_fetcher_test.exs
+++ b/test/arrow/adjustment_fetcher_test.exs
@@ -1,0 +1,39 @@
+defmodule Arrow.PredictionFetcherTest do
+  use ExUnit.Case
+
+  @test_json_filename "test_adjustments.json"
+
+  @test_json [%{id: "foo", attributes: %{route_id: "bar"}}] |> Jason.encode!()
+
+  setup do
+    on_exit(fn -> File.rm_rf!(@test_json_filename) end)
+
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Arrow.Repo)
+
+    File.write!(@test_json_filename, @test_json)
+  end
+
+  describe "init/1" do
+    test "inserts data" do
+      :ignore = Arrow.AdjustmentFetcher.init(path: @test_json_filename)
+
+      assert [%Arrow.Adjustment{source_label: "foo", route_id: "bar", source: "gtfs_creator"}] =
+               Arrow.Repo.all(Arrow.Adjustment)
+    end
+
+    test "updates source if an adjustment with the same label already exists" do
+      adj = %Arrow.Adjustment{
+        source: "arrow",
+        source_label: "foo",
+        route_id: "bar"
+      }
+
+      {:ok, _new_adj} = Arrow.Repo.insert(adj)
+
+      :ignore = Arrow.AdjustmentFetcher.init(path: @test_json_filename)
+
+      assert [%Arrow.Adjustment{source_label: "foo", source: "gtfs_creator"}] =
+               Arrow.Repo.all(Arrow.Adjustment)
+    end
+  end
+end

--- a/test/arrow/adjustment_fetcher_test.exs
+++ b/test/arrow/adjustment_fetcher_test.exs
@@ -35,5 +35,42 @@ defmodule Arrow.PredictionFetcherTest do
       assert [%Arrow.Adjustment{source_label: "foo", source: "gtfs_creator"}] =
                Arrow.Repo.all(Arrow.Adjustment)
     end
+
+    test "cleans out old gtfs_creator adjustments no longer present in the JSON" do
+      adj = %Arrow.Adjustment{
+        source: "gtfs_creator",
+        source_label: "no_longer_exists",
+        route_id: "bar"
+      }
+
+      {:ok, _new_adj} = Arrow.Repo.insert(adj)
+
+      :ignore = Arrow.AdjustmentFetcher.init(path: @test_json_filename)
+
+      assert is_nil(Arrow.Repo.get_by(Arrow.Adjustment, source_label: "no_longer_exists"))
+    end
+
+    test "doesn't remove adjustments that are no longer present if they're still associated with disruptions" do
+      adj = %Arrow.Adjustment{
+        source: "gtfs_creator",
+        source_label: "no_longer_exists",
+        route_id: "bar"
+      }
+
+      {:ok, new_adj} = Arrow.Repo.insert(adj)
+
+      disruption = %Arrow.Disruption{
+        adjustments: [new_adj]
+      }
+
+      {:ok, _new_disruption} = Arrow.Repo.insert(disruption)
+
+      :ignore = Arrow.AdjustmentFetcher.init(path: @test_json_filename)
+
+      refute Arrow.Adjustment
+             |> Arrow.Repo.all()
+             |> Enum.find(fn a -> a.source_label == "no_longer_exists" end)
+             |> is_nil()
+    end
   end
 end

--- a/test/arrow/adjustment_test.exs
+++ b/test/arrow/adjustment_test.exs
@@ -1,19 +1,15 @@
 defmodule Arrow.AdjustmentTest do
   @moduledoc false
-  use Arrow.DataCase, async: true
+  use Arrow.DataCase
   alias Arrow.Adjustment
   alias Arrow.Repo
 
   describe "database" do
-    test "starts with no adjustments" do
-      assert [] = Repo.all(Adjustment)
-    end
-
     test "can insert an adjustment" do
       adj = %Adjustment{
         source: "testing",
-        source_label: "NewtonHighlandsKenmore",
-        route_id: "Green-D"
+        source_label: "test_insert_adjustment",
+        route_id: "test_route"
       }
 
       assert {:ok, new_adj} = Repo.insert(adj)
@@ -21,20 +17,20 @@ defmodule Arrow.AdjustmentTest do
       assert adj.source_label == new_adj.source_label
       assert adj.route_id == new_adj.route_id
 
-      assert [^new_adj] = Repo.all(Adjustment)
+      assert new_adj in Repo.all(Adjustment)
     end
 
     test "source_label is unique" do
       adj1 = %Adjustment{
         source: "testing1",
-        source_label: "NewtonHighlandsKenmore",
-        route_id: "Green-D"
+        source_label: "test_unique_source_label",
+        route_id: "test_route"
       }
 
       adj2 = %Adjustment{
         source: "testing2",
-        source_label: "NewtonHighlandsKenmore",
-        route_id: "Green-D"
+        source_label: "test_unique_source_label",
+        route_id: "test_route"
       }
 
       assert {:ok, _} = Repo.insert(adj1)

--- a/test/arrow/adjustment_test.exs
+++ b/test/arrow/adjustment_test.exs
@@ -24,15 +24,21 @@ defmodule Arrow.AdjustmentTest do
       assert [^new_adj] = Repo.all(Adjustment)
     end
 
-    test "source/source_label is unique" do
-      adj = %Adjustment{
-        source: "testing",
+    test "source_label is unique" do
+      adj1 = %Adjustment{
+        source: "testing1",
         source_label: "NewtonHighlandsKenmore",
         route_id: "Green-D"
       }
 
-      assert {:ok, _} = Repo.insert(adj)
-      assert {:error, _} = Repo.insert(Adjustment.changeset(adj, %{}))
+      adj2 = %Adjustment{
+        source: "testing2",
+        source_label: "NewtonHighlandsKenmore",
+        route_id: "Green-D"
+      }
+
+      assert {:ok, _} = Repo.insert(adj1)
+      assert {:error, _} = Repo.insert(Adjustment.changeset(adj2, %{}))
     end
   end
 end

--- a/test/arrow/disruption_test.exs
+++ b/test/arrow/disruption_test.exs
@@ -1,6 +1,6 @@
 defmodule Arrow.DisruptionTest do
   @moduledoc false
-  use Arrow.DataCase, async: true
+  use Arrow.DataCase
   alias Arrow.Adjustment
   alias Arrow.Disruption
   alias Arrow.Repo
@@ -28,8 +28,8 @@ defmodule Arrow.DisruptionTest do
     test "can insert a disruption with adjustments" do
       adj = %Adjustment{
         source: "testing",
-        source_label: "NewtonHighlandsKenmore",
-        route_id: "Green-D"
+        source_label: "test_insert_disruption",
+        route_id: "test_route"
       }
 
       {:ok, new_adj} = Repo.insert(adj)


### PR DESCRIPTION
Asana ticket: [🏹 Arrow loads adjustments on startup](https://app.asana.com/0/584764604969369/1157557244099559/f)

Two commits should be reviewable independently. The fact that the app now loads stuff into the database on startup makes testing a little weird. I've tried to make it all make sense, but some things like testing that the database starts out with no adjustments just don't really apply anymore.