### PR TITLE
fix: wrap Routes in Switch component

### DIFF
--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -8,7 +8,7 @@ require("../css/app.scss")
 import "phoenix_html"
 import * as React from "react"
 import ReactDOM from "react-dom"
-import { BrowserRouter, Route } from "react-router-dom"
+import { BrowserRouter, Route, Switch } from "react-router-dom"
 
 import EditDisruption from "./disruptions/editDisruption"
 import { NewDisruption } from "./disruptions/newDisruption"
@@ -18,18 +18,24 @@ import DisruptionIndex from "./disruptions/disruptionIndex"
 const App = (): JSX.Element => {
   return (
     <BrowserRouter>
-      <Route
-        exact={true}
-        path="/"
-        render={() => <DisruptionIndex disruptions={[]} />}
-      />
-      <Route exact={true} path="/disruptions/new" component={NewDisruption} />
-      <Route exact={true} path="/disruptions/:id" component={ViewDisruption} />
-      <Route
-        exact={true}
-        path="/disruptions/:id/edit"
-        component={EditDisruption}
-      />
+      <Switch>
+        <Route
+          exact={true}
+          path="/"
+          render={() => <DisruptionIndex disruptions={[]} />}
+        />
+        <Route exact={true} path="/disruptions/new" component={NewDisruption} />
+        <Route
+          exact={true}
+          path="/disruptions/:id"
+          component={ViewDisruption}
+        />
+        <Route
+          exact={true}
+          path="/disruptions/:id/edit"
+          component={EditDisruption}
+        />
+      </Switch>
     </BrowserRouter>
   )
 }


### PR DESCRIPTION
Adding the `Switch` component ensures we render the first `Route` that matches rather than _all_ `Routes` that match.