### PR TITLE
feat: disruption time of day picker

### DIFF
--- a/assets/src/disruptions/newDisruptionPreview.tsx
+++ b/assets/src/disruptions/newDisruptionPreview.tsx
@@ -23,7 +23,13 @@ const DayOfWeekPreview = ({
       <span className="m-new-disruption-preview__day_label">
         {indexToDayOfWeekString(dayIndex)}
       </span>
-      {timeStart} &ndash; {timeEnd}
+      {timeStart
+        ? `${timeStart.hour}:${timeStart.minute}${timeStart.period}`
+        : "Start of service"}{" "}
+      &ndash;{" "}
+      {timeEnd
+        ? `${timeEnd.hour}:${timeEnd.minute}${timeEnd.period}`
+        : "End of service"}
     </div>
   )
 }

--- a/assets/tests/disruptions/disruptionTimePicker.test.tsx
+++ b/assets/tests/disruptions/disruptionTimePicker.test.tsx
@@ -63,20 +63,66 @@ describe("DisruptionTimePicker", () => {
 
     expect(
       wrapper.find(DisruptionTimePicker).props().disruptionDaysOfWeek
-    ).toStrictEqual([["TBD", "TBD"], null, null, null, null, null, null])
+    ).toStrictEqual([[null, null], null, null, null, null, null, null])
 
     wrapper
-      .find("select#time-of-day-start-0")
-      .simulate("change", { target: { value: "Beginning of Service" } })
+      .find("input#time-of-day-start-type-0")
+      .simulate("change", { target: { checked: false } })
 
     wrapper
-      .find("select#time-of-day-end-0")
-      .simulate("change", { target: { value: "End of Service" } })
+      .find("input#time-of-day-end-type-0")
+      .simulate("change", { target: { checked: false } })
 
     expect(
       wrapper.find(DisruptionTimePicker).props().disruptionDaysOfWeek
     ).toStrictEqual([
-      ["Beginning of Service", "End of Service"],
+      [
+        { hour: "12", minute: "00", period: "AM" },
+        { hour: "12", minute: "00", period: "AM" },
+      ],
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ])
+
+    wrapper
+      .find("select#time-of-day-start-hour-0")
+      .simulate("change", { target: { value: "9" } })
+
+    wrapper
+      .find("select#time-of-day-end-minute-0")
+      .simulate("change", { target: { value: "30" } })
+
+    wrapper
+      .find("select#time-of-day-end-period-0")
+      .simulate("change", { target: { value: "PM" } })
+
+    expect(
+      wrapper.find(DisruptionTimePicker).props().disruptionDaysOfWeek
+    ).toStrictEqual([
+      [
+        { hour: "9", minute: "00", period: "AM" },
+        { hour: "12", minute: "30", period: "PM" },
+      ],
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ])
+
+    wrapper
+      .find("input#time-of-day-end-type-0")
+      .simulate("change", { target: { checked: true } })
+
+    expect(
+      wrapper.find(DisruptionTimePicker).props().disruptionDaysOfWeek
+    ).toStrictEqual([
+      [{ hour: "9", minute: "00", period: "AM" }, null],
       null,
       null,
       null,

--- a/assets/tests/disruptions/newDisruptionPreview.test.tsx
+++ b/assets/tests/disruptions/newDisruptionPreview.test.tsx
@@ -35,7 +35,7 @@ describe("NewDisruptionPreview", () => {
   })
 
   test("Days of week are included and translated", () => {
-    const text = mount(
+    let text = mount(
       <NewDisruptionPreview
         adjustments={[]}
         setIsPreview={() => null}
@@ -44,7 +44,7 @@ describe("NewDisruptionPreview", () => {
         disruptionDaysOfWeek={[
           null,
           null,
-          ["Beginning of Service", "End of Service"],
+          [null, null],
           null,
           null,
           null,
@@ -55,6 +55,31 @@ describe("NewDisruptionPreview", () => {
     ).text()
 
     expect(text).toMatch("Wednesday")
-    expect(text).toMatch("Beginning of Service – End of Service")
+    expect(text).toMatch("Start of service – End of service")
+
+    text = mount(
+      <NewDisruptionPreview
+        adjustments={[]}
+        setIsPreview={() => null}
+        fromDate={null}
+        toDate={null}
+        disruptionDaysOfWeek={[
+          null,
+          null,
+          null,
+          [
+            { hour: "12", minute: "30", period: "AM" },
+            { hour: "9", minute: "30", period: "PM" },
+          ],
+          null,
+          null,
+          null,
+        ]}
+        exceptionDates={[new Date(2020, 0, 10)]}
+      />
+    ).text()
+
+    expect(text).toMatch("Thursday")
+    expect(text).toMatch("12:30AM – 9:30PM")
   })
 })


### PR DESCRIPTION
Asana ticket: [🏹 Time of day selectors should have AM/PM widget](https://app.asana.com/0/584764604969369/1158326786257805/f)

<img width="520" alt="Screen Shot 2020-03-03 at 4 49 56 PM" src="https://user-images.githubusercontent.com/18427346/75828732-852e0380-5d7a-11ea-9a9f-ecb2daa151b8.png">
