### PR TITLE
feat: Disruption index page

### DIFF
--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -19,11 +19,7 @@ const App = (): JSX.Element => {
   return (
     <BrowserRouter>
       <Switch>
-        <Route
-          exact={true}
-          path="/"
-          render={() => <DisruptionIndex disruptions={[]} />}
-        />
+        <Route exact={true} path="/" render={() => <DisruptionIndex />} />
         <Route exact={true} path="/disruptions/new" component={NewDisruption} />
         <Route
           exact={true}

--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -13,7 +13,7 @@ import { BrowserRouter, Route, Switch } from "react-router-dom"
 import EditDisruption from "./disruptions/editDisruption"
 import { NewDisruption } from "./disruptions/newDisruption"
 import ViewDisruption from "./disruptions/viewDisruption"
-import DisruptionIndex from "./disruptions/disruptionIndex"
+import { DisruptionIndex } from "./disruptions/disruptionIndex"
 
 const App = (): JSX.Element => {
   return (

--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -19,7 +19,7 @@ const App = (): JSX.Element => {
   return (
     <BrowserRouter>
       <Switch>
-        <Route exact={true} path="/" render={() => <DisruptionIndex />} />
+        <Route exact={true} path="/" component={DisruptionIndex} />
         <Route exact={true} path="/disruptions/new" component={NewDisruption} />
         <Route
           exact={true}

--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -14,7 +14,7 @@ import DisruptionCalendar from "./disruptionCalendar"
 import Disruption from "../models/disruption"
 import { apiGet } from "../api"
 import { ModelObject, toModelObject } from "../jsonApi"
-import {parseDaysAndTimes} from "../disruptions/time"
+import { parseDaysAndTimes } from "../disruptions/time"
 
 type Routes =
   | "Red"

--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -243,7 +243,7 @@ const DisruptionIndex = () => {
             .filter(
               (routeId: string | undefined): routeId is Routes => !!routeId
             ),
-          daysAndTimes: x.daysOfWeek.length
+          daysAndTimes: x.daysOfWeek.length > 0
             ? parseDaysAndTimes(x.daysOfWeek)
             : "",
         }

--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -9,7 +9,7 @@ import Form from "react-bootstrap/Form"
 import Header from "../header"
 import Button from "react-bootstrap/Button"
 import Icon from "../icons"
-import DisruptionTable from "./disruptionTable"
+import { DisruptionTable } from "./disruptionTable"
 import DisruptionCalendar from "./disruptionCalendar"
 import Disruption from "../models/disruption"
 import { apiGet } from "../api"
@@ -58,7 +58,7 @@ interface RouteFilterToggleProps {
   onClick: (route: keyof RouteFilterState) => void
 }
 // eslint-disable-next-line react/display-name
-export const RouteFilterToggle = React.memo(
+const RouteFilterToggle = React.memo(
   ({ route, active, onClick }: RouteFilterToggleProps) => {
     return (
       <a
@@ -104,7 +104,7 @@ interface DisruptionIndexProps {
   disruptions: DisruptionRow[]
 }
 
-export const DisruptionIndexView = ({ disruptions }: DisruptionIndexProps) => {
+const DisruptionIndexView = ({ disruptions }: DisruptionIndexProps) => {
   const [view, setView] = React.useState<"table" | "calendar">("table")
   const toggleView = React.useCallback(() => {
     if (view === "table") {
@@ -218,7 +218,7 @@ export const DisruptionIndexView = ({ disruptions }: DisruptionIndexProps) => {
   )
 }
 
-const DisruptionIndexConnected = () => {
+const DisruptionIndex = () => {
   const [disruptions, setDisruptions] = React.useState<Disruption[] | "error">(
     []
   )
@@ -243,7 +243,9 @@ const DisruptionIndexConnected = () => {
             .filter(
               (routeId: string | undefined): routeId is Routes => !!routeId
             ),
-          daysAndTimes: parseDaysAndTimes(x.daysOfWeek),
+          daysAndTimes: x.daysOfWeek.length
+            ? parseDaysAndTimes(x.daysOfWeek)
+            : "",
         }
       })
     }
@@ -273,4 +275,4 @@ const DisruptionIndexConnected = () => {
   }
 }
 
-export default DisruptionIndexConnected
+export { DisruptionIndex, RouteFilterToggle, DisruptionIndexView }

--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -243,9 +243,8 @@ const DisruptionIndex = () => {
             .filter(
               (routeId: string | undefined): routeId is Routes => !!routeId
             ),
-          daysAndTimes: x.daysOfWeek.length > 0
-            ? parseDaysAndTimes(x.daysOfWeek)
-            : "",
+          daysAndTimes:
+            x.daysOfWeek.length > 0 ? parseDaysAndTimes(x.daysOfWeek) : "",
         }
       })
     }

--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -14,8 +14,7 @@ import DisruptionCalendar from "./disruptionCalendar"
 import Disruption from "../models/disruption"
 import { apiGet } from "../api"
 import { ModelObject, toModelObject } from "../jsonApi"
-import DayOfWeek, { DayName } from "../models/dayOfWeek"
-import {dayToIx, parseDaysAndTimes} from "../disruptions/time"
+import {parseDaysAndTimes} from "../disruptions/time"
 
 type Routes =
   | "Red"
@@ -223,7 +222,6 @@ const DisruptionIndexConnected = () => {
   const [disruptions, setDisruptions] = React.useState<Disruption[] | "error">(
     []
   )
-
   const disruptionRows = React.useMemo(() => {
     if (disruptions === "error") {
       return []

--- a/assets/src/disruptions/disruptionTable.tsx
+++ b/assets/src/disruptions/disruptionTable.tsx
@@ -13,7 +13,7 @@ interface DisruptionTableHeaderProps {
   onClick?: () => void
 }
 
-export const DisruptionTableHeader = ({
+const DisruptionTableHeader = ({
   sortable,
   sortOrder,
   active,
@@ -119,4 +119,4 @@ const DisruptionTable = ({ disruptions }: DisruptionTableProps) => {
   )
 }
 
-export default DisruptionTable
+export { DisruptionTableHeader, DisruptionTable }

--- a/assets/src/disruptions/disruptionTable.tsx
+++ b/assets/src/disruptions/disruptionTable.tsx
@@ -53,9 +53,13 @@ const DisruptionTable = ({ disruptions }: DisruptionTableProps) => {
   const sortedDisruptions = React.useMemo(() => {
     const { by, order } = sortState
     return disruptions.sort((a, b) => {
-      if (a[by] > b[by]) {
+      if (!a[by] || !b[by]) {
+        return 0
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      } else if (a[by]! > b[by]!) {
         return order === "asc" ? 1 : -1
-      } else if (a[by] < b[by]) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      } else if (a[by]! < b[by]!) {
         return order === "asc" ? -1 : 1
       } else {
         return 0
@@ -99,9 +103,11 @@ const DisruptionTable = ({ disruptions }: DisruptionTableProps) => {
         {sortedDisruptions.map(x => (
           <tr key={x.id}>
             <td>{x.label}</td>
-            <td>{`${formatDisruptionDate(x.startDate)} - ${formatDisruptionDate(
-              x.endDate
-            )}`}</td>
+            {!!x.startDate && !!x.endDate && (
+              <td>{`${formatDisruptionDate(
+                x.startDate
+              )} - ${formatDisruptionDate(x.endDate)}`}</td>
+            )}
             <td>{x.daysAndTimes}</td>
             <td>
               <Link to={`/disruptions/${x.id}`}>See details</Link>

--- a/assets/src/disruptions/disruptionTable.tsx
+++ b/assets/src/disruptions/disruptionTable.tsx
@@ -54,7 +54,7 @@ const DisruptionTable = ({ disruptions }: DisruptionTableProps) => {
     const { by, order } = sortState
     return disruptions.sort((a, b) => {
       if (!a[by] || !b[by]) {
-        return 0
+        return -1
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       } else if (a[by]! > b[by]!) {
         return order === "asc" ? 1 : -1

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -1,4 +1,4 @@
-import DayOfWeek from "../models/dayOfWeek"
+import DayOfWeek, { DayName } from "../models/dayOfWeek"
 
 type HourOptions =
   | "12"

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -284,7 +284,7 @@ const getTimeType = (
   } else if (
     (startTimeSet.size + endTimeSet.size === 3 &&
       firstTime.startTime !== lastTime.endTime) ||
-    (startTimeSet.size + endTimeSet.size == 4 &&
+    (startTimeSet.size + endTimeSet.size === 4 &&
       !!firstTime.startTime &&
       !!lastTime.endTime &&
       firstTime.startTime === lastTime.endTime)
@@ -327,7 +327,7 @@ export const parseDaysAndTimes = (daysAndTimes: DayOfWeek[]): string => {
   const last = daysAndTimes[daysAndTimes.length - 1]
   const startTimeSet = new Set<string | undefined>()
   const endTimeSet = new Set<string | undefined>()
-  let fallBackStringList: string[] = []
+  const fallBackStringList: string[] = []
   daysAndTimes.forEach(dayOfWeek => {
     const { day, startTime, endTime } = dayOfWeek
     if (day) {

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -279,18 +279,14 @@ const getTimeType = (
   startTimeSet: Set<string | undefined>,
   endTimeSet: Set<string | undefined>
 ): "daily" | "ends" | "other" => {
-  if (startTimeSet.size === 1 && endTimeSet.size === 1) {
+  const setSizeSum = startTimeSet.size + endTimeSet.size
+  if (setSizeSum == 2) {
     return "daily"
   } else if (
-    ((!!firstTime.startTime || !!lastTime.endTime) &&
-      !firstTime.endTime &&
-      startTimeSet.size + endTimeSet.size === 3 &&
-      firstTime.startTime !== lastTime.endTime) ||
-    (startTimeSet.size + endTimeSet.size === 4 &&
-      !!firstTime.startTime &&
-      !!lastTime.endTime &&
-      !firstTime.endTime &&
-      firstTime.startTime === lastTime.endTime)
+    (!!firstTime.startTime || !!firstTime.endTime) &&
+    !firstTime.endTime &&
+    !lastTime.startTime &&
+    setSizeSum === (firstTime.startTime === lastTime.endTime ? 4 : 3)
   ) {
     return "ends"
   } else {

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -282,7 +282,8 @@ const getTimeType = (
   if (startTimeSet.size === 1 && endTimeSet.size === 1) {
     return "daily"
   } else if (
-    ((!!firstTime.startTime || !!lastTime.endTime) && startTimeSet.size + endTimeSet.size === 3 &&
+    ((!!firstTime.startTime || !!lastTime.endTime) &&
+      startTimeSet.size + endTimeSet.size === 3 &&
       firstTime.startTime !== lastTime.endTime) ||
     (startTimeSet.size + endTimeSet.size === 4 &&
       !!firstTime.startTime &&

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -187,6 +187,33 @@ const ixToDayName = (
   }
 }
 
+export const dayToIx = (
+  day: | "monday"
+  | "tuesday"
+  | "wednesday"
+  | "thursday"
+  | "friday"
+  | "saturday"
+  | "sunday"
+): number => {
+  switch (day) {
+    case "monday":
+      return 0
+    case "tuesday":
+      return 1
+    case "wednesday":
+      return 2
+    case "thursday":
+      return 3
+    case "friday":
+      return 4
+    case "saturday":
+      return 5
+    default:
+      return 6
+  }
+}
+
 const dayOfWeekTimeRangesToDayOfWeeks = (
   timeRanges: DayOfWeekTimeRanges
 ): DayOfWeek[] => {
@@ -218,4 +245,83 @@ export {
   fromDaysOfWeek,
   isEmpty,
   dayOfWeekTimeRangesToDayOfWeeks,
+}
+
+const hourToString = (hour: number) => {
+  if (hour == 0) {
+    return "12"
+  } else if (hour > 12) {
+    return (hour - 12).toString()
+  } else {
+    return hour.toString()
+  }
+}
+
+const timeOrEndOfService = (time?: string, end: "start" | "end" = "start"): string => {
+  if (time) {
+    const hoursInt = parseInt(time.slice(0,2))
+    const hours = hourToString(hoursInt)
+    const minutes = time.slice(2,5)
+    const period = hoursInt < 12 ? "AM" : "PM"
+    return `${hours}${minutes}${period}`
+  } else {
+    return end === "start" ? "Start of service" : "End of service"
+  }
+}
+
+const getTimeType = (firstTime: DayOfWeek, lastTime: DayOfWeek, startTimeSet: Set<string | undefined>, endTimeSet: Set<string | undefined>) : "same-but-ends" | "other" | "same-each-day" => {
+  if (startTimeSet.size == 1 && endTimeSet.size == 1) {
+    return "same-each-day"
+  } else if (startTimeSet.size + endTimeSet.size == 3 && firstTime.startTime !== lastTime.endTime) {
+    return "same-but-ends"
+  } else {
+    return "other"
+  }
+}
+
+type DaysType = "consecutive" | "other"
+
+const getDaysType = (days: DayName[]): DaysType=> {
+  const sortedDays = days.map(day => ({day, index: dayToIx(day)})).sort((a,b) => a.index - b.index)
+  let consecutive = true;
+  sortedDays.forEach((day, index, array) => {
+    if (index && day.index - array[index - 1].index != 1) {
+      consecutive = false
+    }
+  })
+  return consecutive ? "consecutive" : "other"
+}
+
+function capitalizeFirstLetter(string?: string) {
+  return string ? string.charAt(0).toUpperCase() + string.slice(1) : "";
+}
+
+const describeSingleDay = ({day, startTime, endTime}: DayOfWeek) => `${day}, ${timeOrEndOfService(startTime)} - ${timeOrEndOfService(endTime, "end")}, `
+
+export const parseDaysAndTimes = (daysAndTimes: DayOfWeek[]): string => {
+  if (daysAndTimes.length == 1) {
+    return describeSingleDay(daysAndTimes[0])
+  }
+  const first = daysAndTimes[0]
+  const last = daysAndTimes[daysAndTimes.length - 1] 
+  const startTimeSet = new Set<string | undefined>()
+  const endTimeSet = new Set<string | undefined>()
+  let fallBackString = ""
+  daysAndTimes.forEach(dayOfWeek => {
+    const {day, startTime, endTime} = dayOfWeek
+    if (day) {
+      startTimeSet.add(startTime)
+      endTimeSet.add(endTime)
+      fallBackString += describeSingleDay(dayOfWeek)
+    }
+  })
+  const daysType = getDaysType(daysAndTimes.map(day => day.day).filter((day: DayName | undefined): day is DayName => !!day))
+  const timeType = getTimeType(first, last, startTimeSet, endTimeSet)
+  if (daysType == "other" || timeType == "other") {
+    return fallBackString
+  } else if (timeType == "same-each-day") {
+    return `${capitalizeFirstLetter(first.day)} - ${capitalizeFirstLetter(last.day)}, ${timeOrEndOfService(first.startTime)} - ${timeOrEndOfService(first.endTime, "end")}`
+  } else {
+    return `${capitalizeFirstLetter(first.day)} ${timeOrEndOfService(first.startTime)} - ${capitalizeFirstLetter(last.day)} ${timeOrEndOfService(last.endTime, "end")}`
+  }
 }

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -248,7 +248,7 @@ export {
 }
 
 const hourToString = (hour: number) => {
-  if (hour == 0) {
+  if (hour === 0) {
     return "12"
   } else if (hour > 12) {
     return (hour - 12).toString()
@@ -259,7 +259,7 @@ const hourToString = (hour: number) => {
 
 const timeOrEndOfService = (time?: string, end: "start" | "end" = "start"): string => {
   if (time) {
-    const hoursInt = parseInt(time.slice(0,2))
+    const hoursInt = parseInt(time.slice(0,2), 10)
     const hours = hourToString(hoursInt)
     const minutes = time.slice(2,5)
     const period = hoursInt < 12 ? "AM" : "PM"
@@ -270,9 +270,9 @@ const timeOrEndOfService = (time?: string, end: "start" | "end" = "start"): stri
 }
 
 const getTimeType = (firstTime: DayOfWeek, lastTime: DayOfWeek, startTimeSet: Set<string | undefined>, endTimeSet: Set<string | undefined>) : "same-but-ends" | "other" | "same-each-day" => {
-  if (startTimeSet.size == 1 && endTimeSet.size == 1) {
+  if (startTimeSet.size === 1 && endTimeSet.size === 1) {
     return "same-each-day"
-  } else if (startTimeSet.size + endTimeSet.size == 3 && firstTime.startTime !== lastTime.endTime) {
+  } else if (startTimeSet.size + endTimeSet.size === 3 && firstTime.startTime !== lastTime.endTime) {
     return "same-but-ends"
   } else {
     return "other"
@@ -285,21 +285,21 @@ const getDaysType = (days: DayName[]): DaysType=> {
   const sortedDays = days.map(day => ({day, index: dayToIx(day)})).sort((a,b) => a.index - b.index)
   let consecutive = true;
   sortedDays.forEach((day, index, array) => {
-    if (index && day.index - array[index - 1].index != 1) {
+    if (index && day.index - array[index - 1].index !== 1) {
       consecutive = false
     }
   })
   return consecutive ? "consecutive" : "other"
 }
 
-function capitalizeFirstLetter(string?: string) {
-  return string ? string.charAt(0).toUpperCase() + string.slice(1) : "";
+const capitalizeFirstLetter = (str?: string) => {
+  return str ? str.charAt(0).toUpperCase() + str.slice(1) : "";
 }
 
 const describeSingleDay = ({day, startTime, endTime}: DayOfWeek) => `${day}, ${timeOrEndOfService(startTime)} - ${timeOrEndOfService(endTime, "end")}, `
 
 export const parseDaysAndTimes = (daysAndTimes: DayOfWeek[]): string => {
-  if (daysAndTimes.length == 1) {
+  if (daysAndTimes.length === 1) {
     return describeSingleDay(daysAndTimes[0])
   }
   const first = daysAndTimes[0]
@@ -317,9 +317,9 @@ export const parseDaysAndTimes = (daysAndTimes: DayOfWeek[]): string => {
   })
   const daysType = getDaysType(daysAndTimes.map(day => day.day).filter((day: DayName | undefined): day is DayName => !!day))
   const timeType = getTimeType(first, last, startTimeSet, endTimeSet)
-  if (daysType == "other" || timeType == "other") {
+  if (daysType === "other" || timeType === "other") {
     return fallBackString
-  } else if (timeType == "same-each-day") {
+  } else if (timeType === "same-each-day") {
     return `${capitalizeFirstLetter(first.day)} - ${capitalizeFirstLetter(last.day)}, ${timeOrEndOfService(first.startTime)} - ${timeOrEndOfService(first.endTime, "end")}`
   } else {
     return `${capitalizeFirstLetter(first.day)} ${timeOrEndOfService(first.startTime)} - ${capitalizeFirstLetter(last.day)} ${timeOrEndOfService(last.endTime, "end")}`

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -280,7 +280,7 @@ const getTimeType = (
   endTimeSet: Set<string | undefined>
 ): "daily" | "ends" | "other" => {
   const setSizeSum = startTimeSet.size + endTimeSet.size
-  if (setSizeSum == 2) {
+  if (setSizeSum === 2) {
     return "daily"
   } else if (
     (!!firstTime.startTime || !!firstTime.endTime) &&
@@ -313,8 +313,12 @@ const capitalizeFirstLetter = (str?: string) => {
   return str ? str.charAt(0).toUpperCase() + str.slice(1) : ""
 }
 
-const describeSingleDay = ({ day, startTime, endTime }: DayOfWeek): string =>
-  `${capitalizeFirstLetter(day)}, ${timeOrEndOfService(
+const describeSingleDay = ({
+  dayName,
+  startTime,
+  endTime,
+}: DayOfWeek): string =>
+  `${capitalizeFirstLetter(dayName)}, ${timeOrEndOfService(
     startTime
   )} - ${timeOrEndOfService(endTime, "end")}`
 
@@ -328,8 +332,8 @@ export const parseDaysAndTimes = (daysAndTimes: DayOfWeek[]): string => {
   const endTimeSet = new Set<string | undefined>()
   const fallBackStringList: string[] = []
   daysAndTimes.forEach(dayOfWeek => {
-    const { day, startTime, endTime } = dayOfWeek
-    if (day) {
+    const { dayName, startTime, endTime } = dayOfWeek
+    if (dayName) {
       startTimeSet.add(startTime)
       endTimeSet.add(endTime)
       fallBackStringList.push(describeSingleDay(dayOfWeek))
@@ -337,23 +341,23 @@ export const parseDaysAndTimes = (daysAndTimes: DayOfWeek[]): string => {
   })
   const daysType = getDaysType(
     daysAndTimes
-      .map(day => day.day)
+      .map(day => day.dayName)
       .filter((day: DayName | undefined): day is DayName => !!day)
   )
   const timeType = getTimeType(first, last, startTimeSet, endTimeSet)
   if (daysType === "other" || timeType === "other") {
     return fallBackStringList.join(", ")
   } else if (timeType === "daily") {
-    return `${capitalizeFirstLetter(first.day)} - ${capitalizeFirstLetter(
-      last.day
+    return `${capitalizeFirstLetter(first.dayName)} - ${capitalizeFirstLetter(
+      last.dayName
     )}, ${timeOrEndOfService(first.startTime)} - ${timeOrEndOfService(
       first.endTime,
       "end"
     )}`
   } else {
-    return `${capitalizeFirstLetter(first.day)} ${timeOrEndOfService(
+    return `${capitalizeFirstLetter(first.dayName)} ${timeOrEndOfService(
       first.startTime
-    )} - ${capitalizeFirstLetter(last.day)} ${timeOrEndOfService(
+    )} - ${capitalizeFirstLetter(last.dayName)} ${timeOrEndOfService(
       last.endTime,
       "end"
     )}`

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -187,7 +187,7 @@ const ixToDayName = (
   }
 }
 
-export const dayToIx = (
+const dayToIx = (
   day:
     | "monday"
     | "tuesday"
@@ -234,28 +234,6 @@ const dayOfWeekTimeRangesToDayOfWeeks = (
   })
 
   return daysOfWeek
-}
-
-export {
-  Time,
-  HourOptions,
-  MinuteOptions,
-  PeriodOptions,
-  TimeRange,
-  DayOfWeekTimeRanges,
-  fromDaysOfWeek,
-  isEmpty,
-  dayOfWeekTimeRangesToDayOfWeeks,
-}
-
-const hourToString = (hour: number) => {
-  if (hour === 0) {
-    return "12"
-  } else if (hour > 12) {
-    return (hour - 12).toString()
-  } else {
-    return hour.toString()
-  }
 }
 
 const timeOrEndOfService = (
@@ -322,7 +300,7 @@ const describeSingleDay = ({
     startTime
   )} - ${timeOrEndOfService(endTime, "end")}`
 
-export const parseDaysAndTimes = (daysAndTimes: DayOfWeek[]): string => {
+const parseDaysAndTimes = (daysAndTimes: DayOfWeek[]): string => {
   if (daysAndTimes.length === 1) {
     return describeSingleDay(daysAndTimes[0])
   }
@@ -361,5 +339,29 @@ export const parseDaysAndTimes = (daysAndTimes: DayOfWeek[]): string => {
       last.endTime,
       "end"
     )}`
+  }
+}
+
+export {
+  Time,
+  HourOptions,
+  MinuteOptions,
+  PeriodOptions,
+  TimeRange,
+  DayOfWeekTimeRanges,
+  fromDaysOfWeek,
+  isEmpty,
+  dayOfWeekTimeRangesToDayOfWeeks,
+  parseDaysAndTimes,
+  dayToIx,
+}
+
+const hourToString = (hour: number) => {
+  if (hour === 0) {
+    return "12"
+  } else if (hour > 12) {
+    return (hour - 12).toString()
+  } else {
+    return hour.toString()
   }
 }

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -77,19 +77,22 @@ const timeStringToTime = (
   if (typeof timeString === "undefined") {
     return null
   }
-
   const timeStringComponents = timeString.split(":")
 
   if (timeStringComponents.length === 3) {
+    const hourString = timeStringComponents[0].startsWith("0")
+      ? timeStringComponents[0].slice(1)
+      : timeStringComponents[0]
     const hour = String(
-      +timeStringComponents[0] > 12
-        ? +timeStringComponents[0] - 12
-        : timeStringComponents[0]
+      +hourString > 12
+        ? +hourString - 12
+        : hourString === "0"
+        ? "12"
+        : hourString
     )
     const minute = timeStringComponents[1]
     const second = timeStringComponents[2]
     const period = +timeStringComponents[0] > 12 ? "PM" : "AM"
-
     if (isHourOption(hour) && isMinuteOption(minute) && second === "00") {
       return {
         hour,
@@ -159,16 +162,7 @@ const timeToString = (time: Time): string => {
   return `${numToString(hourNum)}:${numToString(minuteNum)}:00`
 }
 
-const ixToDayName = (
-  ix: number
-):
-  | "monday"
-  | "tuesday"
-  | "wednesday"
-  | "thursday"
-  | "friday"
-  | "saturday"
-  | "sunday" => {
+const ixToDayName = (ix: number): DayName => {
   switch (ix) {
     case 0:
       return "monday"
@@ -187,16 +181,7 @@ const ixToDayName = (
   }
 }
 
-const dayToIx = (
-  day:
-    | "monday"
-    | "tuesday"
-    | "wednesday"
-    | "thursday"
-    | "friday"
-    | "saturday"
-    | "sunday"
-): number => {
+const dayToIx = (day: DayName): number => {
   switch (day) {
     case "monday":
       return 0
@@ -237,18 +222,17 @@ const dayOfWeekTimeRangesToDayOfWeeks = (
 }
 
 const timeOrEndOfService = (
-  time?: string,
+  timeString?: string,
   end: "start" | "end" = "start"
 ): string => {
-  if (time) {
-    const hoursInt = parseInt(time.slice(0, 2), 10)
-    const hours = hourToString(hoursInt)
-    const minutes = time.slice(2, 5)
-    const period = hoursInt < 12 ? "AM" : "PM"
-    return `${hours}${minutes}${period}`
-  } else {
-    return end === "start" ? "Start of service" : "End of service"
+  if (timeString) {
+    const time = timeStringToTime(timeString)
+    if (time && time !== "error") {
+      const { hour, minute, period } = time
+      return `${hour}:${minute}${period}`
+    }
   }
+  return end === "start" ? "Start of service" : "End of service"
 }
 
 const getTimeType = (
@@ -354,14 +338,4 @@ export {
   dayOfWeekTimeRangesToDayOfWeeks,
   parseDaysAndTimes,
   dayToIx,
-}
-
-const hourToString = (hour: number) => {
-  if (hour === 0) {
-    return "12"
-  } else if (hour > 12) {
-    return (hour - 12).toString()
-  } else {
-    return hour.toString()
-  }
 }

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -282,7 +282,7 @@ const getTimeType = (
   if (startTimeSet.size === 1 && endTimeSet.size === 1) {
     return "daily"
   } else if (
-    (startTimeSet.size + endTimeSet.size === 3 &&
+    ((!!firstTime.startTime || !!lastTime.endTime) && startTimeSet.size + endTimeSet.size === 3 &&
       firstTime.startTime !== lastTime.endTime) ||
     (startTimeSet.size + endTimeSet.size === 4 &&
       !!firstTime.startTime &&

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -283,11 +283,13 @@ const getTimeType = (
     return "daily"
   } else if (
     ((!!firstTime.startTime || !!lastTime.endTime) &&
+      !firstTime.endTime &&
       startTimeSet.size + endTimeSet.size === 3 &&
       firstTime.startTime !== lastTime.endTime) ||
     (startTimeSet.size + endTimeSet.size === 4 &&
       !!firstTime.startTime &&
       !!lastTime.endTime &&
+      !firstTime.endTime &&
       firstTime.startTime === lastTime.endTime)
   ) {
     return "ends"

--- a/assets/src/jsonApi.ts
+++ b/assets/src/jsonApi.ts
@@ -14,7 +14,7 @@ type ModelObject =
 const toModelObject = (
   response: any
 ): ModelObject | ModelObject[] | "error" => {
-  const includedObjectsMap: {
+  const includedObjects: {
     [key: string]: ModelObject | "error"
   } = Array.isArray(response?.included)
     ? response.included.reduce(
@@ -25,14 +25,9 @@ const toModelObject = (
         {}
       )
     : {}
-  let includedObjects = Object.values(includedObjectsMap)
   if (Array.isArray(response?.included)) {
-    includedObjects = response.included.map((raw: any) =>
-      modelFromJsonApiResource(raw, [])
-    )
-
     if (
-      Object.values(includedObjectsMap).some(
+      Object.values(includedObjects).some(
         (modelObject: ModelObject | "error") => modelObject === "error"
       )
     ) {
@@ -51,7 +46,7 @@ const toModelObject = (
               return [
                 ...acc,
                 ...(curr?.data || []).map(
-                  (x: any) => includedObjectsMap[`${x.type}-${x.id}`]
+                  (x: any) => includedObjects[`${x.type}-${x.id}`]
                 ),
               ]
             },
@@ -69,7 +64,7 @@ const toModelObject = (
   } else {
     return modelFromJsonApiResource(
       response.data,
-      includedObjects as ModelObject[]
+      Object.values(includedObjects) as ModelObject[]
     )
   }
 }

--- a/assets/src/models/dayOfWeek.ts
+++ b/assets/src/models/dayOfWeek.ts
@@ -1,7 +1,7 @@
 import { JsonApiResource, JsonApiResourceData } from "../jsonApiResource"
 import JsonApiResourceObject from "../jsonApiResourceObject"
 
-type DayName =
+export type DayName =
   | "monday"
   | "tuesday"
   | "wednesday"

--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -259,4 +259,19 @@ describe("DisruptionIndexConnected", () => {
       expect(dataColumns[2].textContent).toEqual(expected[index][2])
     })
   })
+
+  test("renders error", async () => {
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
+      return Promise.resolve("error")
+    })
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      ReactDOM.render(<DisruptionIndexWithRouter connected />, container)
+    })
+
+    expect(container.textContent).toMatch("Something went wrong")
+  })
 })

--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -170,7 +170,7 @@ describe("DisruptionIndexConnected", () => {
             new DayOfWeek({
               id: "1",
               startTime: "20:45:00",
-              day: "friday",
+              dayName: "friday",
             }),
           ],
           exceptions: [
@@ -214,12 +214,12 @@ describe("DisruptionIndexConnected", () => {
             new DayOfWeek({
               id: "1",
               startTime: "20:45:00",
-              day: "saturday",
+              dayName: "saturday",
             }),
             new DayOfWeek({
               id: "2",
               endTime: "20:45:00",
-              day: "sunday",
+              dayName: "sunday",
             }),
           ],
           exceptions: [

--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -2,7 +2,8 @@ import * as React from "react"
 import { BrowserRouter } from "react-router-dom"
 import { mount } from "enzyme"
 import * as renderer from "react-test-renderer"
-import DisruptionIndex, {
+import {
+  DisruptionIndexView as DisruptionIndex,
   RouteFilterToggle,
 } from "../../src/disruptions/disruptionIndex"
 import DisruptionTable from "../../src/disruptions/disruptionTable"

--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -2,42 +2,53 @@ import * as React from "react"
 import { BrowserRouter } from "react-router-dom"
 import { mount } from "enzyme"
 import * as renderer from "react-test-renderer"
-import {
+import DisruptionIndexConnected, {
   DisruptionIndexView as DisruptionIndex,
   RouteFilterToggle,
 } from "../../src/disruptions/disruptionIndex"
 import DisruptionTable from "../../src/disruptions/disruptionTable"
 import DisruptionCalendar from "../../src/disruptions/disruptionCalendar"
 import Header from "../../src/header"
+import Disruption from "../../src/models/disruption"
+import Adjustment from "../../src/models/adjustment"
+import DayOfWeek from "../../src/models/dayOfWeek"
+import Exception from "../../src/models/exception"
+import * as api from "../../src/api"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
 
-const DisruptionIndexWithRouter = () => {
+const DisruptionIndexWithRouter = ({ connected = false }) => {
   return (
     <BrowserRouter>
-      <DisruptionIndex
-        disruptions={[
-          {
-            id: "1",
-            routes: ["Red"],
-            label: "AlewifeHarvard",
-            startDate: new Date("2019-10-31"),
-            endDate: new Date("2019-11-15"),
-            daysAndTimes: "Weekends, starting Friday 845",
-          },
-          {
-            id: "2",
-            routes: ["Green-D", "Green-E"],
-            label: "Kenmore—Newton Highlands",
-            startDate: new Date("2019-09-22"),
-            endDate: new Date("2019-10-22"),
-            daysAndTimes: "Weekends, starting Friday 845",
-          },
-        ]}
-      />
+      {connected ? (
+        <DisruptionIndexConnected />
+      ) : (
+        <DisruptionIndex
+          disruptions={[
+            {
+              id: "1",
+              routes: ["Red"],
+              label: "AlewifeHarvard",
+              startDate: new Date("2019-10-31"),
+              endDate: new Date("2019-11-15"),
+              daysAndTimes: "Weekends, starting Friday 845",
+            },
+            {
+              id: "2",
+              routes: ["Green-D", "Green-E"],
+              label: "Kenmore—Newton Highlands",
+              startDate: new Date("2019-09-22"),
+              endDate: new Date("2019-10-22"),
+              daysAndTimes: "Weekends, starting Friday 845",
+            },
+          ]}
+        />
+      )}
     </BrowserRouter>
   )
 }
 
-describe("DisruptionIndex", () => {
+describe("DisruptionIndexView", () => {
   test("header does not include link to homepage", () => {
     const testInstance = renderer.create(<DisruptionIndexWithRouter />).root
 
@@ -132,5 +143,116 @@ describe("DisruptionIndex", () => {
     expect(wrapper.exists(DisruptionTable)).toBe(true)
     expect(wrapper.exists(DisruptionCalendar)).toBe(false)
     expect(toggleButton.text()).toEqual("calendar view")
+  })
+})
+
+describe("DisruptionIndexConnected", () => {
+  test.each([
+    [
+      [
+        new Disruption({
+          id: "1",
+          startDate: new Date("2020-01-15"),
+          endDate: new Date("2020-01-30"),
+          adjustments: [
+            new Adjustment({
+              id: "1",
+              routeId: "Green-D",
+              source: "gtfs_creator",
+              sourceLabel: "NewtonHighlandsKenmore",
+            }),
+          ],
+          daysOfWeek: [
+            new DayOfWeek({
+              id: "1",
+              startTime: "20:45:00",
+              day: "friday",
+            }),
+          ],
+          exceptions: [
+            new Exception({
+              id: "1",
+              excludedDate: new Date("2020-01-20"),
+            }),
+          ],
+          tripShortNames: [],
+        }),
+      ],
+      [
+        [
+          "NewtonHighlandsKenmore",
+          "1/15/2020 - 1/30/2020",
+          "Friday, 8:45PM - End of service",
+        ],
+      ],
+    ],
+    [
+      [
+        new Disruption({
+          id: "1",
+          startDate: new Date("2020-01-15"),
+          endDate: new Date("2020-01-30"),
+          adjustments: [
+            new Adjustment({
+              id: "1",
+              routeId: "Green-D",
+              source: "gtfs_creator",
+              sourceLabel: "NewtonHighlandsKenmore",
+            }),
+            new Adjustment({
+              id: "1",
+              routeId: "Red",
+              source: "gtfs_creator",
+              sourceLabel: "HarvardAlewife",
+            }),
+          ],
+          daysOfWeek: [
+            new DayOfWeek({
+              id: "1",
+              startTime: "20:45:00",
+              day: "saturday",
+            }),
+            new DayOfWeek({
+              id: "2",
+              day: "sunday",
+              endTime: "20:45:00",
+            }),
+          ],
+          exceptions: [
+            new Exception({
+              id: "1",
+              excludedDate: new Date("2020-01-20"),
+            }),
+          ],
+          tripShortNames: [],
+        }),
+      ],
+      [
+        [
+          "NewtonHighlandsKenmore, HarvardAlewife",
+          "1/15/2020 - 1/30/2020",
+          "Saturday 8:45PM - Sunday 8:45PM",
+        ],
+      ],
+    ],
+  ])(`Renders the table correctly`, async (disruptions, expected) => {
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
+      return Promise.resolve(disruptions)
+    })
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      ReactDOM.render(<DisruptionIndexWithRouter connected />, container)
+    })
+    const rows = container.querySelectorAll("tbody tr")
+    expect(rows.length).toEqual(disruptions.length)
+    rows.forEach((row, index) => {
+      const dataColumns = row.querySelectorAll("td")
+      expect(dataColumns[0].textContent).toEqual(expected[index][0])
+      expect(dataColumns[1].textContent).toEqual(expected[index][1])
+      expect(dataColumns[2].textContent).toEqual(expected[index][2])
+    })
   })
 })

--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -205,10 +205,16 @@ describe("DisruptionIndexConnected", () => {
               sourceLabel: "NewtonHighlandsKenmore",
             }),
             new Adjustment({
-              id: "1",
+              id: "2",
               routeId: "Red",
               source: "gtfs_creator",
               sourceLabel: "HarvardAlewife",
+            }),
+            new Adjustment({
+              id: "3",
+              routeId: "CR-Fairmount",
+              source: "arrow",
+              sourceLabel: "Fairmount--Newmarket",
             }),
           ],
           daysOfWeek: [
@@ -234,7 +240,7 @@ describe("DisruptionIndexConnected", () => {
       ],
       [
         [
-          "NewtonHighlandsKenmore, HarvardAlewife",
+          "NewtonHighlandsKenmore, HarvardAlewife, Fairmount--Newmarket",
           "1/15/2020 - 1/30/2020",
           "Saturday 8:45PM - Sunday 8:45PM",
         ],

--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -17,7 +17,11 @@ import * as api from "../../src/api"
 import ReactDOM from "react-dom"
 import { act } from "react-dom/test-utils"
 
-const DisruptionIndexWithRouter = ({ connected = false }) => {
+const DisruptionIndexWithRouter = ({
+  connected = false,
+}: {
+  connected?: boolean
+}) => {
   return (
     <BrowserRouter>
       {connected ? (
@@ -214,8 +218,8 @@ describe("DisruptionIndexConnected", () => {
             }),
             new DayOfWeek({
               id: "2",
-              day: "sunday",
               endTime: "20:45:00",
+              day: "sunday",
             }),
           ],
           exceptions: [

--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -2,11 +2,12 @@ import * as React from "react"
 import { BrowserRouter } from "react-router-dom"
 import { mount } from "enzyme"
 import * as renderer from "react-test-renderer"
-import DisruptionIndexConnected, {
-  DisruptionIndexView as DisruptionIndex,
+import {
+  DisruptionIndexView,
+  DisruptionIndex,
   RouteFilterToggle,
 } from "../../src/disruptions/disruptionIndex"
-import DisruptionTable from "../../src/disruptions/disruptionTable"
+import { DisruptionTable } from "../../src/disruptions/disruptionTable"
 import DisruptionCalendar from "../../src/disruptions/disruptionCalendar"
 import Header from "../../src/header"
 import Disruption from "../../src/models/disruption"
@@ -25,9 +26,9 @@ const DisruptionIndexWithRouter = ({
   return (
     <BrowserRouter>
       {connected ? (
-        <DisruptionIndexConnected />
+        <DisruptionIndex />
       ) : (
-        <DisruptionIndex
+        <DisruptionIndexView
           disruptions={[
             {
               id: "1",
@@ -238,6 +239,32 @@ describe("DisruptionIndexConnected", () => {
           "Saturday 8:45PM - Sunday 8:45PM",
         ],
       ],
+    ],
+    [
+      [
+        new Disruption({
+          id: "1",
+          startDate: new Date("2020-01-15"),
+          endDate: new Date("2020-01-30"),
+          adjustments: [
+            new Adjustment({
+              id: "1",
+              routeId: "Green-D",
+              source: "gtfs_creator",
+              sourceLabel: "NewtonHighlandsKenmore",
+            }),
+          ],
+          daysOfWeek: [],
+          exceptions: [
+            new Exception({
+              id: "1",
+              excludedDate: new Date("2020-01-20"),
+            }),
+          ],
+          tripShortNames: [],
+        }),
+      ],
+      [["NewtonHighlandsKenmore", "1/15/2020 - 1/30/2020", ""]],
     ],
   ])(`Renders the table correctly`, async (disruptions, expected) => {
     jest.spyOn(api, "apiGet").mockImplementationOnce(() => {

--- a/assets/tests/disruptions/disruptionTable.test.tsx
+++ b/assets/tests/disruptions/disruptionTable.test.tsx
@@ -14,7 +14,6 @@ const DisruptionTableWithRouter = () => {
           {
             id: "1",
             routes: ["Red"],
-            label: "AlewifeHarvard",
             startDate: new Date("2019-10-31"),
             endDate: new Date("2019-11-15"),
             daysAndTimes: "Weekends, starting Friday 845",
@@ -48,10 +47,10 @@ describe("DisruptionTable", () => {
     expect(tableRows.length).toEqual(3)
     let firstRow = tableRows.at(0)
     let firstRowData = firstRow.find("td")
-    expect(firstRowData.at(0).text()).toEqual("AlewifeHarvard")
-    expect(firstRowData.at(1).text()).toEqual("10/31/2019 - 11/15/2019")
+    expect(firstRowData.at(0).text()).toEqual("Kenmore—Newton Highlands")
+    expect(firstRowData.at(1).text()).toEqual("10/23/2019 - 10/24/2019")
     expect(firstRowData.at(2).text()).toEqual("Weekends, starting Friday 845")
-    expect(firstRowData.at(3).find("a[href='/disruptions/1']").length).toEqual(
+    expect(firstRowData.at(3).find("a[href='/disruptions/2']").length).toEqual(
       1
     )
     let activeSortToggle = wrapper
@@ -70,7 +69,7 @@ describe("DisruptionTable", () => {
       .find({ active: true })
     expect(activeSortToggle.text()).toEqual("stops")
     expect(activeSortToggle.props().sortOrder).toEqual("desc")
-    expect(firstRowData.at(0).text()).toEqual("Kenmore—Newton Highlands")
+    expect(firstRowData.at(0).text()).toEqual("")
 
     wrapper
       .find(".m-disruption-table__sortable[children='dates']")

--- a/assets/tests/disruptions/disruptionTable.test.tsx
+++ b/assets/tests/disruptions/disruptionTable.test.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
 import { BrowserRouter } from "react-router-dom"
 import { mount } from "enzyme"
-import DisruptionTable, {
+import {
+  DisruptionTable,
   DisruptionTableHeader,
 } from "../../src/disruptions/disruptionTable"
 

--- a/assets/tests/disruptions/time.test.ts
+++ b/assets/tests/disruptions/time.test.ts
@@ -128,7 +128,7 @@ describe("parseDaysAndTimes", () => {
       ],
       "Wednesday - Friday, 11:30AM - 8:45PM",
     ],
-    
+
     [
       [
         new DayOfWeek({ startTime: "20:45:00", day: "saturday" }),

--- a/assets/tests/disruptions/time.test.ts
+++ b/assets/tests/disruptions/time.test.ts
@@ -172,15 +172,15 @@ describe("parseDaysAndTimes", () => {
     ],
     [
       [
-        new DayOfWeek({ day: "friday", startTime: "09:00:00" }),
+        new DayOfWeek({ startTime: "09:00:00", day: "monday", }),
         new DayOfWeek({
           startTime: "11:30:00",
           endTime: "18:30:00",
-          day: "saturday",
+          day: "tuesday",
         }),
-        new DayOfWeek({ day: "sunday", endTime: "20:45:00" }),
+        new DayOfWeek({ day: "wednesday", endTime: "20:45:00" }),
       ],
-      "Friday, 9:00AM - End of service, Saturday, 11:30AM - 6:30PM, Sunday, Start of service - 8:45PM",
+      "Monday, 9:00AM - End of service, Tuesday, 11:30AM - 6:30PM, Wednesday, Start of service - 8:45PM",
     ],
   ])("parses days and times correctly", (daysOfWeek, expected) => {
     expect(parseDaysAndTimes(daysOfWeek)).toEqual(expected)

--- a/assets/tests/disruptions/time.test.ts
+++ b/assets/tests/disruptions/time.test.ts
@@ -3,6 +3,7 @@ import {
   fromDaysOfWeek,
   dayOfWeekTimeRangesToDayOfWeeks,
   DayOfWeekTimeRanges,
+  parseDaysAndTimes,
 } from "../../src/disruptions/time"
 
 describe("fromDaysOfWeek", () => {
@@ -91,5 +92,73 @@ describe("dayOfWeekTimeRangesToDayOfWeeks", () => {
       new DayOfWeek({ dayName: "saturday" }),
       new DayOfWeek({ dayName: "sunday" }),
     ])
+  })
+})
+
+describe("parseDaysAndTimes", () => {
+  test.each([
+    [
+      [new DayOfWeek({ day: "monday" })],
+      "Monday, Start of service - End of service",
+    ],
+    [
+      [
+        new DayOfWeek({ startTime: "09:30:00", day: "tuesday" }),
+        new DayOfWeek({ startTime: "09:30:00", day: "thursday" }),
+      ],
+      "Tuesday, 9:30AM - End of service, Thursday, 9:30AM - End of service",
+    ],
+    [
+      [
+        new DayOfWeek({
+          startTime: "11:30:00",
+          endTime: "20:45:00",
+          day: "wednesday",
+        }),
+        new DayOfWeek({
+          startTime: "11:30:00",
+          endTime: "20:45:00",
+          day: "thursday",
+        }),
+        new DayOfWeek({
+          startTime: "11:30:00",
+          endTime: "20:45:00",
+          day: "friday",
+        }),
+      ],
+      "Wednesday - Friday, 11:30AM - 8:45PM",
+    ],
+    [
+      [
+        new DayOfWeek({ startTime: "20:45:00", day: "saturday" }),
+        new DayOfWeek({ day: "sunday" }),
+      ],
+      "Saturday 8:45PM - Sunday End of service",
+    ],
+    [
+      [
+        new DayOfWeek({ startTime: "20:45:00", day: "saturday" }),
+        new DayOfWeek({ endTime: "20:45:00", day: "sunday" }),
+      ],
+      "Saturday 8:45PM - Sunday 8:45PM",
+    ],
+    [
+      [new DayOfWeek({ day: "saturday" }), new DayOfWeek({ day: "sunday" })],
+      "Saturday - Sunday, Start of service - End of service",
+    ],
+    [
+      [
+        new DayOfWeek({ day: "friday" }),
+        new DayOfWeek({
+          day: "saturday",
+          startTime: "11:30:00",
+          endTime: "20:45:00",
+        }),
+        new DayOfWeek({ day: "sunday" }),
+      ],
+      "Friday, Start of service - End of service, Saturday, 11:30AM - 8:45PM, Sunday, Start of service - End of service",
+    ],
+  ])("parses days and times correctly", (daysOfWeek, expected) => {
+    expect(parseDaysAndTimes(daysOfWeek)).toEqual(expected)
   })
 })

--- a/assets/tests/disruptions/time.test.ts
+++ b/assets/tests/disruptions/time.test.ts
@@ -98,13 +98,13 @@ describe("dayOfWeekTimeRangesToDayOfWeeks", () => {
 describe("parseDaysAndTimes", () => {
   test.each([
     [
-      [new DayOfWeek({ day: "monday" })],
+      [new DayOfWeek({ dayName: "monday" })],
       "Monday, Start of service - End of service",
     ],
     [
       [
-        new DayOfWeek({ startTime: "09:30:00", day: "tuesday" }),
-        new DayOfWeek({ startTime: "09:30:00", day: "thursday" }),
+        new DayOfWeek({ startTime: "09:30:00", dayName: "tuesday" }),
+        new DayOfWeek({ startTime: "09:30:00", dayName: "thursday" }),
       ],
       "Tuesday, 9:30AM - End of service, Thursday, 9:30AM - End of service",
     ],
@@ -113,17 +113,17 @@ describe("parseDaysAndTimes", () => {
         new DayOfWeek({
           startTime: "11:30:00",
           endTime: "20:45:00",
-          day: "wednesday",
+          dayName: "wednesday",
         }),
         new DayOfWeek({
           startTime: "11:30:00",
           endTime: "20:45:00",
-          day: "thursday",
+          dayName: "thursday",
         }),
         new DayOfWeek({
           startTime: "11:30:00",
           endTime: "20:45:00",
-          day: "friday",
+          dayName: "friday",
         }),
       ],
       "Wednesday - Friday, 11:30AM - 8:45PM",
@@ -131,54 +131,57 @@ describe("parseDaysAndTimes", () => {
 
     [
       [
-        new DayOfWeek({ startTime: "20:45:00", day: "saturday" }),
-        new DayOfWeek({ day: "sunday" }),
+        new DayOfWeek({ startTime: "20:45:00", dayName: "saturday" }),
+        new DayOfWeek({ dayName: "sunday" }),
       ],
       "Saturday 8:45PM - Sunday End of service",
     ],
     [
       [
-        new DayOfWeek({ startTime: "20:45:00", day: "saturday" }),
-        new DayOfWeek({ endTime: "20:45:00", day: "sunday" }),
+        new DayOfWeek({ startTime: "20:45:00", dayName: "saturday" }),
+        new DayOfWeek({ endTime: "20:45:00", dayName: "sunday" }),
       ],
       "Saturday 8:45PM - Sunday 8:45PM",
     ],
     [
-      [new DayOfWeek({ day: "saturday" }), new DayOfWeek({ day: "sunday" })],
+      [
+        new DayOfWeek({ dayName: "saturday" }),
+        new DayOfWeek({ dayName: "sunday" }),
+      ],
       "Saturday - Sunday, Start of service - End of service",
     ],
     [
       [
-        new DayOfWeek({ day: "friday" }),
+        new DayOfWeek({ dayName: "friday" }),
         new DayOfWeek({
           startTime: "11:30:00",
           endTime: "20:45:00",
-          day: "saturday",
+          dayName: "saturday",
         }),
-        new DayOfWeek({ day: "sunday" }),
+        new DayOfWeek({ dayName: "sunday" }),
       ],
       "Friday, Start of service - End of service, Saturday, 11:30AM - 8:45PM, Sunday, Start of service - End of service",
     ],
     [
       [
-        new DayOfWeek({ day: "friday" }),
+        new DayOfWeek({ dayName: "friday" }),
         new DayOfWeek({
           startTime: "00:30:00",
-          day: "saturday",
+          dayName: "saturday",
         }),
-        new DayOfWeek({ day: "sunday" }),
+        new DayOfWeek({ dayName: "sunday" }),
       ],
       "Friday, Start of service - End of service, Saturday, 12:30AM - End of service, Sunday, Start of service - End of service",
     ],
     [
       [
-        new DayOfWeek({ startTime: "09:00:00", day: "monday" }),
+        new DayOfWeek({ startTime: "09:00:00", dayName: "monday" }),
         new DayOfWeek({
           startTime: "11:30:00",
           endTime: "18:30:00",
-          day: "tuesday",
+          dayName: "tuesday",
         }),
-        new DayOfWeek({ endTime: "20:45:00", day: "wednesday" }),
+        new DayOfWeek({ endTime: "20:45:00", dayName: "wednesday" }),
       ],
       "Monday, 9:00AM - End of service, Tuesday, 11:30AM - 6:30PM, Wednesday, Start of service - 8:45PM",
     ],

--- a/assets/tests/disruptions/time.test.ts
+++ b/assets/tests/disruptions/time.test.ts
@@ -163,22 +163,22 @@ describe("parseDaysAndTimes", () => {
       [
         new DayOfWeek({ day: "friday" }),
         new DayOfWeek({
-          startTime: "11:30:00",
+          startTime: "00:30:00",
           day: "saturday",
         }),
         new DayOfWeek({ day: "sunday" }),
       ],
-      "Friday, Start of service - End of service, Saturday, 11:30AM - End of service, Sunday, Start of service - End of service",
+      "Friday, Start of service - End of service, Saturday, 12:30AM - End of service, Sunday, Start of service - End of service",
     ],
     [
       [
-        new DayOfWeek({ startTime: "09:00:00", day: "monday", }),
+        new DayOfWeek({ startTime: "09:00:00", day: "monday" }),
         new DayOfWeek({
           startTime: "11:30:00",
           endTime: "18:30:00",
           day: "tuesday",
         }),
-        new DayOfWeek({ day: "wednesday", endTime: "20:45:00" }),
+        new DayOfWeek({ endTime: "20:45:00", day: "wednesday" }),
       ],
       "Monday, 9:00AM - End of service, Tuesday, 11:30AM - 6:30PM, Wednesday, Start of service - 8:45PM",
     ],

--- a/assets/tests/disruptions/time.test.ts
+++ b/assets/tests/disruptions/time.test.ts
@@ -170,6 +170,18 @@ describe("parseDaysAndTimes", () => {
       ],
       "Friday, Start of service - End of service, Saturday, 11:30AM - End of service, Sunday, Start of service - End of service",
     ],
+    [
+      [
+        new DayOfWeek({ day: "friday", startTime: "09:00:00" }),
+        new DayOfWeek({
+          startTime: "11:30:00",
+          endTime: "18:30:00",
+          day: "saturday",
+        }),
+        new DayOfWeek({ day: "sunday", endTime: "20:45:00" }),
+      ],
+      "Friday, 9:00AM - End of service, Saturday, 11:30AM - 6:30PM, Sunday, Start of service - 8:45PM",
+    ],
   ])("parses days and times correctly", (daysOfWeek, expected) => {
     expect(parseDaysAndTimes(daysOfWeek)).toEqual(expected)
   })

--- a/assets/tests/disruptions/time.test.ts
+++ b/assets/tests/disruptions/time.test.ts
@@ -150,9 +150,9 @@ describe("parseDaysAndTimes", () => {
       [
         new DayOfWeek({ day: "friday" }),
         new DayOfWeek({
-          day: "saturday",
           startTime: "11:30:00",
           endTime: "20:45:00",
+          day: "saturday",
         }),
         new DayOfWeek({ day: "sunday" }),
       ],

--- a/assets/tests/disruptions/time.test.ts
+++ b/assets/tests/disruptions/time.test.ts
@@ -128,6 +128,7 @@ describe("parseDaysAndTimes", () => {
       ],
       "Wednesday - Friday, 11:30AM - 8:45PM",
     ],
+    
     [
       [
         new DayOfWeek({ startTime: "20:45:00", day: "saturday" }),
@@ -157,6 +158,17 @@ describe("parseDaysAndTimes", () => {
         new DayOfWeek({ day: "sunday" }),
       ],
       "Friday, Start of service - End of service, Saturday, 11:30AM - 8:45PM, Sunday, Start of service - End of service",
+    ],
+    [
+      [
+        new DayOfWeek({ day: "friday" }),
+        new DayOfWeek({
+          startTime: "11:30:00",
+          day: "saturday",
+        }),
+        new DayOfWeek({ day: "sunday" }),
+      ],
+      "Friday, Start of service - End of service, Saturday, 11:30AM - End of service, Sunday, Start of service - End of service",
     ],
   ])("parses days and times correctly", (daysOfWeek, expected) => {
     expect(parseDaysAndTimes(daysOfWeek)).toEqual(expected)

--- a/assets/tests/jsonApi.test.ts
+++ b/assets/tests/jsonApi.test.ts
@@ -235,6 +235,101 @@ describe("toModelObject", () => {
     ])
   })
 
+  test("properly assigns included objects when there are multiple entities", () => {
+    expect(
+      toModelObject({
+        data: [
+          {
+            attributes: {
+              end_date: "2020-01-12",
+              start_date: "2019-12-20",
+            },
+            id: "1",
+            relationships: {
+              adjustments: {
+                data: [{ id: "12", type: "adjustment" }],
+              },
+              days_of_week: { data: [] },
+              exceptions: { data: [] },
+              trip_short_names: { data: [] },
+            },
+            type: "disruption",
+          },
+          {
+            attributes: {
+              end_date: "2020-01-15",
+              start_date: "2019-12-25",
+            },
+            id: "2",
+            relationships: {
+              adjustments: {
+                data: [{ id: "13", type: "adjustment" }],
+              },
+              days_of_week: { data: [] },
+              exceptions: { data: [] },
+              trip_short_names: { data: [] },
+            },
+            type: "disruption",
+          },
+        ],
+        included: [
+          {
+            attributes: {
+              route_id: "Green-D",
+              source: "gtfs_creator",
+              source_label: "KenmoreReservoir",
+            },
+            id: "12",
+            type: "adjustment",
+          },
+          {
+            attributes: {
+              route_id: "Green-D",
+              source: "gtfs_creator",
+              source_label: "Kenmore-Newton",
+            },
+            id: "13",
+            type: "adjustment",
+          },
+        ],
+        jsonapi: { version: "1.0" },
+      })
+    ).toEqual([
+      new Disruption({
+        id: "1",
+        startDate: new Date("2019-12-20"),
+        endDate: new Date("2020-01-12"),
+        adjustments: [
+          new Adjustment({
+            id: "12",
+            routeId: "Green-D",
+            source: "gtfs_creator",
+            sourceLabel: "KenmoreReservoir",
+          }),
+        ],
+        daysOfWeek: [],
+        exceptions: [],
+        tripShortNames: [],
+      }),
+      new Disruption({
+        id: "2",
+        startDate: new Date("2019-12-25"),
+        endDate: new Date("2020-01-15"),
+        adjustments: [
+          new Adjustment({
+            id: "13",
+            routeId: "Green-D",
+            source: "gtfs_creator",
+            sourceLabel: "Kenmore-Newton",
+          }),
+        ],
+        daysOfWeek: [],
+        exceptions: [],
+        tripShortNames: [],
+      }),
+    ])
+  })
+
   test("returns error when one of multiple objects fails to parse", () => {
     expect(
       toModelObject({

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -32,98 +32,100 @@ adjustments =
 
 Repo.insert_all(Adjustment, adjustments, on_conflict: :nothing)
 
-for attrs <- [
-      %{
-        start_date: ~D[2019-12-20],
-        end_date: ~D[2020-01-12],
-        adjustments: [Repo.get_by!(Adjustment, source_label: "KenmoreReservoir")],
-        exceptions: [~D[2019-12-29]],
-        days_of_week: [
-          %{day_name: "friday", start_time: ~T[20:45:00]},
-          %{day_name: "saturday"},
-          %{day_name: "sunday"}
-        ]
-      },
-      %{
-        start_date: ~D[2020-01-06],
-        end_date: ~D[2020-01-17],
-        adjustments: [Repo.get_by!(Adjustment, source_label: "KenmoreReservoir")],
-        days_of_week: [
-          %{day_name: "monday", start_time: ~T[20:45:00]},
-          %{day_name: "tuesday", start_time: ~T[20:45:00]},
-          %{day_name: "wednesday", start_time: ~T[20:45:00]},
-          %{day_name: "thursday", start_time: ~T[20:45:00]},
-          %{day_name: "friday", start_time: ~T[20:45:00]}
-        ]
-      },
-      %{
-        start_date: ~D[2020-01-11],
-        end_date: ~D[2020-02-09],
-        adjustments: [Repo.get_by!(Adjustment, source_label: "AlewifeHarvard")],
-        days_of_week: [
-          %{day_name: "saturday"},
-          %{day_name: "sunday"}
-        ]
-      },
-      %{
-        start_date: ~D[2019-12-11],
-        end_date: ~D[2020-03-29],
-        adjustments: [Repo.get_by!(Adjustment, source_label: "ForgeParkReadville")],
-        exceptions: [
-          ~D[2019-12-28],
-          ~D[2019-12-29],
-          ~D[2020-01-04],
-          ~D[2020-01-05]
-        ],
-        trip_short_names: [
-          "1702",
-          "1704",
-          "1706",
-          "1708",
-          "1710",
-          "1712",
-          "1714",
-          "2706",
-          "2708",
-          "2710",
-          "2712",
-          "2714",
-          "1703",
-          "1705",
-          "1707",
-          "1709",
-          "1711",
-          "1713",
-          "1715",
-          "1717",
-          "2707",
-          "2709",
-          "2711",
-          "2713",
-          "2715",
-          "2717"
-        ],
-        days_of_week: [
-          %{day_name: "saturday"},
-          %{day_name: "sunday"}
-        ]
-      },
-      %{
-        start_date: ~D[2019-12-11],
-        end_date: ~D[2020-03-29],
-        adjustments: [Repo.get_by!(Adjustment, source_label: "ForgeParkSouthStation")],
-        exceptions: [
-          ~D[2019-12-28],
-          ~D[2019-12-29],
-          ~D[2020-01-04],
-          ~D[2020-01-05]
-        ],
-        trip_short_names: ["1716", "1718", "1719", "2716", "2718", "2719"],
-        days_of_week: [
-          %{day_name: "saturday"},
-          %{day_name: "sunday"}
-        ]
-      }
+for {attrs, adjustments} <- [
+      {%{
+         "exceptions" => [%{excluded_date: ~D[2019-12-29]}],
+         "days_of_week" => [
+           %{day_name: "friday", start_time: ~T[20:45:00]},
+           %{day_name: "saturday"},
+           %{day_name: "sunday"}
+         ],
+         "start_date" => ~D[2019-12-20],
+         "end_date" => ~D[2020-01-12]
+       }, [Repo.get_by!(Adjustment, source_label: "KenmoreReservoir")]},
+      {%{
+         "days_of_week" => [
+           %{day_name: "monday", start_time: ~T[20:45:00]},
+           %{day_name: "tuesday", start_time: ~T[20:45:00]},
+           %{day_name: "wednesday", start_time: ~T[20:45:00]},
+           %{day_name: "thursday", start_time: ~T[20:45:00]},
+           %{day_name: "friday", start_time: ~T[20:45:00]}
+         ],
+         "start_date" => ~D[2020-01-06],
+         "end_date" => ~D[2020-01-17]
+       }, [Repo.get_by!(Adjustment, source_label: "KenmoreReservoir")]},
+      {%{
+         "days_of_week" => [
+           %{day_name: "saturday"},
+           %{day_name: "sunday"}
+         ],
+         "start_date" => ~D[2020-01-11],
+         "end_date" => ~D[2020-02-09]
+       }, [Repo.get_by!(Adjustment, source_label: "AlewifeHarvard")]},
+      {%{
+         "exceptions" => [
+           %{excluded_date: ~D[2019-12-28]},
+           %{excluded_date: ~D[2019-12-29]},
+           %{excluded_date: ~D[2020-01-04]},
+           %{excluded_date: ~D[2020-01-05]}
+         ],
+         "trip_short_names" => [
+           %{trip_short_name: "1702"},
+           %{trip_short_name: "1704"},
+           %{trip_short_name: "1706"},
+           %{trip_short_name: "1708"},
+           %{trip_short_name: "1710"},
+           %{trip_short_name: "1712"},
+           %{trip_short_name: "1714"},
+           %{trip_short_name: "2706"},
+           %{trip_short_name: "2708"},
+           %{trip_short_name: "2710"},
+           %{trip_short_name: "2712"},
+           %{trip_short_name: "2714"},
+           %{trip_short_name: "1703"},
+           %{trip_short_name: "1705"},
+           %{trip_short_name: "1707"},
+           %{trip_short_name: "1709"},
+           %{trip_short_name: "1711"},
+           %{trip_short_name: "1713"},
+           %{trip_short_name: "1715"},
+           %{trip_short_name: "1717"},
+           %{trip_short_name: "2707"},
+           %{trip_short_name: "2709"},
+           %{trip_short_name: "2711"},
+           %{trip_short_name: "2713"},
+           %{trip_short_name: "2715"},
+           %{trip_short_name: "2717"}
+         ],
+         "days_of_week" => [
+           %{day_name: "saturday"},
+           %{day_name: "sunday"}
+         ],
+         "start_date" => ~D[2019-12-11],
+         "end_date" => ~D[2020-03-29]
+       }, [Repo.get_by!(Adjustment, source_label: "ForgeParkReadville")]},
+      {%{
+         "exceptions" => [
+           %{excluded_date: ~D[2019-12-28]},
+           %{excluded_date: ~D[2019-12-29]},
+           %{excluded_date: ~D[2020-01-04]},
+           %{excluded_date: ~D[2020-01-05]}
+         ],
+         "trip_short_names" => [
+           %{trip_short_name: "1716"},
+           %{trip_short_name: "1718"},
+           %{trip_short_name: "1719"},
+           %{trip_short_name: "2716"},
+           %{trip_short_name: "2718"},
+           %{trip_short_name: "2719"}
+         ],
+         "days_of_week" => [
+           %{day_name: "saturday"},
+           %{day_name: "sunday"}
+         ],
+         "start_date" => ~D[2019-12-11],
+         "end_date" => ~D[2020-03-29]
+       }, [Repo.get_by!(Adjustment, source_label: "ForgeParkSouthStation")]}
     ] do
-  Repo.insert!(Disruption.changeset(%Disruption{}, attrs))
+  Repo.insert!(Disruption.changeset(%Disruption{}, attrs, adjustments))
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Arrow frontend uses API to load disruptions for index page](https://app.asana.com/0/584764604969369/1165773329683249/f)

Changes:
* add function `parseDaysAndTimes` in `/disruptions/time.ts`
  * if single day, render `"{day}, {start_time} - {end_time}
  * else if days are consecutive and all times are the same, render `"{first_day} - {last_day}, {start_time - end_time}"
  * else if days are consecutive and all times are `undefined` besides the first day's `startTime` and/or the last day's `endTime`, render `"{first_day}, {start_time} - {last_day}, {end_time}`
* add component `DisruptionIndexConnected` responsible for fetching disruptions and parsing them into format expected by `DisruptionIndexView`
* update `toModelObject` to make sure we are only attaching an entity's related included objects rather than all
* updated the database seeder file to handle recent changes to the `Disruption` changeset

<img width="1142" alt="Screen Shot 2020-04-09 at 11 19 21 AM" src="https://user-images.githubusercontent.com/18427346/78911334-2c761880-7a54-11ea-9709-daeb7fc2c449.png">


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
