### PR TITLE
Add config to allow synchronous migrations if necessary

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+#### Summary of changes
+**Asana Ticket:** [TICKET_NAME](TICKET_LINK)
+
+[Please include a brief description of what was changed]
+
+#### Reviewer Checklist
+- [ ] Meets ticket's acceptance criteria
+- [ ] Any new or changed functions have typespecs
+- [ ] Tests were added for any new functionality (don't just rely on Codecov)
+- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,7 +11,9 @@ config :arrow,
   ecto_repos: [Arrow.Repo],
   aws_rds_mod: ExAws.RDS,
   run_migrations_at_startup?: false,
-  fetch_adjustments_at_startup?: true
+  fetch_adjustments_at_startup?: true,
+  # Run migrations synchronously before anything else. Must finish in <5 seconds
+  migrate_synchronously?: false
 
 # Configures the endpoint
 config :arrow, ArrowWeb.Endpoint,

--- a/lib/arrow/application.ex
+++ b/lib/arrow/application.ex
@@ -15,13 +15,15 @@ defmodule Arrow.Application do
     children =
       [
         # Start the Ecto repository
-        Arrow.Repo,
-        # Start the endpoint when the application starts
-        ArrowWeb.Endpoint
-        # Starts a worker by calling: Arrow.Worker.start_link(arg)
-        # {Arrow.Worker, arg},
+        Arrow.Repo
       ] ++
         migrate_children(run_migrations_at_startup?) ++
+        [
+          # Start the endpoint when the application starts
+          ArrowWeb.Endpoint
+          # Starts a worker by calling: Arrow.Worker.start_link(arg)
+          # {Arrow.Worker, arg},
+        ] ++
         adjustment_fetcher_children(run_adjustment_fetcher_at_startup?)
 
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -38,7 +40,8 @@ defmodule Arrow.Application do
   end
 
   def migrate_children(true) do
-    [Arrow.Repo.Migrator]
+    migrate_synchronously? = Application.get_env(:arrow, :migrate_synchronously?)
+    [{Arrow.Repo.Migrator, [migrate_synchronously?: migrate_synchronously?]}]
   end
 
   def migrate_children(false) do

--- a/lib/arrow/repo/migrator.ex
+++ b/lib/arrow/repo/migrator.ex
@@ -5,7 +5,7 @@ defmodule Arrow.Repo.Migrator do
   use GenServer, restart: :transient
   require Logger
 
-  @opts [module: Ecto.Migrator]
+  @opts [module: Ecto.Migrator, migrate_synchronously?: false]
 
   def start_link(opts) do
     opts = Keyword.merge(@opts, opts)
@@ -14,7 +14,14 @@ defmodule Arrow.Repo.Migrator do
 
   @impl GenServer
   def init(opts) do
-    {:ok, opts, {:continue, :migrate}}
+    if opts[:migrate_synchronously?] do
+      _ = Logger.info("Migrating synchronously")
+      migrate!(opts[:module])
+      _ = Logger.info("Finished migrations")
+      :ignore
+    else
+      {:ok, opts, {:continue, :migrate}}
+    end
   end
 
   @impl GenServer

--- a/test/arrow/application_test.exs
+++ b/test/arrow/application_test.exs
@@ -5,7 +5,7 @@ defmodule Arrow.ApplicationTest do
 
   describe "migrate_children/1" do
     test "starts the migrator when passed true" do
-      assert migrate_children(true) == [Arrow.Repo.Migrator]
+      assert [{Arrow.Repo.Migrator, [{:migrate_synchronously?, _}]}] = migrate_children(true)
     end
 
     test "starts nothing when passed false" do

--- a/test/arrow/repo/migrator_test.exs
+++ b/test/arrow/repo/migrator_test.exs
@@ -30,6 +30,17 @@ defmodule Arrow.Repo.MigratorTest do
       assert {:ok, pid} = Migrator.start_link(module: FakeMigrator)
     end
 
+    test "runs migrations and ends when run synchronously" do
+      log_level_info()
+
+      log =
+        capture_log(fn ->
+          assert :ignore = Migrator.start_link(module: FakeMigrator, migrate_synchronously?: true)
+        end)
+
+      assert log =~ "Migrating synchronously"
+    end
+
     test "logs a migration for each repo" do
       log_level_info()
 


### PR DESCRIPTION
The last deploy failed, I think because of the migration to change the day_of_weeks table. Normally, we migrate concurrently with the app starting up, but then the code has to be forwards/backwards compatible, and I didn't do that with those changes...

This adds a simple config flag to either run the migrations concurrently, or blocking during start-up (in which case they have to finish in < 5 seconds or the app won't start).

I deployed this branch, with `migrate_synchronously?: true` and it migrated and the deploy worked. So this branch isn't strictly necessary, but I figured it's useful to have as an option. I set the config value here to `false` (status quo), since we should generally have it that way, 

I also added our PR template that we use in other repos.