### PR TITLE
fix: toJsonApi() nesting of data fields

### DIFF
--- a/assets/src/jsonApiResource.ts
+++ b/assets/src/jsonApiResource.ts
@@ -1,10 +1,12 @@
-interface JsonApiResource {
-  data: {
-    id?: string
-    type: string
-    attributes: any
-    relationships?: any
-  }
+interface JsonApiResourceData {
+  id?: string
+  type: string
+  attributes: any
+  relationships?: any
 }
 
-export default JsonApiResource
+interface JsonApiResource {
+  data: JsonApiResourceData
+}
+
+export { JsonApiResource, JsonApiResourceData }

--- a/assets/src/jsonApiResourceObject.ts
+++ b/assets/src/jsonApiResourceObject.ts
@@ -1,0 +1,8 @@
+import { JsonApiResourceData, JsonApiResource } from "./jsonApiResource"
+
+abstract class JsonApiResourceObject {
+  abstract toJsonApiData(): JsonApiResourceData
+  abstract toJsonApi(): JsonApiResource
+}
+
+export default JsonApiResourceObject

--- a/assets/src/models/adjustment.ts
+++ b/assets/src/models/adjustment.ts
@@ -1,8 +1,9 @@
-import JsonApiResource from "../jsonApiResource"
+import { JsonApiResource, JsonApiResourceData } from "../jsonApiResource"
+import JsonApiResourceObject from "../jsonApiResourceObject"
 
 type Source = "gtfs_creator" | "arrow"
 
-class Adjustment {
+class Adjustment extends JsonApiResourceObject {
   id?: number
   routeId?: string
   source?: Source
@@ -19,6 +20,7 @@ class Adjustment {
     source?: Source
     sourceLabel?: string
   }) {
+    super()
     this.id = id
     this.routeId = routeId
     this.source = source
@@ -27,14 +29,18 @@ class Adjustment {
 
   toJsonApi(): JsonApiResource {
     return {
-      data: {
-        type: "adjustment",
-        ...(this.id && { id: this.id.toString() }),
-        attributes: {
-          ...(this.routeId && { route_id: this.routeId }),
-          ...(this.source && { source: this.source }),
-          ...(this.sourceLabel && { source_label: this.sourceLabel }),
-        },
+      data: this.toJsonApiData(),
+    }
+  }
+
+  toJsonApiData(): JsonApiResourceData {
+    return {
+      type: "adjustment",
+      ...(this.id && { id: this.id.toString() }),
+      attributes: {
+        ...(this.routeId && { route_id: this.routeId }),
+        ...(this.source && { source: this.source }),
+        ...(this.sourceLabel && { source_label: this.sourceLabel }),
       },
     }
   }

--- a/assets/src/models/dayOfWeek.ts
+++ b/assets/src/models/dayOfWeek.ts
@@ -1,4 +1,5 @@
-import JsonApiResource from "../jsonApiResource"
+import { JsonApiResource, JsonApiResourceData } from "../jsonApiResource"
+import JsonApiResourceObject from "../jsonApiResourceObject"
 
 type DayName =
   | "monday"
@@ -9,7 +10,7 @@ type DayName =
   | "saturday"
   | "sunday"
 
-class DayOfWeek {
+class DayOfWeek extends JsonApiResourceObject {
   id?: number
   startTime?: string
   endTime?: string
@@ -26,6 +27,7 @@ class DayOfWeek {
     endTime?: string
     day?: DayName
   }) {
+    super()
     this.id = id
     this.startTime = startTime
     this.endTime = endTime
@@ -34,14 +36,18 @@ class DayOfWeek {
 
   toJsonApi(): JsonApiResource {
     return {
-      data: {
-        type: "day_of_week",
-        ...(this.id && { id: this.id.toString() }),
-        attributes: {
-          ...(this.startTime && { start_time: this.startTime }),
-          ...(this.endTime && { end_time: this.endTime }),
-          ...(this.day && { day: this.day }),
-        },
+      data: this.toJsonApiData(),
+    }
+  }
+
+  toJsonApiData(): JsonApiResourceData {
+    return {
+      type: "day_of_week",
+      ...(this.id && { id: this.id.toString() }),
+      attributes: {
+        ...(this.startTime && { start_time: this.startTime }),
+        ...(this.endTime && { end_time: this.endTime }),
+        ...(this.day && { day: this.day }),
       },
     }
   }

--- a/assets/src/models/disruption.ts
+++ b/assets/src/models/disruption.ts
@@ -1,11 +1,12 @@
-import JsonApiResource from "../jsonApiResource"
+import { JsonApiResource, JsonApiResourceData } from "../jsonApiResource"
+import JsonApiResourceObject from "../jsonApiResourceObject"
 
 import Adjustment from "./adjustment"
 import DayOfWeek from "./dayOfWeek"
 import Exception from "./exception"
 import TripShortName from "./tripShortName"
 
-class Disruption {
+class Disruption extends JsonApiResourceObject {
   id?: number
   endDate?: Date
   startDate?: Date
@@ -32,6 +33,7 @@ class Disruption {
     exceptions: Exception[]
     tripShortNames: TripShortName[]
   }) {
+    super()
     this.id = id
     this.endDate = endDate
     this.startDate = startDate
@@ -43,22 +45,28 @@ class Disruption {
 
   toJsonApi(): JsonApiResource {
     return {
-      data: {
-        type: "disruption",
-        ...(this.id && { id: this.id.toString() }),
-        attributes: {
-          ...(this.startDate && {
-            start_date: this.startDate.toISOString().slice(0, 10),
-          }),
-          ...(this.endDate && {
-            end_date: this.endDate.toISOString().slice(0, 10),
-          }),
-        },
-        relationships: {
-          adjustment: this.adjustments.map(adj => adj.toJsonApi()),
-          day_of_week: this.daysOfWeek.map(dow => dow.toJsonApi()),
-          exceptions: this.exceptions.map(ex => ex.toJsonApi()),
-          trip_short_name: this.tripShortNames.map(tsn => tsn.toJsonApi()),
+      data: this.toJsonApiData(),
+    }
+  }
+
+  toJsonApiData(): JsonApiResourceData {
+    return {
+      type: "disruption",
+      ...(this.id && { id: this.id.toString() }),
+      attributes: {
+        ...(this.startDate && {
+          start_date: this.startDate.toISOString().slice(0, 10),
+        }),
+        ...(this.endDate && {
+          end_date: this.endDate.toISOString().slice(0, 10),
+        }),
+      },
+      relationships: {
+        adjustment: { data: this.adjustments.map(adj => adj.toJsonApiData()) },
+        day_of_week: { data: this.daysOfWeek.map(dow => dow.toJsonApiData()) },
+        exceptions: { data: this.exceptions.map(ex => ex.toJsonApiData()) },
+        trip_short_name: {
+          data: this.tripShortNames.map(tsn => tsn.toJsonApiData()),
         },
       },
     }

--- a/assets/src/models/exception.ts
+++ b/assets/src/models/exception.ts
@@ -1,24 +1,30 @@
-import JsonApiResource from "../jsonApiResource"
+import { JsonApiResource, JsonApiResourceData } from "../jsonApiResource"
+import JsonApiResourceObject from "../jsonApiResourceObject"
 
-class Exception {
+class Exception extends JsonApiResourceObject {
   id?: number
   excludedDate?: Date
 
   constructor({ id, excludedDate }: { id?: number; excludedDate?: Date }) {
+    super()
     this.id = id
     this.excludedDate = excludedDate
   }
 
   toJsonApi(): JsonApiResource {
     return {
-      data: {
-        type: "exception",
-        ...(this.id && { id: this.id.toString() }),
-        attributes: {
-          ...(this.excludedDate && {
-            excluded_date: this.excludedDate.toISOString().slice(0, 10),
-          }),
-        },
+      data: this.toJsonApiData(),
+    }
+  }
+
+  toJsonApiData(): JsonApiResourceData {
+    return {
+      type: "exception",
+      ...(this.id && { id: this.id.toString() }),
+      attributes: {
+        ...(this.excludedDate && {
+          excluded_date: this.excludedDate.toISOString().slice(0, 10),
+        }),
       },
     }
   }

--- a/assets/src/models/tripShortName.ts
+++ b/assets/src/models/tripShortName.ts
@@ -1,22 +1,28 @@
-import JsonApiResource from "../jsonApiResource"
+import { JsonApiResource, JsonApiResourceData } from "../jsonApiResource"
+import JsonApiResourceObject from "../jsonApiResourceObject"
 
-class TripShortName {
+class TripShortName extends JsonApiResourceObject {
   id?: number
   tripShortName?: string
 
   constructor({ id, tripShortName }: { id?: number; tripShortName?: string }) {
+    super()
     this.id = id
     this.tripShortName = tripShortName
   }
 
   toJsonApi(): JsonApiResource {
     return {
-      data: {
-        type: "trip_short_name",
-        ...(this.id && { id: this.id.toString() }),
-        attributes: {
-          ...(this.tripShortName && { trip_short_name: this.tripShortName }),
-        },
+      data: this.toJsonApiData(),
+    }
+  }
+
+  toJsonApiData(): JsonApiResourceData {
+    return {
+      type: "trip_short_name",
+      ...(this.id && { id: this.id.toString() }),
+      attributes: {
+        ...(this.tripShortName && { trip_short_name: this.tripShortName }),
       },
     }
   }

--- a/assets/tests/models/disruption.test.ts
+++ b/assets/tests/models/disruption.test.ts
@@ -25,18 +25,18 @@ describe("Disruption", () => {
           end_date: "2020-03-01",
         },
         relationships: {
-          adjustment: [
-            { data: { id: "1", type: "adjustment", attributes: {} } },
-          ],
-          day_of_week: [
-            { data: { id: "2", type: "day_of_week", attributes: {} } },
-          ],
-          exceptions: [
-            { data: { id: "3", type: "exception", attributes: {} } },
-          ],
-          trip_short_name: [
-            { data: { id: "4", type: "trip_short_name", attributes: {} } },
-          ],
+          adjustment: {
+            data: [{ id: "1", type: "adjustment", attributes: {} }],
+          },
+          day_of_week: {
+            data: [{ id: "2", type: "day_of_week", attributes: {} }],
+          },
+          exceptions: {
+            data: [{ id: "3", type: "exception", attributes: {} }],
+          },
+          trip_short_name: {
+            data: [{ id: "4", type: "trip_short_name", attributes: {} }],
+          },
         },
       },
     })


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

Fixes an issue in how we were serializing data for disruptions. Before it was like:

```
{
  ...
  relationships: {
    adjustments: [ { data: { adjustment data } }, {data: { adjustment data }} ]
    ...
  }
}
```

But according to the spec, that's not right. There should be _one_ data field, and its contents should be either the resource data or an array of resource data objects:

```
{
  ...
  relationships: {
    adjustments: { data: [ { adjustment data}, {adjustment data} ] }
    ...
  }
}
```

This means that there's really two ways to serialize an object: one, the encapsulated way, you'd use at the top level, and the other just the "data" part when embedding it in a relationship.

To the old `toJsonApi()` method I added a `toJsonApiData()` method for the other use case. Since all our models should implement these two methods, with the same shape, I opted to inherit them all from a new abstract base class, to have the compiler enforce that. I don't love inheritance, and would have liked something akin to `@behaviour` in the Elixir world, but that seemed to be the closest thing in TypeScript that I could find.
  

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
