### PR TITLE
Change disruption_day_of_weeks to use day_name enum

### DIFF
--- a/lib/arrow/disruption/day_of_week.ex
+++ b/lib/arrow/disruption/day_of_week.ex
@@ -3,15 +3,9 @@ defmodule Arrow.Disruption.DayOfWeek do
   import Ecto.Changeset
 
   schema "disruption_day_of_weeks" do
+    field :day_name, :string
     field :start_time, :time
     field :end_time, :time
-    field :monday, :boolean, default: false
-    field :tuesday, :boolean, default: false
-    field :wednesday, :boolean, default: false
-    field :thursday, :boolean, default: false
-    field :friday, :boolean, default: false
-    field :saturday, :boolean, default: false
-    field :sunday, :boolean, default: false
     belongs_to :disruption, Arrow.Disruption
 
     timestamps(type: :utc_datetime)
@@ -20,16 +14,16 @@ defmodule Arrow.Disruption.DayOfWeek do
   @doc false
   def changeset(day_of_week, attrs) do
     day_of_week
-    |> cast(attrs, [
-      :monday,
-      :tuesday,
-      :wednesday,
-      :thursday,
-      :friday,
-      :saturday,
-      :sunday,
-      :start_time,
-      :end_time
+    |> cast(attrs, [:day_name, :start_time, :end_time])
+    |> validate_inclusion(:day_name, [
+      "monday",
+      "tuesday",
+      "wednesday",
+      "thursday",
+      "friday",
+      "saturday",
+      "sunday"
     ])
+    |> unique_constraint(:day_name, name: "unique_disruption_weekday")
   end
 end

--- a/lib/arrow_web/views/api/day_of_week_view.ex
+++ b/lib/arrow_web/views/api/day_of_week_view.ex
@@ -6,12 +6,6 @@ defmodule ArrowWeb.API.DayOfWeekView do
     :id,
     :start_time,
     :end_time,
-    :monday,
-    :tuesday,
-    :wednesday,
-    :thursday,
-    :friday,
-    :saturday,
-    :sunday
+    :day_name
   ])
 end

--- a/priv/repo/migrations/20200326133115_change_day_of_week_to_enum.exs
+++ b/priv/repo/migrations/20200326133115_change_day_of_week_to_enum.exs
@@ -1,0 +1,49 @@
+defmodule Arrow.Repo.Migrations.ChangeDayOfWeekToEnum do
+  use Ecto.Migration
+
+  def up do
+    execute("create type day_name as enum (
+      'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'
+    )")
+
+    drop table(:disruption_day_of_weeks)
+
+    create table("disruption_day_of_weeks") do
+      add :day_name, :day_name, null: false
+      add :start_time, :time
+      add :end_time, :time
+      add :disruption_id, references(:disruptions, on_delete: :delete_all), null: false
+
+      timestamps(type: :timestamptz)
+    end
+
+    create index(:disruption_day_of_weeks, [:disruption_id])
+
+    create unique_index(:disruption_day_of_weeks, [:disruption_id, :day_name],
+             name: "unique_disruption_weekday"
+           )
+  end
+
+  def down do
+    drop table(:disruption_day_of_weeks)
+
+    create table(:disruption_day_of_weeks) do
+      add :monday, :boolean, default: false, null: false
+      add :tuesday, :boolean, default: false, null: false
+      add :wednesday, :boolean, default: false, null: false
+      add :thursday, :boolean, default: false, null: false
+      add :friday, :boolean, default: false, null: false
+      add :saturday, :boolean, default: false, null: false
+      add :sunday, :boolean, default: false, null: false
+      add :start_time, :time
+      add :end_time, :time
+      add :disruption_id, references(:disruptions, on_delete: :delete_all)
+
+      timestamps(type: :timestamptz)
+    end
+
+    create index(:disruption_day_of_weeks, [:disruption_id])
+
+    execute("drop type day_name")
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -29,6 +29,21 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
+--
+-- Name: day_name; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.day_name AS ENUM (
+    'monday',
+    'tuesday',
+    'wednesday',
+    'thursday',
+    'friday',
+    'saturday',
+    'sunday'
+);
+
+
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -102,16 +117,10 @@ ALTER SEQUENCE public.disruption_adjustments_id_seq OWNED BY public.disruption_a
 
 CREATE TABLE public.disruption_day_of_weeks (
     id bigint NOT NULL,
-    monday boolean DEFAULT false NOT NULL,
-    tuesday boolean DEFAULT false NOT NULL,
-    wednesday boolean DEFAULT false NOT NULL,
-    thursday boolean DEFAULT false NOT NULL,
-    friday boolean DEFAULT false NOT NULL,
-    saturday boolean DEFAULT false NOT NULL,
-    sunday boolean DEFAULT false NOT NULL,
+    day_name public.day_name NOT NULL,
     start_time time(0) without time zone,
     end_time time(0) without time zone,
-    disruption_id bigint,
+    disruption_id bigint NOT NULL,
     inserted_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL
 );
