### PR TITLE
feat: load disruption to front-end of edit page

### DIFF
--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -13,7 +13,7 @@ import { DisruptionTable } from "./disruptionTable"
 import DisruptionCalendar from "./disruptionCalendar"
 import Disruption from "../models/disruption"
 import { apiGet } from "../api"
-import { ModelObject, toModelObject } from "../jsonApi"
+import { JsonApiResponse, toModelObject } from "../jsonApi"
 import { parseDaysAndTimes } from "../disruptions/time"
 
 type Routes =
@@ -251,11 +251,11 @@ const DisruptionIndex = () => {
   }, [disruptions])
 
   React.useEffect(() => {
-    apiGet<ModelObject | ModelObject[] | "error">({
+    apiGet<JsonApiResponse>({
       url: "/api/disruptions",
       parser: toModelObject,
       defaultResult: "error",
-    }).then((result: ModelObject | ModelObject[] | "error") => {
+    }).then((result: JsonApiResponse) => {
       if (
         Array.isArray(result) &&
         result.every(res => res instanceof Disruption)

--- a/assets/src/disruptions/editDisruption.tsx
+++ b/assets/src/disruptions/editDisruption.tsx
@@ -21,7 +21,7 @@ import { DisruptionTimePicker } from "./disruptionTimePicker"
 import Adjustment from "../models/adjustment"
 import Disruption from "../models/disruption"
 import Exception from "../models/exception"
-import { ModelObject, toModelObject } from "../jsonApi"
+import { JsonApiResponse, toModelObject } from "../jsonApi"
 import DayOfWeek from "../models/dayOfWeek"
 
 interface TParams {
@@ -65,11 +65,11 @@ const EditDisruption = ({
   >(null)
 
   React.useEffect(() => {
-    apiGet<ModelObject | ModelObject[] | "error">({
+    apiGet<JsonApiResponse>({
       url: "/api/disruptions/" + encodeURIComponent(match.params.id),
       parser: toModelObject,
       defaultResult: "error",
-    }).then((result: ModelObject | ModelObject[] | "error") => {
+    }).then((result: JsonApiResponse) => {
       if (result instanceof Disruption) {
         setDisruption(result)
       } else {

--- a/assets/src/disruptions/newDisruption.tsx
+++ b/assets/src/disruptions/newDisruption.tsx
@@ -7,7 +7,7 @@ import Form from "react-bootstrap/Form"
 import Alert from "react-bootstrap/Alert"
 
 import { apiGet, apiPost } from "../api"
-import { toModelObject, ModelObject, parseErrors } from "../jsonApi"
+import { toModelObject, JsonApiResponse, parseErrors } from "../jsonApi"
 import Disruption from "../models/disruption"
 import Adjustment from "../models/adjustment"
 import Exception from "../models/exception"
@@ -283,11 +283,11 @@ const NewDisruption = ({}): JSX.Element => {
   }
 
   React.useEffect(() => {
-    apiGet<ModelObject | ModelObject[] | "error">({
+    apiGet<JsonApiResponse>({
       url: "/api/adjustments",
       parser: toModelObject,
       defaultResult: "error",
-    }).then((result: ModelObject | ModelObject[] | "error") => {
+    }).then((result: JsonApiResponse) => {
       if (
         Array.isArray(result) &&
         result.every(res => res instanceof Adjustment)

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -334,6 +334,8 @@ export {
   TimeRange,
   DayOfWeekTimeRanges,
   fromDaysOfWeek,
+  timeToString,
+  ixToDayName,
   isEmpty,
   dayOfWeekTimeRangesToDayOfWeeks,
   parseDaysAndTimes,

--- a/assets/src/disruptions/viewDisruption.tsx
+++ b/assets/src/disruptions/viewDisruption.tsx
@@ -9,7 +9,7 @@ import { DisruptionPreview } from "./disruptionPreview"
 import { fromDaysOfWeek } from "./time"
 
 import Disruption from "../models/disruption"
-import { ModelObject, toModelObject } from "../jsonApi"
+import { JsonApiResponse, toModelObject } from "../jsonApi"
 
 interface TParams {
   id: string
@@ -51,11 +51,11 @@ const ViewDisruptionForm = ({
   >(null)
 
   React.useEffect(() => {
-    apiGet<ModelObject | ModelObject[] | "error">({
+    apiGet<JsonApiResponse>({
       url: "/api/disruptions/" + encodeURIComponent(disruptionId),
       parser: toModelObject,
       defaultResult: "error",
-    }).then((result: ModelObject | ModelObject[] | "error") => {
+    }).then((result: JsonApiResponse) => {
       if (result instanceof Disruption) {
         setDisruption(result)
       } else {

--- a/assets/src/jsonApi.ts
+++ b/assets/src/jsonApi.ts
@@ -11,9 +11,9 @@ type ModelObject =
   | Exception
   | TripShortName
 
-const toModelObject = (
-  response: any
-): ModelObject | ModelObject[] | "error" => {
+type JsonApiResponse = ModelObject | ModelObject[] | "error"
+
+const toModelObject = (response: any): JsonApiResponse => {
   const includedObjects: {
     [key: string]: ModelObject | "error"
   } = Array.isArray(response?.included)
@@ -111,4 +111,4 @@ const modelFromJsonApiResource = (
   return "error"
 }
 
-export { ModelObject, toModelObject, parseErrors }
+export { ModelObject, JsonApiResponse, toModelObject, parseErrors }

--- a/assets/src/models/disruption.ts
+++ b/assets/src/models/disruption.ts
@@ -80,8 +80,12 @@ class Disruption extends JsonApiResourceObject {
     if (typeof raw.attributes === "object") {
       return new Disruption({
         id: raw.id,
-        startDate: new Date(raw.attributes.start_date),
-        endDate: new Date(raw.attributes.end_date),
+        ...(raw.attributes.start_date && {
+          startDate: new Date(raw.attributes.start_date + "T00:00:00"),
+        }),
+        ...(raw.attributes.end_date && {
+          endDate: new Date(raw.attributes.end_date + "T00:00:00"),
+        }),
         adjustments: included.filter(i => i instanceof Adjustment),
         daysOfWeek: included.filter(i => i instanceof DayOfWeek),
         exceptions: included.filter(i => i instanceof Exception),

--- a/assets/src/models/exception.ts
+++ b/assets/src/models/exception.ts
@@ -33,7 +33,9 @@ class Exception extends JsonApiResourceObject {
     if (typeof raw.attributes === "object") {
       return new Exception({
         id: raw.id,
-        excludedDate: new Date(raw.attributes.excluded_date),
+        ...(raw.attributes.excluded_date && {
+          excludedDate: new Date(raw.attributes.excluded_date + "T00:00:00"),
+        }),
       })
     }
 

--- a/assets/tests/disruptions/editDisruption.test.tsx
+++ b/assets/tests/disruptions/editDisruption.test.tsx
@@ -1,92 +1,439 @@
-import { createBrowserHistory } from "history"
-import { mount } from "enzyme"
 import * as React from "react"
-import { Redirect } from "react-router"
-import { BrowserRouter } from "react-router-dom"
-import * as renderer from "react-test-renderer"
+import { MemoryRouter, Route, Switch } from "react-router-dom"
+import { render, fireEvent, screen } from "@testing-library/react"
+import { waitForElementToBeRemoved } from "@testing-library/dom"
 
+import * as api from "../../src/api"
 import EditDisruption from "../../src/disruptions/editDisruption"
-import Header from "../../src/header"
 
-describe("NewDisruption", () => {
-  test("header include link to homepage", () => {
-    const history = createBrowserHistory()
-    const testInstance = renderer.create(
-      <EditDisruption
-        match={{
-          params: { id: "foo" },
-          isExact: true,
-          path: "/disruptions/foo/edit",
-          url: "https://localhost/disruptions/foo/edit",
-        }}
-        history={history}
-        location={{
-          pathname: "/disruptions/foo/edit",
-          search: "",
-          state: {},
-          hash: "",
-        }}
-      />
-    ).root
+import Adjustment from "../../src/models/adjustment"
+import DayOfWeek from "../../src/models/dayOfWeek"
+import Disruption from "../../src/models/disruption"
+import Exception from "../../src/models/exception"
 
-    expect(testInstance.findByType(Header).props.includeHomeLink).toBe(true)
+describe("EditDisruption", () => {
+  let apiCallSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    apiCallSpy = jest.spyOn(api, "apiGet").mockImplementation(() => {
+      return Promise.resolve(
+        new Disruption({
+          id: "1",
+          startDate: new Date("2020-01-15T00:00:00"),
+          endDate: new Date("2020-01-30T00:00:00"),
+          adjustments: [
+            new Adjustment({
+              id: "1",
+              routeId: "Green-D",
+              source: "gtfs_creator",
+              sourceLabel: "NewtonHighlandsKenmore",
+            }),
+          ],
+          daysOfWeek: [
+            new DayOfWeek({
+              id: "1",
+              startTime: "20:45:00",
+              dayName: "friday",
+            }),
+          ],
+          exceptions: [
+            new Exception({
+              id: "1",
+              excludedDate: new Date("2020-01-20T00:00:00"),
+            }),
+          ],
+          tripShortNames: [],
+        })
+      )
+    })
   })
 
-  test("save link previews disruption", () => {
-    const history = createBrowserHistory()
-    const wrapper = mount(
-      <EditDisruption
-        match={{
-          params: { id: "foo" },
-          isExact: true,
-          path: "/disruptions/foo/edit",
-          url: "https://localhost/disruptions/foo/edit",
-        }}
-        history={history}
-        location={{
-          pathname: "/disruptions/foo/edit",
-          search: "",
-          state: {},
-          hash: "",
-        }}
-      />
-    )
-
-    wrapper
-      .find("#save-changes-button")
-      .find("button")
-      .simulate("click")
-
-    expect(wrapper.exists("DisruptionPreview")).toBe(true)
+  afterAll(() => {
+    apiCallSpy.mockRestore()
   })
 
-  test("cancel link redirects back to view page", () => {
-    const history = createBrowserHistory()
-    const wrapper = mount(
-      <BrowserRouter>
-        <EditDisruption
-          match={{
-            params: { id: "foo" },
-            isExact: true,
-            path: "/disruptions/foo/edit",
-            url: "https://localhost/disruptions/foo/edit",
-          }}
-          history={history}
-          location={{
-            pathname: "/disruptions/foo/edit",
-            search: "",
-            state: {},
-            hash: "",
-          }}
-        />
-      </BrowserRouter>
+  test("header include link to homepage", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/foo/edit"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/edit"
+            component={EditDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
     )
 
-    wrapper
-      .find("#cancel-button")
-      .find("button")
-      .simulate("click")
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
 
-    expect(wrapper.exists(Redirect)).toBe(true)
+    expect(container.querySelector("#header-home-link")).not.toBeNull()
+  })
+
+  test("save link previews disruption", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/foo/edit"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/edit"
+            component={EditDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    const saveButton = container.querySelector("#save-changes-button")
+
+    if (saveButton) {
+      fireEvent.click(saveButton)
+    } else {
+      throw new Error("save button not found")
+    }
+
+    expect(screen.getByText("When")).not.toBeNull()
+  })
+
+  test("cancel link redirects back to view page", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/foo/edit"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id"
+            render={() => <div>Success!!!</div>}
+          />
+          <Route
+            exact={true}
+            path="/disruptions/:id/edit"
+            component={EditDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    const cancelButton = container.querySelector("#cancel-button")
+
+    if (cancelButton) {
+      fireEvent.click(cancelButton)
+    } else {
+      throw new Error("cancel button not found")
+    }
+
+    expect(screen.getByText("Success!!!")).not.toBeNull()
+  })
+
+  test("handles error fetching disruption", async () => {
+    apiCallSpy = jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
+      return Promise.resolve("error")
+    })
+
+    render(
+      <MemoryRouter initialEntries={["/disruptions/foo/edit"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/edit"
+            component={EditDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    expect(screen.getByText("Error loading disruption.")).not.toBeNull()
+  })
+
+  test("handles error with day of week information", async () => {
+    apiCallSpy = jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
+      return Promise.resolve(
+        new Disruption({
+          adjustments: [],
+          daysOfWeek: [
+            new DayOfWeek({
+              startTime: "20:37:00",
+              dayName: "friday",
+            }),
+          ],
+          exceptions: [],
+          tripShortNames: [],
+        })
+      )
+    })
+
+    render(
+      <MemoryRouter initialEntries={["/disruptions/foo/edit"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/edit"
+            component={EditDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    expect(
+      screen.queryByText("Error parsing day of week information.")
+    ).not.toBeNull()
+  })
+
+  test("update start date", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/foo/edit"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/edit"
+            component={EditDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    const startDateInput = container.querySelector(
+      "#disruption-date-range-start"
+    )
+
+    if (startDateInput) {
+      fireEvent.change(startDateInput, { target: { value: "01/14/2020" } })
+    } else {
+      throw new Error("disruption date range start input not found")
+    }
+
+    expect(screen.queryByDisplayValue("01/14/2020")).not.toBeNull()
+  })
+
+  test("clear start date", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/foo/edit"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/edit"
+            component={EditDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    const startDateInput = container.querySelector(
+      "#disruption-date-range-start"
+    )
+
+    if (startDateInput) {
+      fireEvent.change(startDateInput, { target: { value: "" } })
+    } else {
+      throw new Error("disruption date range start input not found")
+    }
+
+    expect((startDateInput as HTMLInputElement).value).toEqual("")
+  })
+
+  test("update end date", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/foo/edit"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/edit"
+            component={EditDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    const startDateInput = container.querySelector("#disruption-date-range-end")
+
+    if (startDateInput) {
+      fireEvent.change(startDateInput, { target: { value: "01/19/2020" } })
+    } else {
+      throw new Error("disruption date range end input not found")
+    }
+
+    expect(screen.queryByDisplayValue("01/19/2020")).not.toBeNull()
+  })
+
+  test("clear end date", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/foo/edit"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/edit"
+            component={EditDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    const endDateInput = container.querySelector("#disruption-date-range-end")
+
+    if (endDateInput) {
+      fireEvent.change(endDateInput, { target: { value: "" } })
+    } else {
+      throw new Error("disruption date range start input not found")
+    }
+
+    expect((endDateInput as HTMLInputElement).value).toEqual("")
+  })
+
+  test("adding exception date", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/foo/edit"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/edit"
+            component={EditDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    const addExceptionLink = container.querySelector("#date-exception-add-link")
+
+    if (addExceptionLink) {
+      fireEvent.click(addExceptionLink)
+    } else {
+      throw new Error("add exception link not found")
+    }
+
+    const exceptionDateInput = container.querySelector(
+      "#date-exception-new input"
+    )
+
+    if (exceptionDateInput) {
+      fireEvent.change(exceptionDateInput, { target: { value: "01/21/2020" } })
+    } else {
+      throw new Error("new exception input not found")
+    }
+
+    expect(screen.queryByDisplayValue("01/21/2020")).not.toBeNull()
+  })
+
+  test("removing exception date", async () => {
+    render(
+      <MemoryRouter initialEntries={["/disruptions/foo/edit"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/edit"
+            component={EditDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    fireEvent.click(screen.getByText("delete exception"))
+
+    expect(screen.queryByDisplayValue("01/20/2020")).toBeNull()
+  })
+
+  test("adding and updating day of week", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/foo/edit"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/edit"
+            component={EditDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    const dayOfWeekMCheck = container.querySelector("#day-of-week-M")
+
+    if (dayOfWeekMCheck) {
+      fireEvent.click(dayOfWeekMCheck)
+    } else {
+      throw new Error("Monday checkbox not found")
+    }
+
+    const startOfServiceCheck = container.querySelector(
+      "#time-of-day-start-type-0"
+    )
+    const endOfServiceCheck = container.querySelector("#time-of-day-end-type-0")
+    const startHour = container.querySelector("#time-of-day-start-hour-0")
+    const startMinute = container.querySelector("#time-of-day-start-minute-0")
+    const startPeriod = container.querySelector("#time-of-day-start-period-0")
+    const endHour = container.querySelector("#time-of-day-end-hour-0")
+    const endMinute = container.querySelector("#time-of-day-end-minute-0")
+    const endPeriod = container.querySelector("#time-of-day-end-period-0")
+
+    if (
+      startOfServiceCheck &&
+      endOfServiceCheck &&
+      startHour &&
+      startMinute &&
+      startPeriod &&
+      endHour &&
+      endMinute &&
+      endPeriod
+    ) {
+      fireEvent.click(startOfServiceCheck)
+      fireEvent.click(endOfServiceCheck)
+      fireEvent.change(startHour, { target: { value: "8" } })
+      fireEvent.change(startMinute, { target: { value: "30" } })
+      fireEvent.change(startPeriod, { target: { value: "AM" } })
+      fireEvent.change(endHour, { target: { value: "8" } })
+      fireEvent.change(endMinute, { target: { value: "30" } })
+      fireEvent.change(endPeriod, { target: { value: "PM" } })
+    } else {
+      throw new Error("day of week time range inputs not found")
+    }
+
+    expect((startHour as HTMLInputElement).value).toBe("8")
+    expect((startMinute as HTMLInputElement).value).toBe("30")
+    expect((startPeriod as HTMLInputElement).value).toBe("AM")
+    expect((endHour as HTMLInputElement).value).toBe("8")
+    expect((endMinute as HTMLInputElement).value).toBe("30")
+    expect((endPeriod as HTMLInputElement).value).toBe("PM")
   })
 })

--- a/assets/tests/disruptions/time.test.ts
+++ b/assets/tests/disruptions/time.test.ts
@@ -13,21 +13,22 @@ describe("fromDaysOfWeek", () => {
         new DayOfWeek({ dayName: "monday" }),
         new DayOfWeek({ startTime: "11:30:00", dayName: "tuesday" }),
         new DayOfWeek({
-          startTime: "11:30:00",
+          startTime: "08:30:00",
           endTime: "20:45:00",
           dayName: "wednesday",
         }),
         new DayOfWeek({ endTime: "20:45:00", dayName: "thursday" }),
+        new DayOfWeek({ startTime: "00:00:00", dayName: "friday" }),
       ])
     ).toEqual([
       [null, null],
       [{ hour: "11", minute: "30", period: "AM" }, null],
       [
-        { hour: "11", minute: "30", period: "AM" },
+        { hour: "8", minute: "30", period: "AM" },
         { hour: "8", minute: "45", period: "PM" },
       ],
       [null, { hour: "8", minute: "45", period: "PM" }],
-      null,
+      [{ hour: "12", minute: "00", period: "AM" }, null],
       null,
       null,
     ])

--- a/assets/tests/jsonApi.test.ts
+++ b/assets/tests/jsonApi.test.ts
@@ -106,8 +106,8 @@ describe("toModelObject", () => {
     ).toEqual(
       new Disruption({
         id: "1",
-        startDate: new Date("2019-12-20"),
-        endDate: new Date("2020-01-12"),
+        startDate: new Date("2019-12-20T00:00:00"),
+        endDate: new Date("2020-01-12T00:00:00"),
         adjustments: [
           new Adjustment({
             id: "12",
@@ -145,7 +145,7 @@ describe("toModelObject", () => {
     ).toEqual(
       new Exception({
         id: "1",
-        excludedDate: new Date("2019-12-20"),
+        excludedDate: new Date("2019-12-20T00:00:00"),
       })
     )
   })
@@ -297,8 +297,8 @@ describe("toModelObject", () => {
     ).toEqual([
       new Disruption({
         id: "1",
-        startDate: new Date("2019-12-20"),
-        endDate: new Date("2020-01-12"),
+        startDate: new Date("2019-12-20T00:00:00"),
+        endDate: new Date("2020-01-12T00:00:00"),
         adjustments: [
           new Adjustment({
             id: "12",
@@ -313,8 +313,8 @@ describe("toModelObject", () => {
       }),
       new Disruption({
         id: "2",
-        startDate: new Date("2019-12-25"),
-        endDate: new Date("2020-01-15"),
+        startDate: new Date("2019-12-25T00:00:00"),
+        endDate: new Date("2020-01-15T00:00:00"),
         adjustments: [
           new Adjustment({
             id: "13",

--- a/assets/tests/models/disruption.test.ts
+++ b/assets/tests/models/disruption.test.ts
@@ -61,8 +61,8 @@ describe("Disruption", () => {
     ).toEqual(
       new Disruption({
         id: "1",
-        startDate: new Date("2019-12-20"),
-        endDate: new Date("2020-01-12"),
+        startDate: new Date("2019-12-20T00:00:00"),
+        endDate: new Date("2020-01-12T00:00:00"),
         adjustments: [],
         daysOfWeek: [
           new DayOfWeek({

--- a/assets/tests/models/exception.test.ts
+++ b/assets/tests/models/exception.test.ts
@@ -25,7 +25,9 @@ describe("Exception", () => {
         type: "exception",
         attributes: { excluded_date: "2020-03-30" },
       })
-    ).toEqual(new Exception({ id: "1", excludedDate: new Date("2020-03-30") }))
+    ).toEqual(
+      new Exception({ id: "1", excludedDate: new Date("2020-03-30T00:00:00") })
+    )
   })
 
   test("fromJsonObject error wrong format", () => {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Part of [🏹 API to edit disruption, frontend uses it](https://app.asana.com/0/584764604969369/1163421197919734/f)

This ended up being a fair bit of code that will be largely independent of the rest of the work on this ticket, so I decided to open a separate PR for it. It's all in one commit, unfortunately, but I don't think it's _too_ unwieldy to review.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
