### PR TITLE
feat: Style date select with a little calendar

### DIFF
--- a/assets/css/_datepicker.scss
+++ b/assets/css/_datepicker.scss
@@ -1,0 +1,27 @@
+.m-datepicker__container {
+  display: inline-block;
+  border: 1px solid gray;
+  padding-left: 1rem;
+
+  input {
+    border: none;
+    width: 7rem;
+  }
+}
+
+.m-datepicker__icon {
+  color: #888;
+  border-left: 1px solid gray;
+  display: inline-block;
+  padding: 0.5rem;
+}
+
+.m-datepicker__react {
+  input {
+    padding: 0.5rem;
+  }
+}
+
+.react-datepicker__tab-loop {
+  display: inline-block;
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -11,3 +11,4 @@
 @import "new_disruption_preview";
 @import "disruption_table";
 @import "disruption_index";
+@import "datepicker";

--- a/assets/src/datePicker.tsx
+++ b/assets/src/datePicker.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import ReactDatePicker, { ReactDatePickerProps } from "react-datepicker"
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faCalendar } from "@fortawesome/free-solid-svg-icons"
+
+const DatePicker = (props: ReactDatePickerProps): JSX.Element => {
+  return (
+    <div className="m-datepicker__container">
+      <ReactDatePicker
+        className="m-datepicker__react"
+        placeholderText="__ / __ / ____"
+        {...props}
+      />
+      <div className="m-datepicker__icon">
+        <FontAwesomeIcon icon={faCalendar} />
+      </div>
+    </div>
+  )
+}
+
+export default DatePicker

--- a/assets/src/disruptions/disruptionTimePicker.tsx
+++ b/assets/src/disruptions/disruptionTimePicker.tsx
@@ -3,7 +3,7 @@ import Col from "react-bootstrap/Col"
 import Form from "react-bootstrap/Form"
 import Row from "react-bootstrap/Row"
 
-import DatePicker from "react-datepicker"
+import DatePicker from "../datePicker"
 
 import {
   Time,
@@ -37,7 +37,7 @@ const DisruptionDateRange = ({
         selected={fromDate}
         onChange={date => setFromDate(date)}
       />
-      until{" "}
+      <span className="px-3">until</span>
       <DatePicker
         id="disruption-date-range-end"
         selected={toDate}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Date range selector should have a little calendar in it and placeholder text](https://app.asana.com/0/584764604969369/1158326786257801)

Mostly just a styling change. Since there are a few datepicker widgets on the new/edit forms, and they all use this, I assumed this would just be how our datepickers should look throughout the app. I created a new `DatePicker` component that basically wraps the underlying `react-datepicker` component and adds a font awesome icon next to it.

---

<img width="419" alt="Screen Shot 2020-04-13 at 1 23 04 PM" src="https://user-images.githubusercontent.com/384428/79148299-e211d600-7d8a-11ea-9b01-956a9d646db1.png">

---

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
