### PR TITLE
feat: front-end edit page

### DIFF
--- a/assets/css/_disruption_summary.scss
+++ b/assets/css/_disruption_summary.scss
@@ -16,3 +16,7 @@
 .m-disruption-summary__adjustment_route {
   font-style: italic;
 }
+
+.m-disruption-summary__disruption_id {
+  font-size: 1rem;
+}

--- a/assets/src/disruptions/disruptionPreview.tsx
+++ b/assets/src/disruptions/disruptionPreview.tsx
@@ -34,7 +34,8 @@ const DayOfWeekPreview = ({
   )
 }
 
-interface NewDisruptionPreviewProps {
+interface DisruptionPreviewProps {
+  disruptionId?: string
   adjustments: Adjustment[]
   setIsPreview: React.Dispatch<boolean>
   fromDate: Date | null
@@ -43,14 +44,15 @@ interface NewDisruptionPreviewProps {
   exceptionDates: Date[]
 }
 
-const NewDisruptionPreview = ({
+const DisruptionPreview = ({
+  disruptionId,
   adjustments,
   setIsPreview,
   fromDate,
   toDate,
   disruptionDaysOfWeek,
   exceptionDates,
-}: NewDisruptionPreviewProps): JSX.Element => {
+}: DisruptionPreviewProps): JSX.Element => {
   const listedDays: JSX.Element[] = []
   disruptionDaysOfWeek.forEach((timeRange, i) => {
     if (timeRange !== null) {
@@ -71,7 +73,10 @@ const NewDisruptionPreview = ({
 
   return (
     <div>
-      <DisruptionSummary adjustments={adjustments} />
+      <DisruptionSummary
+        disruptionId={disruptionId}
+        adjustments={adjustments}
+      />
       <h2>When</h2>
       <p>
         {formatDisruptionDate(fromDate)} &ndash; {formatDisruptionDate(toDate)}
@@ -90,4 +95,4 @@ const NewDisruptionPreview = ({
   )
 }
 
-export { NewDisruptionPreview }
+export { DisruptionPreview }

--- a/assets/src/disruptions/disruptionSummary.tsx
+++ b/assets/src/disruptions/disruptionSummary.tsx
@@ -2,10 +2,12 @@ import * as React from "react"
 import { Adjustment } from "./disruptions"
 
 interface DisruptionSummaryProps {
+  disruptionId?: string
   adjustments: Adjustment[]
 }
 
 const DisruptionSummary = ({
+  disruptionId,
   adjustments,
 }: DisruptionSummaryProps): JSX.Element => {
   return (
@@ -15,6 +17,13 @@ const DisruptionSummary = ({
           <span className="m-disruption-summary__adjustment_label">
             {adjustment.label}
           </span>
+          {disruptionId && (
+            <div>
+              <span className="m-disruption-summary__disruption_id">
+                Disruption ID: {disruptionId}
+              </span>
+            </div>
+          )}
           <div>
             <span className="m-disruption-summary__adjustment_route">
               {adjustment.route}

--- a/assets/src/disruptions/editDisruption.tsx
+++ b/assets/src/disruptions/editDisruption.tsx
@@ -2,8 +2,11 @@ import * as React from "react"
 import Button from "react-bootstrap/Button"
 import ButtonGroup from "react-bootstrap/ButtonGroup"
 import { RouteComponentProps } from "react-router-dom"
+import { Redirect } from "react-router"
 
 import Header from "../header"
+import { DisruptionPreview } from "./disruptionPreview"
+import { DisruptionSummary } from "./disruptionSummary"
 import {
   DayOfWeekTimeRanges,
   DisruptionTimePicker,
@@ -13,21 +16,31 @@ interface TParams {
   id: string
 }
 
-const AdjustmentSummary = (): JSX.Element => {
-  return (
-    <div>
-      <div>Adjustment name(s) go here.</div>
-      <div>Disruption ID goes here.</div>
-      <div>Route bullet goes here.</div>
-    </div>
-  )
+interface SaveCancelButtonProps {
+  setRedirect: React.Dispatch<boolean>
+  setIsPreview: React.Dispatch<boolean>
 }
 
-const SaveCancelButton = (): JSX.Element => {
+const SaveCancelButton = ({
+  setRedirect,
+  setIsPreview,
+}: SaveCancelButtonProps): JSX.Element => {
   return (
     <ButtonGroup vertical>
-      <Button variant="primary">save changes</Button>
-      <Button variant="light">cancel</Button>
+      <Button
+        variant="primary"
+        onClick={() => setIsPreview(true)}
+        id="save-changes-button"
+      >
+        save changes
+      </Button>
+      <Button
+        variant="light"
+        onClick={() => setRedirect(true)}
+        id="cancel-button"
+      >
+        cancel
+      </Button>
     </ButtonGroup>
   )
 }
@@ -35,31 +48,129 @@ const SaveCancelButton = (): JSX.Element => {
 const EditDisruption = ({
   match,
 }: RouteComponentProps<TParams>): JSX.Element => {
-  const [fromDate, setFromDate] = React.useState<Date | null>(null)
-  const [toDate, setToDate] = React.useState<Date | null>(null)
-  const [exceptionDates, setExceptionDates] = React.useState<Date[]>([])
+  // TODO: Dummy data, to be filled in with the results from an API call once that's ready
+  const [fromDate, setFromDate] = React.useState<Date | null>(
+    new Date("2020-03-06")
+  )
+  const [toDate, setToDate] = React.useState<Date | null>(
+    new Date("2020-03-22")
+  )
+  const [exceptionDates, setExceptionDates] = React.useState<Date[]>([
+    new Date("2020-03-13"),
+  ])
   const [disruptionDaysOfWeek, setDisruptionDaysOfWeek] = React.useState<
     DayOfWeekTimeRanges
-  >([null, null, null, null, null, null, null])
+  >([
+    null,
+    null,
+    null,
+    null,
+    [
+      { hour: "1", minute: "00", period: "PM" },
+      { hour: "11", minute: "00", period: "PM" },
+    ],
+    [
+      { hour: "1", minute: "00", period: "PM" },
+      { hour: "11", minute: "00", period: "PM" },
+    ],
+    [
+      { hour: "1", minute: "00", period: "PM" },
+      { hour: "11", minute: "00", period: "PM" },
+    ],
+  ])
 
   return (
-    <div>
-      <Header />
-      <div>id is {match.params.id}</div>
-      <AdjustmentSummary />
-      <DisruptionTimePicker
-        fromDate={fromDate}
-        setFromDate={setFromDate}
-        toDate={toDate}
-        setToDate={setToDate}
-        disruptionDaysOfWeek={disruptionDaysOfWeek}
-        setDisruptionDaysOfWeek={setDisruptionDaysOfWeek}
-        exceptionDates={exceptionDates}
-        setExceptionDates={setExceptionDates}
-      />
-      <SaveCancelButton />
-    </div>
+    <EditDisruptionForm
+      disruptionId={match.params.id}
+      fromDate={fromDate}
+      setFromDate={setFromDate}
+      toDate={toDate}
+      setToDate={setToDate}
+      exceptionDates={exceptionDates}
+      setExceptionDates={setExceptionDates}
+      disruptionDaysOfWeek={disruptionDaysOfWeek}
+      setDisruptionDaysOfWeek={setDisruptionDaysOfWeek}
+    />
   )
+}
+
+interface EditDisruptionFormProps {
+  disruptionId?: string
+  fromDate: Date | null
+  setFromDate: React.Dispatch<Date | null>
+  toDate: Date | null
+  setToDate: React.Dispatch<Date | null>
+  exceptionDates: Date[]
+  setExceptionDates: React.Dispatch<Date[]>
+  disruptionDaysOfWeek: DayOfWeekTimeRanges
+  setDisruptionDaysOfWeek: React.Dispatch<DayOfWeekTimeRanges>
+}
+
+const EditDisruptionForm = ({
+  disruptionId,
+  fromDate,
+  setFromDate,
+  toDate,
+  setToDate,
+  exceptionDates,
+  setExceptionDates,
+  disruptionDaysOfWeek,
+  setDisruptionDaysOfWeek,
+}: EditDisruptionFormProps): JSX.Element => {
+  const [redirect, setRedirect] = React.useState(false)
+  const [isPreview, setIsPreview] = React.useState<boolean>(false)
+
+  // TODO: Dummy data, to be filled in with the results from an API call once that's ready
+  const adjustment = {
+    label: "Kenmore - Newton Highlands",
+    route: "Green-D",
+  }
+
+  if (redirect && disruptionId) {
+    return <Redirect to={"/disruptions/" + encodeURIComponent(disruptionId)} />
+  } else if (isPreview) {
+    return (
+      <div>
+        <Header />
+        <DisruptionPreview
+          disruptionId={disruptionId}
+          adjustments={[adjustment]}
+          setIsPreview={setIsPreview}
+          fromDate={fromDate}
+          toDate={toDate}
+          disruptionDaysOfWeek={disruptionDaysOfWeek}
+          exceptionDates={exceptionDates}
+        />
+      </div>
+    )
+  } else {
+    return (
+      <div>
+        <Header />
+        <DisruptionSummary
+          disruptionId={disruptionId}
+          adjustments={[adjustment]}
+        />
+        <fieldset>
+          <legend>Edit disruption times</legend>
+          <DisruptionTimePicker
+            fromDate={fromDate}
+            setFromDate={setFromDate}
+            toDate={toDate}
+            setToDate={setToDate}
+            disruptionDaysOfWeek={disruptionDaysOfWeek}
+            setDisruptionDaysOfWeek={setDisruptionDaysOfWeek}
+            exceptionDates={exceptionDates}
+            setExceptionDates={setExceptionDates}
+          />
+        </fieldset>
+        <SaveCancelButton
+          setRedirect={setRedirect}
+          setIsPreview={setIsPreview}
+        />
+      </div>
+    )
+  }
 }
 
 export default EditDisruption

--- a/assets/src/disruptions/newDisruption.tsx
+++ b/assets/src/disruptions/newDisruption.tsx
@@ -12,7 +12,7 @@ import {
 import { Adjustment, TransitMode, modeForRoute } from "./disruptions"
 
 import Header from "../header"
-import { NewDisruptionPreview } from "./newDisruptionPreview"
+import { DisruptionPreview } from "./disruptionPreview"
 
 interface AdjustmentModePickerProps {
   transitMode: TransitMode
@@ -238,7 +238,7 @@ const NewDisruption = ({}): JSX.Element => {
     <div>
       <Header />
       {isPreview ? (
-        <NewDisruptionPreview
+        <DisruptionPreview
           adjustments={adjustments}
           setIsPreview={setIsPreview}
           fromDate={fromDate}

--- a/assets/tests/disruptions/disruptionPreview.test.tsx
+++ b/assets/tests/disruptions/disruptionPreview.test.tsx
@@ -1,11 +1,11 @@
 import { mount } from "enzyme"
 import * as React from "react"
-import { NewDisruptionPreview } from "../../src/disruptions/newDisruptionPreview"
+import { DisruptionPreview } from "../../src/disruptions/disruptionPreview"
 
-describe("NewDisruptionPreview", () => {
+describe("DisruptionPreview", () => {
   test("includes formatted from and to dates", () => {
     const text = mount(
-      <NewDisruptionPreview
+      <DisruptionPreview
         adjustments={[]}
         setIsPreview={() => null}
         fromDate={new Date(2020, 0, 1)}
@@ -21,7 +21,7 @@ describe("NewDisruptionPreview", () => {
 
   test("includes formatted exception dates", () => {
     const text = mount(
-      <NewDisruptionPreview
+      <DisruptionPreview
         adjustments={[]}
         setIsPreview={() => null}
         fromDate={null}
@@ -36,7 +36,7 @@ describe("NewDisruptionPreview", () => {
 
   test("Days of week are included and translated", () => {
     let text = mount(
-      <NewDisruptionPreview
+      <DisruptionPreview
         adjustments={[]}
         setIsPreview={() => null}
         fromDate={null}
@@ -58,7 +58,7 @@ describe("NewDisruptionPreview", () => {
     expect(text).toMatch("Start of service – End of service")
 
     text = mount(
-      <NewDisruptionPreview
+      <DisruptionPreview
         adjustments={[]}
         setIsPreview={() => null}
         fromDate={null}

--- a/assets/tests/disruptions/disruptionSummary.test.tsx
+++ b/assets/tests/disruptions/disruptionSummary.test.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { mount } from "enzyme"
 import * as renderer from "react-test-renderer"
 import { DisruptionSummary } from "../../src/disruptions/disruptionSummary"
 
@@ -15,5 +16,19 @@ describe("DisruptionSummary", () => {
 
     const testInstance = renderer.create(summary).root
     expect(testInstance.findAllByType("li").length).toEqual(2)
+  })
+
+  test("renders the disruption ID if present", () => {
+    const text = mount(
+      <DisruptionSummary
+        disruptionId={"123"}
+        adjustments={[
+          { label: "adjustment1", route: "route1" },
+          { label: "adjustment2", route: "route2" },
+        ]}
+      />
+    ).text()
+
+    expect(text).toMatch("Disruption ID: 123")
   })
 })

--- a/assets/tests/disruptions/editDisruption.test.tsx
+++ b/assets/tests/disruptions/editDisruption.test.tsx
@@ -1,5 +1,8 @@
 import { createBrowserHistory } from "history"
+import { mount } from "enzyme"
 import * as React from "react"
+import { Redirect } from "react-router"
+import { BrowserRouter } from "react-router-dom"
 import * as renderer from "react-test-renderer"
 
 import EditDisruption from "../../src/disruptions/editDisruption"
@@ -27,5 +30,63 @@ describe("NewDisruption", () => {
     ).root
 
     expect(testInstance.findByType(Header).props.includeHomeLink).toBe(true)
+  })
+
+  test("save link previews disruption", () => {
+    const history = createBrowserHistory()
+    const wrapper = mount(
+      <EditDisruption
+        match={{
+          params: { id: "foo" },
+          isExact: true,
+          path: "/disruptions/foo/edit",
+          url: "https://localhost/disruptions/foo/edit",
+        }}
+        history={history}
+        location={{
+          pathname: "/disruptions/foo/edit",
+          search: "",
+          state: {},
+          hash: "",
+        }}
+      />
+    )
+
+    wrapper
+      .find("#save-changes-button")
+      .find("button")
+      .simulate("click")
+
+    expect(wrapper.exists("DisruptionPreview")).toBe(true)
+  })
+
+  test("cancel link redirects back to view page", () => {
+    const history = createBrowserHistory()
+    const wrapper = mount(
+      <BrowserRouter>
+        <EditDisruption
+          match={{
+            params: { id: "foo" },
+            isExact: true,
+            path: "/disruptions/foo/edit",
+            url: "https://localhost/disruptions/foo/edit",
+          }}
+          history={history}
+          location={{
+            pathname: "/disruptions/foo/edit",
+            search: "",
+            state: {},
+            hash: "",
+          }}
+        />
+      </BrowserRouter>
+    )
+
+    wrapper
+      .find("#cancel-button")
+      .find("button")
+      .simulate("click")
+
+    expect(wrapper.exists(Redirect)).toBe(true)
   })
 })

--- a/assets/tests/disruptions/newDisruption.test.tsx
+++ b/assets/tests/disruptions/newDisruption.test.tsx
@@ -142,7 +142,7 @@ describe("NewDisruption", () => {
       .find("button")
       .simulate("click")
 
-    expect(wrapper.exists("NewDisruptionPreview")).toBe(true)
+    expect(wrapper.exists("DisruptionPreview")).toBe(true)
   })
 
   test("can go back to edit from preview", () => {


### PR DESCRIPTION
This should be all of the front-end logic that's feasible to do for now without having the API to actually save changes.

Right now I just have the "cancel" button redirecting to the view page URL for the corresponding disruption, but we might want to change that in the future if there are multiple ways that the user can reach the edit page.

Also note that I've included some dummy data just so that we can actually see the functionality of the edit page. We should remove this as soon as we have an API we can read from.