@@ -383,6 +392,13 @@ CREATE INDEX disruption_trip_short_names_disruption_id_index ON public.disruptio
 
 
 --
+-- Name: unique_disruption_weekday; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX unique_disruption_weekday ON public.disruption_day_of_weeks USING btree (disruption_id, day_name);
+
+
+--
 -- Name: disruption_adjustments disruption_adjustments_adjustment_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -426,5 +442,5 @@ ALTER TABLE ONLY public.disruption_trip_short_names
 -- PostgreSQL database dump complete
 --
 
-INSERT INTO public."schema_migrations" (version) VALUES (20191223181419), (20191223181443), (20191223181711), (20191223181837), (20191223182116), (20191223182231), (20200129212636);
+INSERT INTO public."schema_migrations" (version) VALUES (20191223181419), (20191223181443), (20191223181711), (20191223181837), (20191223182116), (20191223182231), (20200129212636), (20200326133115);
 

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -1,0 +1,430 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 10.5
+-- Dumped by pg_dump version 10.5
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: adjustments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.adjustments (
+    id bigint NOT NULL,
+    source character varying(255),
+    source_label character varying(255),
+    route_id character varying(255),
+    inserted_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: adjustments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.adjustments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: adjustments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.adjustments_id_seq OWNED BY public.adjustments.id;
+
+
+--
+-- Name: disruption_adjustments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.disruption_adjustments (
+    id bigint NOT NULL,
+    disruption_id bigint,
+    adjustment_id bigint
+);
+
+
+--
+-- Name: disruption_adjustments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.disruption_adjustments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: disruption_adjustments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.disruption_adjustments_id_seq OWNED BY public.disruption_adjustments.id;
+
+
+--
+-- Name: disruption_day_of_weeks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.disruption_day_of_weeks (
+    id bigint NOT NULL,
+    monday boolean DEFAULT false NOT NULL,
+    tuesday boolean DEFAULT false NOT NULL,
+    wednesday boolean DEFAULT false NOT NULL,
+    thursday boolean DEFAULT false NOT NULL,
+    friday boolean DEFAULT false NOT NULL,
+    saturday boolean DEFAULT false NOT NULL,
+    sunday boolean DEFAULT false NOT NULL,
+    start_time time(0) without time zone,
+    end_time time(0) without time zone,
+    disruption_id bigint,
+    inserted_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: disruption_day_of_weeks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.disruption_day_of_weeks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: disruption_day_of_weeks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.disruption_day_of_weeks_id_seq OWNED BY public.disruption_day_of_weeks.id;
+
+
+--
+-- Name: disruption_exceptions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.disruption_exceptions (
+    id bigint NOT NULL,
+    excluded_date date NOT NULL,
+    disruption_id bigint,
+    inserted_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: disruption_exceptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.disruption_exceptions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: disruption_exceptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.disruption_exceptions_id_seq OWNED BY public.disruption_exceptions.id;
+
+
+--
+-- Name: disruption_trip_short_names; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.disruption_trip_short_names (
+    id bigint NOT NULL,
+    trip_short_name character varying(255) NOT NULL,
+    disruption_id bigint,
+    inserted_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: disruption_trip_short_names_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.disruption_trip_short_names_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: disruption_trip_short_names_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.disruption_trip_short_names_id_seq OWNED BY public.disruption_trip_short_names.id;
+
+
+--
+-- Name: disruptions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.disruptions (
+    id bigint NOT NULL,
+    start_date date,
+    end_date date,
+    inserted_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: disruptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.disruptions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: disruptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.disruptions_id_seq OWNED BY public.disruptions.id;
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_migrations (
+    version bigint NOT NULL,
+    inserted_at timestamp(0) without time zone
+);
+
+
+--
+-- Name: adjustments id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.adjustments ALTER COLUMN id SET DEFAULT nextval('public.adjustments_id_seq'::regclass);
+
+
+--
+-- Name: disruption_adjustments id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_adjustments ALTER COLUMN id SET DEFAULT nextval('public.disruption_adjustments_id_seq'::regclass);
+
+
+--
+-- Name: disruption_day_of_weeks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_day_of_weeks ALTER COLUMN id SET DEFAULT nextval('public.disruption_day_of_weeks_id_seq'::regclass);
+
+
+--
+-- Name: disruption_exceptions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_exceptions ALTER COLUMN id SET DEFAULT nextval('public.disruption_exceptions_id_seq'::regclass);
+
+
+--
+-- Name: disruption_trip_short_names id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_trip_short_names ALTER COLUMN id SET DEFAULT nextval('public.disruption_trip_short_names_id_seq'::regclass);
+
+
+--
+-- Name: disruptions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruptions ALTER COLUMN id SET DEFAULT nextval('public.disruptions_id_seq'::regclass);
+
+
+--
+-- Name: adjustments adjustments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.adjustments
+    ADD CONSTRAINT adjustments_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: disruption_adjustments disruption_adjustments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_adjustments
+    ADD CONSTRAINT disruption_adjustments_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: disruption_day_of_weeks disruption_day_of_weeks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_day_of_weeks
+    ADD CONSTRAINT disruption_day_of_weeks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: disruption_exceptions disruption_exceptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_exceptions
+    ADD CONSTRAINT disruption_exceptions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: disruption_trip_short_names disruption_trip_short_names_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_trip_short_names
+    ADD CONSTRAINT disruption_trip_short_names_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: disruptions disruptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruptions
+    ADD CONSTRAINT disruptions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: adjustments_source_label_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX adjustments_source_label_index ON public.adjustments USING btree (source_label);
+
+
+--
+-- Name: disruption_adjustments_adjustment_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX disruption_adjustments_adjustment_id_index ON public.disruption_adjustments USING btree (adjustment_id);
+
+
+--
+-- Name: disruption_adjustments_disruption_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX disruption_adjustments_disruption_id_index ON public.disruption_adjustments USING btree (disruption_id);
+
+
+--
+-- Name: disruption_day_of_weeks_disruption_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX disruption_day_of_weeks_disruption_id_index ON public.disruption_day_of_weeks USING btree (disruption_id);
+
+
+--
+-- Name: disruption_exceptions_disruption_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX disruption_exceptions_disruption_id_index ON public.disruption_exceptions USING btree (disruption_id);
+
+
+--
+-- Name: disruption_trip_short_names_disruption_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX disruption_trip_short_names_disruption_id_index ON public.disruption_trip_short_names USING btree (disruption_id);
+
+
+--
+-- Name: disruption_adjustments disruption_adjustments_adjustment_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_adjustments
+    ADD CONSTRAINT disruption_adjustments_adjustment_id_fkey FOREIGN KEY (adjustment_id) REFERENCES public.adjustments(id);
+
+
+--
+-- Name: disruption_adjustments disruption_adjustments_disruption_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_adjustments
+    ADD CONSTRAINT disruption_adjustments_disruption_id_fkey FOREIGN KEY (disruption_id) REFERENCES public.disruptions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: disruption_day_of_weeks disruption_day_of_weeks_disruption_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_day_of_weeks
+    ADD CONSTRAINT disruption_day_of_weeks_disruption_id_fkey FOREIGN KEY (disruption_id) REFERENCES public.disruptions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: disruption_exceptions disruption_exceptions_disruption_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_exceptions
+    ADD CONSTRAINT disruption_exceptions_disruption_id_fkey FOREIGN KEY (disruption_id) REFERENCES public.disruptions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: disruption_trip_short_names disruption_trip_short_names_disruption_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_trip_short_names
+    ADD CONSTRAINT disruption_trip_short_names_disruption_id_fkey FOREIGN KEY (disruption_id) REFERENCES public.disruptions(id) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+INSERT INTO public."schema_migrations" (version) VALUES (20191223181419), (20191223181443), (20191223181711), (20191223181837), (20191223182116), (20191223182231), (20200129212636);
+

--- a/test/arrow/disruption_test.exs
+++ b/test/arrow/disruption_test.exs
@@ -79,24 +79,21 @@ defmodule Arrow.DisruptionTest do
                    start_date: @start_date,
                    end_date: @end_date,
                    days_of_week: [
-                     %{friday: true, start_time: ~T[20:30:00]},
-                     %{saturday: true, sunday: true}
+                     %{day_name: "friday", start_time: ~T[20:30:00]},
+                     %{day_name: "saturday"}
                    ]
                  })
                )
 
-      assert [friday, weekend] = new_dis.days_of_week
+      assert [friday, saturday] = new_dis.days_of_week
 
-      assert friday.thursday == false
-      assert friday.friday == true
+      assert friday.day_name == "friday"
       assert friday.start_time == ~T[20:30:00]
       assert friday.end_time == nil
 
-      assert weekend.friday == false
-      assert weekend.saturday == true
-      assert weekend.sunday == true
-      assert weekend.start_time == nil
-      assert weekend.end_time == nil
+      assert saturday.day_name == "saturday"
+      assert saturday.start_time == nil
+      assert saturday.end_time == nil
     end
   end
 end

--- a/test/arrow_web/controllers/api/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/api/disruption_controller_test.exs
@@ -51,14 +51,8 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
                  %{
                    "attributes" => %{
                      "end_time" => nil,
-                     "friday" => true,
-                     "monday" => false,
-                     "saturday" => false,
-                     "start_time" => "20:30:00",
-                     "sunday" => false,
-                     "thursday" => false,
-                     "tuesday" => false,
-                     "wednesday" => false
+                     "day_name" => "friday",
+                     "start_time" => "20:30:00"
                    },
                    "type" => "day_of_week"
                  },
@@ -88,7 +82,7 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
                  }
                ],
                "jsonapi" => %{"version" => "1.0"}
-             } = res
+             } = Enum.sort(res)
     end
 
     test "can include only specified relationships", %{conn: conn} do
@@ -198,7 +192,7 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
         Disruption.changeset(%Disruption{}, %{
           start_date: ~D[2019-11-15],
           end_date: ~D[2019-12-30],
-          days_of_week: [%{friday: true, start_time: ~T[20:30:00]}],
+          days_of_week: [%{day_name: "friday", start_time: ~T[20:30:00]}],
           adjustments: [
             %{
               source: "gtfs_creator",


### PR DESCRIPTION
The first commit just adds the output of `mix ecto.dump` to the repo. At my last company we had the generated schema checked in, and I found it to be a useful resource when developing, and also seeing what new migrations actually _do_, as well as verifying that your local DB is in sync (by running `mix ecto.dump` and verifying there's no git changes).

The second commit drops the old `disruption_day_of_weeks` table and recreates it with the `day_name` enum type. I also changed `disruption_id` to be NOT NULL, and added a unique constraint against disruption_id / day_name. If you look at the commit by itself, I think it shows the value of having the SQL schema, since the diff makes it pretty clear what's changing.