### PR TITLE
fix: Frontend sends `day_name` like backend expects

### DIFF
--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -119,8 +119,8 @@ const fromDaysOfWeek = (
   let invalidTimeFound = false
 
   daysOfWeek.forEach(dayOfWeek => {
-    if (dayOfWeek.day) {
-      const index = dayNamesToIndices[dayOfWeek.day]
+    if (dayOfWeek.dayName) {
+      const index = dayNamesToIndices[dayOfWeek.dayName]
       const startTime = timeStringToTime(dayOfWeek.startTime)
       const endTime = timeStringToTime(dayOfWeek.endTime)
 
@@ -197,7 +197,7 @@ const dayOfWeekTimeRangesToDayOfWeeks = (
       const dayName = ixToDayName(ix)
       const [startTime, endTime] = dow
       const dayOfWeek = new DayOfWeek({
-        ...(dayName !== null && { day: dayName }),
+        ...(dayName !== null && { dayName }),
         ...(startTime !== null && { startTime: timeToString(startTime) }),
         ...(endTime !== null && { endTime: timeToString(endTime) }),
       })

--- a/assets/src/models/dayOfWeek.ts
+++ b/assets/src/models/dayOfWeek.ts
@@ -14,24 +14,24 @@ class DayOfWeek extends JsonApiResourceObject {
   id?: string
   startTime?: string
   endTime?: string
-  day?: DayName
+  dayName?: DayName
 
   constructor({
     id,
     startTime,
     endTime,
-    day,
+    dayName,
   }: {
     id?: string
     startTime?: string
     endTime?: string
-    day?: DayName
+    dayName?: DayName
   }) {
     super()
     this.id = id
     this.startTime = startTime
     this.endTime = endTime
-    this.day = day
+    this.dayName = dayName
   }
 
   toJsonApi(): JsonApiResource {
@@ -47,14 +47,14 @@ class DayOfWeek extends JsonApiResourceObject {
       attributes: {
         ...(this.startTime && { start_time: this.startTime }),
         ...(this.endTime && { end_time: this.endTime }),
-        ...(this.day && { day: this.day }),
+        ...(this.dayName && { day_name: this.dayName }),
       },
     }
   }
 
   static fromJsonObject(raw: any): DayOfWeek | "error" {
     if (typeof raw.attributes === "object") {
-      let day: DayName | undefined
+      let dayName: DayName | undefined
 
       if (
         [
@@ -67,7 +67,7 @@ class DayOfWeek extends JsonApiResourceObject {
           "sunday",
         ].includes(raw.attributes.day_name)
       ) {
-        day = raw.attributes.day_name
+        dayName = raw.attributes.day_name
       } else {
         return "error"
       }
@@ -78,7 +78,7 @@ class DayOfWeek extends JsonApiResourceObject {
           startTime: raw.attributes.start_time,
         }),
         ...(raw.attributes.end_time && { endTime: raw.attributes.end_time }),
-        day,
+        dayName,
       })
     }
 

--- a/assets/tests/disruptions/time.test.ts
+++ b/assets/tests/disruptions/time.test.ts
@@ -9,14 +9,14 @@ describe("fromDaysOfWeek", () => {
   test("successful conversion", () => {
     expect(
       fromDaysOfWeek([
-        new DayOfWeek({ day: "monday" }),
-        new DayOfWeek({ startTime: "11:30:00", day: "tuesday" }),
+        new DayOfWeek({ dayName: "monday" }),
+        new DayOfWeek({ startTime: "11:30:00", dayName: "tuesday" }),
         new DayOfWeek({
           startTime: "11:30:00",
           endTime: "20:45:00",
-          day: "wednesday",
+          dayName: "wednesday",
         }),
-        new DayOfWeek({ endTime: "20:45:00", day: "thursday" }),
+        new DayOfWeek({ endTime: "20:45:00", dayName: "thursday" }),
       ])
     ).toEqual([
       [null, null],
@@ -35,14 +35,14 @@ describe("fromDaysOfWeek", () => {
   test("invalid hours or minutes specified", () => {
     expect(
       fromDaysOfWeek([
-        new DayOfWeek({ day: "monday" }),
-        new DayOfWeek({ startTime: "11:37:00", day: "tuesday" }),
+        new DayOfWeek({ dayName: "monday" }),
+        new DayOfWeek({ startTime: "11:37:00", dayName: "tuesday" }),
         new DayOfWeek({
           startTime: "11:30:00",
           endTime: "20:45:00",
-          day: "wednesday",
+          dayName: "wednesday",
         }),
-        new DayOfWeek({ endTime: "20:45:00", day: "thursday" }),
+        new DayOfWeek({ endTime: "20:45:00", dayName: "thursday" }),
       ])
     ).toEqual("error")
   })
@@ -50,14 +50,14 @@ describe("fromDaysOfWeek", () => {
   test("invalid time format", () => {
     expect(
       fromDaysOfWeek([
-        new DayOfWeek({ day: "monday" }),
-        new DayOfWeek({ startTime: "foo", day: "tuesday" }),
+        new DayOfWeek({ dayName: "monday" }),
+        new DayOfWeek({ startTime: "foo", dayName: "tuesday" }),
         new DayOfWeek({
           startTime: "11:30:00",
           endTime: "20:45:00",
-          day: "wednesday",
+          dayName: "wednesday",
         }),
-        new DayOfWeek({ endTime: "20:45:00", day: "thursday" }),
+        new DayOfWeek({ endTime: "20:45:00", dayName: "thursday" }),
       ])
     ).toEqual("error")
   })
@@ -79,17 +79,17 @@ describe("dayOfWeekTimeRangesToDayOfWeeks", () => {
     ]
 
     expect(dayOfWeekTimeRangesToDayOfWeeks(dayOfWeekTimeRanges)).toEqual([
-      new DayOfWeek({ day: "monday" }),
-      new DayOfWeek({ startTime: "09:30:00", day: "tuesday" }),
+      new DayOfWeek({ dayName: "monday" }),
+      new DayOfWeek({ startTime: "09:30:00", dayName: "tuesday" }),
       new DayOfWeek({
         startTime: "11:30:00",
         endTime: "20:45:00",
-        day: "wednesday",
+        dayName: "wednesday",
       }),
-      new DayOfWeek({ endTime: "20:45:00", day: "thursday" }),
-      new DayOfWeek({ endTime: "00:00:00", day: "friday" }),
-      new DayOfWeek({ day: "saturday" }),
-      new DayOfWeek({ day: "sunday" }),
+      new DayOfWeek({ endTime: "20:45:00", dayName: "thursday" }),
+      new DayOfWeek({ endTime: "00:00:00", dayName: "friday" }),
+      new DayOfWeek({ dayName: "saturday" }),
+      new DayOfWeek({ dayName: "sunday" }),
     ])
   })
 })

--- a/assets/tests/disruptions/viewDisruption.test.tsx
+++ b/assets/tests/disruptions/viewDisruption.test.tsx
@@ -31,7 +31,7 @@ describe("ViewDisruption", () => {
             new DayOfWeek({
               id: "1",
               startTime: "20:45:00",
-              day: "friday",
+              dayName: "friday",
             }),
           ],
           exceptions: [
@@ -198,7 +198,7 @@ describe("ViewDisruption", () => {
             new DayOfWeek({
               id: "1",
               startTime: "20:37:00",
-              day: "friday",
+              dayName: "friday",
             }),
           ],
           exceptions: [

--- a/assets/tests/jsonApi.test.ts
+++ b/assets/tests/jsonApi.test.ts
@@ -66,7 +66,7 @@ describe("toModelObject", () => {
       new DayOfWeek({
         id: "1",
         startTime: "20:45:00",
-        day: "friday",
+        dayName: "friday",
       })
     )
   })

--- a/assets/tests/models/dayOfWeek.test.ts
+++ b/assets/tests/models/dayOfWeek.test.ts
@@ -6,7 +6,7 @@ describe("DayOfWeek", () => {
       id: "5",
       startTime: "10:00:00",
       endTime: "15:00:00",
-      day: "monday",
+      dayName: "monday",
     })
 
     expect(dow.toJsonApi()).toEqual({
@@ -16,7 +16,7 @@ describe("DayOfWeek", () => {
         attributes: {
           start_time: "10:00:00",
           end_time: "15:00:00",
-          day: "monday",
+          day_name: "monday",
         },
       },
     })
@@ -31,7 +31,7 @@ describe("DayOfWeek", () => {
           day_name: "monday",
         },
       })
-    ).toEqual(new DayOfWeek({ startTime: "20:45:00", day: "monday" }))
+    ).toEqual(new DayOfWeek({ startTime: "20:45:00", dayName: "monday" }))
   })
 
   test("fromJsonObject error with invalid day of week", () => {

--- a/assets/tests/models/disruption.test.ts
+++ b/assets/tests/models/disruption.test.ts
@@ -54,7 +54,7 @@ describe("Disruption", () => {
           new DayOfWeek({
             id: "1",
             startTime: "20:45:00",
-            day: "friday",
+            dayName: "friday",
           }),
         ]
       )
@@ -68,7 +68,7 @@ describe("Disruption", () => {
           new DayOfWeek({
             id: "1",
             startTime: "20:45:00",
-            day: "friday",
+            dayName: "friday",
           }),
         ],
         exceptions: [],


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** none

The "New Disruption" form was failing to create a disruption because it was sending `day: "tuesday"` over the wire, while the backend was expecting `day_name: "tuesday"`, consistent with the DB column. Rather than just changing the JSON serialization, I updated the model to have a `dayName` field, so it's referred to by the same term throughout the codebase.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
