### PR TITLE
Create disruption on frontend via API call

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -12,7 +12,7 @@ const checkResponseStatus = (response: Response) => {
   throw new Error(`Response error: ${response.status}`)
 }
 
-const apiCall = <T>({
+const apiGet = <T>({
   url,
   parser,
   defaultResult,
@@ -34,4 +34,4 @@ const apiCall = <T>({
       }
     })
 
-export { apiCall }
+export { apiGet }

--- a/assets/src/disruptions/disruptionPreview.tsx
+++ b/assets/src/disruptions/disruptionPreview.tsx
@@ -39,6 +39,7 @@ interface DisruptionPreviewProps {
   toDate: Date | null
   disruptionDaysOfWeek: DayOfWeekTimeRanges
   exceptionDates: Date[]
+  createFn?: any
 }
 
 const DisruptionPreview = ({
@@ -49,6 +50,7 @@ const DisruptionPreview = ({
   toDate,
   disruptionDaysOfWeek,
   exceptionDates,
+  createFn,
 }: DisruptionPreviewProps): JSX.Element => {
   const listedDays: JSX.Element[] = []
   disruptionDaysOfWeek.forEach((timeRange, i) => {
@@ -68,6 +70,23 @@ const DisruptionPreview = ({
     )
   })
 
+  const createDisruption = React.useCallback(() => {
+    createFn({
+      adjustments,
+      fromDate,
+      toDate,
+      disruptionDaysOfWeek,
+      exceptionDates,
+    })
+  }, [
+    createFn,
+    adjustments,
+    fromDate,
+    toDate,
+    disruptionDaysOfWeek,
+    exceptionDates,
+  ])
+
   return (
     <div>
       <DisruptionSummary
@@ -84,6 +103,13 @@ const DisruptionPreview = ({
         <ul>{listedExceptionDates}</ul>
       ) : (
         <div>none</div>
+      )}
+      {createFn && (
+        <div>
+          <button id="disruption-preview-create" onClick={createDisruption}>
+            create disruption
+          </button>
+        </div>
       )}
       {setIsPreview && (
         <a href="#" onClick={() => setIsPreview(false)} id="back-to-edit-link">

--- a/assets/src/disruptions/editDisruption.tsx
+++ b/assets/src/disruptions/editDisruption.tsx
@@ -122,7 +122,6 @@ const EditDisruptionForm = ({
 
   // TODO: Dummy data, to be filled in with the results from an API call once that's ready
   const adjustment = new Adjustment({
-    id: "1",
     routeId: "Green-D",
     source: "gtfs_creator",
     sourceLabel: "Kenmore - Newton Highlands",

--- a/assets/src/disruptions/newDisruption.tsx
+++ b/assets/src/disruptions/newDisruption.tsx
@@ -5,7 +5,7 @@ import Form from "react-bootstrap/Form"
 
 import { DayOfWeekTimeRanges, TimeRange } from "./time"
 import { DisruptionTimePicker } from "./disruptionTimePicker"
-import { apiCall } from "../api"
+import { apiGet } from "../api"
 
 import { TransitMode, modeForRoute } from "./disruptions"
 import Header from "../header"
@@ -234,7 +234,7 @@ const NewDisruption = ({}): JSX.Element => {
   >(null)
 
   React.useEffect(() => {
-    apiCall<ModelObject | ModelObject[] | "error">({
+    apiGet<ModelObject | ModelObject[] | "error">({
       url: "/api/adjustments",
       parser: toModelObject,
       defaultResult: "error",

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -139,6 +139,75 @@ const fromDaysOfWeek = (
   }
 }
 
+const numToString = (n: number): string => {
+  if (n < 10) {
+    return "0" + n.toString()
+  }
+  return n.toString()
+}
+
+const timeToString = (time: Time): string => {
+  const { hour, minute, period } = time
+  let hourNum = parseInt(hour, 10)
+  const minuteNum = parseInt(minute, 10)
+  if (period === "AM" && hourNum === 12) {
+    hourNum = 0
+  } else if (period === "PM" && hourNum !== 12) {
+    hourNum += 12
+  }
+
+  return `${numToString(hourNum)}:${numToString(minuteNum)}:00`
+}
+
+const ixToDayName = (
+  ix: number
+):
+  | "monday"
+  | "tuesday"
+  | "wednesday"
+  | "thursday"
+  | "friday"
+  | "saturday"
+  | "sunday" => {
+  switch (ix) {
+    case 0:
+      return "monday"
+    case 1:
+      return "tuesday"
+    case 2:
+      return "wednesday"
+    case 3:
+      return "thursday"
+    case 4:
+      return "friday"
+    case 5:
+      return "saturday"
+    default:
+      return "sunday"
+  }
+}
+
+const dayOfWeekTimeRangesToDayOfWeeks = (
+  timeRanges: DayOfWeekTimeRanges
+): DayOfWeek[] => {
+  const daysOfWeek: DayOfWeek[] = []
+
+  timeRanges.forEach((dow, ix) => {
+    if (dow !== null) {
+      const dayName = ixToDayName(ix)
+      const [startTime, endTime] = dow
+      const dayOfWeek = new DayOfWeek({
+        ...(dayName !== null && { day: dayName }),
+        ...(startTime !== null && { startTime: timeToString(startTime) }),
+        ...(endTime !== null && { endTime: timeToString(endTime) }),
+      })
+      daysOfWeek.push(dayOfWeek)
+    }
+  })
+
+  return daysOfWeek
+}
+
 export {
   Time,
   HourOptions,
@@ -148,4 +217,5 @@ export {
   DayOfWeekTimeRanges,
   fromDaysOfWeek,
   isEmpty,
+  dayOfWeekTimeRangesToDayOfWeeks,
 }

--- a/assets/src/disruptions/viewDisruption.tsx
+++ b/assets/src/disruptions/viewDisruption.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { RouteComponentProps, Link } from "react-router-dom"
 
-import { apiCall } from "../api"
+import { apiGet } from "../api"
 
 import Header from "../header"
 import Loading from "../loading"
@@ -51,7 +51,7 @@ const ViewDisruptionForm = ({
   >(null)
 
   React.useEffect(() => {
-    apiCall<ModelObject | ModelObject[] | "error">({
+    apiGet<ModelObject | ModelObject[] | "error">({
       url: "/api/disruptions/" + encodeURIComponent(disruptionId),
       parser: toModelObject,
       defaultResult: "error",

--- a/assets/src/jsonApi.ts
+++ b/assets/src/jsonApi.ts
@@ -54,6 +54,24 @@ const toModelObject = (
   }
 }
 
+const parseErrors = (raw: any): string[] => {
+  const errors: string[] = []
+
+  if (typeof raw === "object") {
+    const rawErrors = raw?.errors
+    if (Array.isArray(rawErrors)) {
+      rawErrors.forEach(err => {
+        const rawDetail = err?.detail
+        if (typeof rawDetail === "string") {
+          errors.push(rawDetail)
+        }
+      })
+    }
+  }
+
+  return errors
+}
+
 const modelFromJsonApiResource = (
   raw: any,
   includedObjects: ModelObject[]
@@ -78,4 +96,4 @@ const modelFromJsonApiResource = (
   return "error"
 }
 
-export { ModelObject, toModelObject }
+export { ModelObject, toModelObject, parseErrors }

--- a/assets/src/models/disruption.ts
+++ b/assets/src/models/disruption.ts
@@ -63,10 +63,10 @@ class Disruption extends JsonApiResourceObject {
         }),
       },
       relationships: {
-        adjustment: { data: this.adjustments.map(adj => adj.toJsonApiData()) },
-        day_of_week: { data: this.daysOfWeek.map(dow => dow.toJsonApiData()) },
+        adjustments: { data: this.adjustments.map(adj => adj.toJsonApiData()) },
+        days_of_week: { data: this.daysOfWeek.map(dow => dow.toJsonApiData()) },
         exceptions: { data: this.exceptions.map(ex => ex.toJsonApiData()) },
-        trip_short_name: {
+        trip_short_names: {
           data: this.tripShortNames.map(tsn => tsn.toJsonApiData()),
         },
       },

--- a/assets/src/models/exception.ts
+++ b/assets/src/models/exception.ts
@@ -39,6 +39,12 @@ class Exception extends JsonApiResourceObject {
 
     return "error"
   }
+
+  static fromDates(exceptions: Date[]): Exception[] {
+    return exceptions.map(
+      exceptionDate => new Exception({ excludedDate: exceptionDate })
+    )
+  }
 }
 
 export default Exception

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -1,4 +1,4 @@
-import { apiCall } from "../src/api"
+import { apiGet } from "../src/api"
 
 declare global {
   interface Window {
@@ -14,7 +14,7 @@ const mockFetch = (status: number, json: any): void => {
     } as Response)
 }
 
-describe("apiCall", () => {
+describe("apiGet", () => {
   let reloadSpy: jest.SpyInstance
 
   beforeEach(() => {
@@ -38,7 +38,7 @@ describe("apiCall", () => {
 
     const parse = jest.fn(() => "parsed")
 
-    apiCall({
+    apiGet({
       url: "/",
       parser: parse,
     }).then(parsed => {
@@ -51,7 +51,7 @@ describe("apiCall", () => {
   test("reloads the page if the response status is a redirect (3xx)", done => {
     mockFetch(302, { data: null })
 
-    apiCall({
+    apiGet({
       url: "/",
       parser: () => null,
     }).catch(() => {
@@ -63,7 +63,7 @@ describe("apiCall", () => {
   test("reloads the page if the response status is forbidden (403)", done => {
     mockFetch(403, { data: null })
 
-    apiCall({
+    apiGet({
       url: "/",
       parser: () => null,
     }).catch(() => {
@@ -75,7 +75,7 @@ describe("apiCall", () => {
   test("returns a default for any other response", done => {
     mockFetch(500, { data: null })
 
-    apiCall({
+    apiGet({
       url: "/",
       parser: () => null,
       defaultResult: "default",
@@ -88,7 +88,7 @@ describe("apiCall", () => {
   test("throws an error for any other response status if there's no default", done => {
     mockFetch(500, { data: null })
 
-    apiCall({
+    apiGet({
       url: "/",
       parser: () => null,
     })

--- a/assets/tests/disruptions/disruptionPreview.test.tsx
+++ b/assets/tests/disruptions/disruptionPreview.test.tsx
@@ -111,4 +111,24 @@ describe("DisruptionPreview", () => {
 
     expect(wrapper.find("#back-to-edit-link").length).toEqual(0)
   })
+
+  test("create callback is invoked", () => {
+    const requests = []
+    const createFn = (args: any) => {
+      requests.push(args)
+    }
+    const wrapper = mount(
+      <DisruptionPreview
+        adjustments={[]}
+        fromDate={null}
+        toDate={null}
+        disruptionDaysOfWeek={[null, null, null, null, null, null, null]}
+        exceptionDates={[]}
+        createFn={createFn}
+      />
+    )
+    wrapper.find("button#disruption-preview-create").simulate("click")
+
+    expect(requests.length).toEqual(1)
+  })
 })

--- a/assets/tests/disruptions/newDisruption.test.tsx
+++ b/assets/tests/disruptions/newDisruption.test.tsx
@@ -12,7 +12,7 @@ describe("NewDisruption", () => {
   let apiCallSpy: jest.SpyInstance
 
   beforeEach(() => {
-    apiCallSpy = jest.spyOn(api, "apiCall").mockImplementation(() => {
+    apiCallSpy = jest.spyOn(api, "apiGet").mockImplementation(() => {
       return Promise.resolve([
         new Adjustment({
           routeId: "Red",
@@ -310,7 +310,7 @@ describe("NewDisruption", () => {
   })
 
   test("handles error fetching / parsing adjustments", async () => {
-    apiCallSpy = jest.spyOn(api, "apiCall").mockImplementationOnce(() => {
+    apiCallSpy = jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
       return Promise.resolve("error")
     })
 

--- a/assets/tests/disruptions/time.test.ts
+++ b/assets/tests/disruptions/time.test.ts
@@ -1,5 +1,9 @@
 import DayOfWeek from "../../src/models/dayOfWeek"
-import { fromDaysOfWeek } from "../../src/disruptions/time"
+import {
+  fromDaysOfWeek,
+  dayOfWeekTimeRangesToDayOfWeeks,
+  DayOfWeekTimeRanges,
+} from "../../src/disruptions/time"
 
 describe("fromDaysOfWeek", () => {
   test("successful conversion", () => {
@@ -56,5 +60,36 @@ describe("fromDaysOfWeek", () => {
         new DayOfWeek({ endTime: "20:45:00", day: "thursday" }),
       ])
     ).toEqual("error")
+  })
+})
+
+describe("dayOfWeekTimeRangesToDayOfWeeks", () => {
+  test("converts from the one to the other", () => {
+    const dayOfWeekTimeRanges: DayOfWeekTimeRanges = [
+      [null, null],
+      [{ hour: "9", minute: "30", period: "AM" }, null],
+      [
+        { hour: "11", minute: "30", period: "AM" },
+        { hour: "8", minute: "45", period: "PM" },
+      ],
+      [null, { hour: "8", minute: "45", period: "PM" }],
+      [null, { hour: "12", minute: "00", period: "AM" }],
+      [null, null],
+      [null, null],
+    ]
+
+    expect(dayOfWeekTimeRangesToDayOfWeeks(dayOfWeekTimeRanges)).toEqual([
+      new DayOfWeek({ day: "monday" }),
+      new DayOfWeek({ startTime: "09:30:00", day: "tuesday" }),
+      new DayOfWeek({
+        startTime: "11:30:00",
+        endTime: "20:45:00",
+        day: "wednesday",
+      }),
+      new DayOfWeek({ endTime: "20:45:00", day: "thursday" }),
+      new DayOfWeek({ endTime: "00:00:00", day: "friday" }),
+      new DayOfWeek({ day: "saturday" }),
+      new DayOfWeek({ day: "sunday" }),
+    ])
   })
 })

--- a/assets/tests/disruptions/viewDisruption.test.tsx
+++ b/assets/tests/disruptions/viewDisruption.test.tsx
@@ -13,7 +13,7 @@ import Exception from "../../src/models/exception"
 
 describe("ViewDisruption", () => {
   test("loads and displays disruption from the API", async () => {
-    jest.spyOn(api, "apiCall").mockImplementationOnce(() => {
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
       return Promise.resolve(
         new Disruption({
           id: "1",
@@ -84,7 +84,7 @@ describe("ViewDisruption", () => {
   })
 
   test("edit link redirects to edit page", async () => {
-    jest.spyOn(api, "apiCall").mockImplementationOnce(() => {
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
       return Promise.resolve(
         new Disruption({
           id: "1",
@@ -141,7 +141,7 @@ describe("ViewDisruption", () => {
   })
 
   test("handles error on fetching / parsing", async () => {
-    jest.spyOn(api, "apiCall").mockImplementationOnce(() => {
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
       return Promise.resolve("error")
     })
 
@@ -180,7 +180,7 @@ describe("ViewDisruption", () => {
   })
 
   test("handles error with day of week values", async () => {
-    jest.spyOn(api, "apiCall").mockImplementationOnce(() => {
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
       return Promise.resolve(
         new Disruption({
           id: "1",

--- a/assets/tests/jsonApi.test.ts
+++ b/assets/tests/jsonApi.test.ts
@@ -1,4 +1,4 @@
-import { toModelObject } from "../src/jsonApi"
+import { toModelObject, parseErrors } from "../src/jsonApi"
 import Adjustment from "../src/models/adjustment"
 import DayOfWeek from "../src/models/dayOfWeek"
 import Disruption from "../src/models/disruption"
@@ -399,5 +399,19 @@ describe("toModelObject", () => {
         jsonapi: { version: "1.0" },
       })
     ).toEqual("error")
+  })
+})
+
+describe("parseErrors", () => {
+  test("Parses JSON:API formatted errors into list of errors", () => {
+    const data = { errors: [{ detail: "error1" }, { detail: "error2" }] }
+    expect(parseErrors(data)).toEqual(["error1", "error2"])
+  })
+
+  test("handles oddly shaped data without crashing", () => {
+    expect(parseErrors("foo")).toEqual([])
+    expect(parseErrors({})).toEqual([])
+    expect(parseErrors({ errors: "foo" })).toEqual([])
+    expect(parseErrors({ errors: [{ foo: "bar" }] })).toEqual([])
   })
 })

--- a/assets/tests/models/disruption.test.ts
+++ b/assets/tests/models/disruption.test.ts
@@ -25,16 +25,16 @@ describe("Disruption", () => {
           end_date: "2020-03-01",
         },
         relationships: {
-          adjustment: {
+          adjustments: {
             data: [{ id: "1", type: "adjustment", attributes: {} }],
           },
-          day_of_week: {
+          days_of_week: {
             data: [{ id: "2", type: "day_of_week", attributes: {} }],
           },
           exceptions: {
             data: [{ id: "3", type: "exception", attributes: {} }],
           },
-          trip_short_name: {
+          trip_short_names: {
             data: [{ id: "4", type: "trip_short_name", attributes: {} }],
           },
         },

--- a/assets/tests/models/exception.test.ts
+++ b/assets/tests/models/exception.test.ts
@@ -35,4 +35,10 @@ describe("Exception", () => {
   test("fromJsonObject error not an object", () => {
     expect(Exception.fromJsonObject(5)).toEqual("error")
   })
+
+  test("constructs from array of dates", () => {
+    expect(Exception.fromDates([new Date("2020-03-31")])).toEqual([
+      new Exception({ excludedDate: new Date("2020-03-31") }),
+    ])
+  })
 })

--- a/lib/arrow/adjustment.ex
+++ b/lib/arrow/adjustment.ex
@@ -35,4 +35,8 @@ defmodule Arrow.Adjustment do
     |> validate_required([:source, :source_label, :route_id])
     |> unique_constraint(:source_label)
   end
+
+  def changeset_assoc(adjustment, attrs) do
+    cast(adjustment, attrs, [:id])
+  end
 end

--- a/lib/arrow/disruption.ex
+++ b/lib/arrow/disruption.ex
@@ -24,23 +24,24 @@ defmodule Arrow.Disruption do
   end
 
   @doc false
-  def changeset(disruption, attrs) do
+  def changeset(disruption, attrs, adjustments) do
     days_of_week =
-      for dow <- attrs[:days_of_week] || [],
+      for dow <- attrs["days_of_week"] || [],
           do: DayOfWeek.changeset(%DayOfWeek{}, dow)
 
     exceptions =
-      for exception <- attrs[:exceptions] || [],
-          do: Exception.changeset(%Exception{}, %{excluded_date: exception})
+      for exception <- attrs["exceptions"] || [],
+          do: Exception.changeset(%Exception{}, exception)
 
     trip_short_names =
-      for name <- attrs[:trip_short_names] || [],
-          do: TripShortName.changeset(%TripShortName{}, %{trip_short_name: name})
+      for name <- attrs["trip_short_names"] || [],
+          do: TripShortName.changeset(%TripShortName{}, name)
 
     disruption
     |> cast(attrs, [:start_date, :end_date])
     |> validate_required([:start_date, :end_date])
-    |> put_assoc(:adjustments, attrs[:adjustments] || [])
+    |> put_assoc(:adjustments, adjustments, with: &Arrow.Adjustment.changeset_assoc/2)
+    |> validate_length(:adjustments, min: 1)
     |> put_assoc(:days_of_week, days_of_week)
     |> put_assoc(:exceptions, exceptions)
     |> put_assoc(:trip_short_names, trip_short_names)

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -11,6 +11,7 @@ defmodule ArrowWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json-api"]
+    plug :fetch_session
     plug JaSerializer.ContentTypeNegotiation
   end
 
@@ -59,9 +60,9 @@ defmodule ArrowWeb.Router do
   end
 
   scope "/api", ArrowWeb.API do
-    pipe_through([:redirect_prod_http, :api])
+    pipe_through([:redirect_prod_http, :api, :auth, :ensure_auth, :ensure_arrow_group])
 
-    resources("/disruptions", DisruptionController, only: [:index, :show])
+    resources("/disruptions", DisruptionController, only: [:index, :show, :create])
     resources("/adjustments", AdjustmentController, only: [:index])
   end
 

--- a/lib/arrow_web/utilities.ex
+++ b/lib/arrow_web/utilities.ex
@@ -1,0 +1,45 @@
+defmodule ArrowWeb.Utilities do
+  @doc """
+  Extract the info from a json:api formatted set of relationships.
+
+  Takes data in the form of
+
+  %{
+    "rel1" => %{
+      "data" => [
+        %{ ...json api resource...},
+        %{ ...json api resource...}
+      ]
+    },
+    "rel2" => %{
+      "data" => %{ ...json api resource...}
+    }
+  }
+
+  and returns
+
+  %{
+    "rel1" => [
+      ...JaSerializer.Params.to_attributes/1'ed form of resource,
+      ...JaSerializer.Params.to_attributes/1'ed form of resource,
+    ],
+    "rel2" => ...JaSerializer.Params.to_attributes/1'ed form of resource,
+  }
+
+  Note that it handles resources in a list, and singular resources.
+  """
+  @spec get_json_api_relationships(map()) :: map()
+  def get_json_api_relationships(params_relationships) do
+    Enum.reduce(
+      params_relationships,
+      %{},
+      fn {relationship, %{"data" => data}}, rels ->
+        if is_list(data) do
+          Map.put(rels, relationship, Enum.map(data, &JaSerializer.Params.to_attributes/1))
+        else
+          Map.put(rels, relationship, JaSerializer.Params.to_attributes(data))
+        end
+      end
+    )
+  end
+end

--- a/test/arrow/adjustment_test.exs
+++ b/test/arrow/adjustment_test.exs
@@ -37,4 +37,9 @@ defmodule Arrow.AdjustmentTest do
       assert {:error, _} = Repo.insert(Adjustment.changeset(adj2, %{}))
     end
   end
+
+  describe "changeset_assoc/2" do
+    assert %Ecto.Changeset{valid?: true} =
+             Adjustment.changeset_assoc(%Adjustment{}, %{id: 10, source: "foo"})
+  end
 end

--- a/test/arrow/disruption_test.exs
+++ b/test/arrow/disruption_test.exs
@@ -13,16 +13,20 @@ defmodule Arrow.DisruptionTest do
       assert [] = Repo.all(Disruption)
     end
 
-    test "can insert a disruption with no adjustments" do
-      assert {:ok, new_dis} =
-               Repo.insert(%Disruption{start_date: @start_date, end_date: @end_date},
-                 preload: [:adjustments, :exceptions, :trip_short_names]
+    test "cannot insert a disruption with no adjustments" do
+      assert {:error, %{errors: errors}} =
+               Repo.insert(
+                 Disruption.changeset(
+                   %Disruption{},
+                   %{
+                     start_date: @start_date,
+                     end_date: @end_date
+                   },
+                   []
+                 )
                )
 
-      new_dis = Repo.preload(new_dis, [:adjustments, :exceptions, :trip_short_names])
-      assert new_dis.adjustments == []
-      assert new_dis.exceptions == []
-      assert new_dis.trip_short_names == []
+      assert Keyword.get(errors, :adjustments)
     end
 
     test "can insert a disruption with adjustments" do
@@ -36,56 +40,97 @@ defmodule Arrow.DisruptionTest do
 
       assert {:ok, new_dis} =
                Repo.insert(
-                 Disruption.changeset(%Disruption{}, %{
-                   start_date: @start_date,
-                   end_date: @end_date,
-                   adjustments: [new_adj]
-                 })
+                 Disruption.changeset(
+                   %Disruption{},
+                   %{
+                     start_date: @start_date,
+                     end_date: @end_date
+                   },
+                   [new_adj]
+                 )
                )
 
       assert [_] = new_dis.adjustments
     end
 
     test "can insert a disruption with exceptions" do
+      adj = %Adjustment{
+        source: "testing",
+        source_label: "test_insert_disruption",
+        route_id: "test_route"
+      }
+
+      {:ok, new_adj} = Repo.insert(adj)
+
       assert {:ok, new_dis} =
                Repo.insert(
-                 Disruption.changeset(%Disruption{}, %{
-                   start_date: @start_date,
-                   end_date: @end_date,
-                   exceptions: [~D[2019-12-01]]
-                 })
+                 Disruption.changeset(
+                   %Disruption{},
+                   %{
+                     "start_date" => @start_date,
+                     "end_date" => @end_date,
+                     "exceptions" => [%{"excluded_date" => ~D[2019-12-01]}]
+                   },
+                   [new_adj]
+                 )
                )
 
       assert [_] = new_dis.exceptions
     end
 
     test "can insert a disruption with short names" do
+      adj = %Adjustment{
+        source: "testing",
+        source_label: "test_insert_disruption",
+        route_id: "test_route"
+      }
+
+      {:ok, new_adj} = Repo.insert(adj)
+
       assert {:ok, new_dis} =
                Repo.insert(
-                 Disruption.changeset(%Disruption{}, %{
-                   start_date: @start_date,
-                   end_date: @end_date,
-                   trip_short_names: ["006"]
-                 })
+                 Disruption.changeset(
+                   %Disruption{},
+                   %{
+                     "start_date" => @start_date,
+                     "end_date" => @end_date,
+                     "trip_short_names" => [%{"trip_short_name" => "006"}]
+                   },
+                   [new_adj]
+                 )
                )
 
       assert [_] = new_dis.trip_short_names
     end
 
     test "can insert a disruption with days of the week (recurrence)" do
+      adj = %Adjustment{
+        source: "testing",
+        source_label: "test_insert_disruption",
+        route_id: "test_route"
+      }
+
+      {:ok, new_adj} = Repo.insert(adj)
+
       assert {:ok, new_dis} =
                Repo.insert(
-                 Disruption.changeset(%Disruption{}, %{
-                   start_date: @start_date,
-                   end_date: @end_date,
-                   days_of_week: [
-                     %{day_name: "friday", start_time: ~T[20:30:00]},
-                     %{day_name: "saturday"}
-                   ]
-                 })
+                 Disruption.changeset(
+                   %Disruption{},
+                   %{
+                     "start_date" => @start_date,
+                     "end_date" => @end_date,
+                     "days_of_week" => [
+                       %{"day_name" => "friday", "start_time" => ~T[20:30:00]},
+                       %{"day_name" => "saturday"}
+                     ]
+                   },
+                   [new_adj]
+                 )
                )
 
       assert [friday, saturday] = new_dis.days_of_week
+
+      assert new_dis.adjustments == [new_adj]
 
       assert friday.day_name == "friday"
       assert friday.start_time == ~T[20:30:00]

--- a/test/arrow_web/controllers/api/adjustment_controller_test.exs
+++ b/test/arrow_web/controllers/api/adjustment_controller_test.exs
@@ -3,10 +3,12 @@ defmodule ArrowWeb.API.AdjustmentControllerTest do
   alias Arrow.{Adjustment, Repo}
 
   describe "index/2" do
+    @tag :authenticated
     test "returns 200", %{conn: conn} do
       assert %{status: 200} = get(conn, "/api/adjustments")
     end
 
+    @tag :authenticated
     test "returns all adjustments by default", %{conn: conn} do
       insert_adjusments()
 
@@ -32,6 +34,7 @@ defmodule ArrowWeb.API.AdjustmentControllerTest do
              ] = res["data"]
     end
 
+    @tag :authenticated
     test "can filter by route_id", %{conn: conn} do
       {adjustment_1, _} = insert_adjusments()
 
@@ -45,6 +48,7 @@ defmodule ArrowWeb.API.AdjustmentControllerTest do
       assert List.first(data)["id"] == Integer.to_string(adjustment_1.id)
     end
 
+    @tag :authenticated
     test "can filter by source", %{conn: conn} do
       {_, adjustment_2} = insert_adjusments()
 

--- a/test/arrow_web/utilities_test.exs
+++ b/test/arrow_web/utilities_test.exs
@@ -1,0 +1,18 @@
+defmodule ArrowWeb.UtilitiesTest do
+  use ExUnit.Case, async: true
+  import ArrowWeb.Utilities
+
+  describe "get_json_api_relationships/1" do
+    test "parses the data correctly" do
+      data = %{
+        "rel1" => %{"data" => %{"attributes" => %{"attr1" => "val1"}}},
+        "rel2" => %{"data" => [%{"attributes" => %{"attr2" => "val2"}}]}
+      }
+
+      assert %{
+               "rel1" => %{"attr1" => "val1"},
+               "rel2" => [%{"attr2" => "val2"}]
+             } = get_json_api_relationships(data)
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 API to create disruption, frontend uses it](https://app.asana.com/0/584764604969369/1157557244099553)

I'm still trying to finesse how I organize the frontend changes around the network call, for the purpose of abstraction and testing, but the functionality should be there, and I think the backend is done.

The commits to review in order:

* A small refactor to rename `apiCall` to `apiGet`, since my code works pretty differently. I plan to move my API calling logic into this module as `apiPost`, which should work fairly similarly, but will, e.g., look at different response statuses and take an error parser in addition to a success parser.
* The backend changes to accept a json:api POST and create the relevant records.
* The frontend changes for the `NewDisruption` component to digest its state and POST it to the backend.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
