### PR TITLE
feat: Style disruption 'day of week' selector

### DIFF
--- a/assets/css/_forms.scss
+++ b/assets/css/_forms.scss
@@ -17,6 +17,6 @@
   }
 
   & input:checked + label {
-    background-color: rgb(182, 225, 178);
+    background-color: rgb(46, 139, 224);
   }
 }

--- a/assets/css/_forms.scss
+++ b/assets/css/_forms.scss
@@ -1,3 +1,22 @@
 .m-forms__sublegend {
   font-weight: bold;
 }
+
+.m-forms__day-of-week-bubble {
+  & input {
+    display: none;
+  }
+
+  & label {
+    border: 1px solid #aaa;
+    border-radius: 1.25rem;
+    height: 2.5rem;
+    padding-top: 0.4rem;
+    text-align: center;
+    width: 2.5rem;
+  }
+
+  & input:checked + label {
+    background-color: rgb(182, 225, 178);
+  }
+}

--- a/assets/src/disruptions/disruptionTimePicker.tsx
+++ b/assets/src/disruptions/disruptionTimePicker.tsx
@@ -84,18 +84,19 @@ const DisruptionDaysOfWeek = ({
       <div className="m-forms__sublegend">Select days of the week</div>
       {["M", "T", "W", "Th", "F", "Sa", "Su"].map((day, i) => {
         return (
-          <Form.Check
-            key={day}
-            inline
-            type="checkbox"
-            id={`day-of-week-${day}`}
-            label={day}
-            name="day-of-week"
-            checked={disruptionDaysOfWeek[i] !== null}
-            onChange={() => {
-              handleClick(i)
-            }}
-          />
+          <span key={day} className="m-forms__day-of-week-bubble">
+            <Form.Check
+              inline
+              type="checkbox"
+              id={`day-of-week-${day}`}
+              label={day}
+              name="day-of-week"
+              checked={disruptionDaysOfWeek[i] !== null}
+              onChange={() => {
+                handleClick(i)
+              }}
+            />
+          </span>
         )
       })}
     </Form.Group>


### PR DESCRIPTION
Asana: [🏹 Days of week should be stylized circles rather than checkboxes](https://app.asana.com/0/584764604969369/1158326786257803).

<img width="491" alt="Screen Shot 2020-03-03 at 3 40 45 PM" src="https://user-images.githubusercontent.com/384428/75822868-5017b600-5d66-11ea-9216-41ada7345616.png">
