### PR TITLE
Edit disruption API

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -20,26 +20,28 @@ const checkResponseStatus = (response: Response) => {
   throw new Error(`Response error: ${response.status}`)
 }
 
-const apiPost = async <T, E>({
+const apiSend = async <T, E>({
   url,
+  method,
   json,
   successParser,
   errorParser,
 }: {
   url: string
+  method: "POST" | "PATCH"
   json: any
   successParser: (json: any) => T
   errorParser: (json: any) => E
 }): Promise<Result<T, E>> => {
   const response = await fetch(url, {
-    method: "POST",
+    method,
     credentials: "include",
     headers: { "Content-Type": "application/vnd.api+json" },
     body: json,
   })
   redirectIfUnauthorized(response.status)
   const responseData = await response.json()
-  if (response.status === 201) {
+  if (response.status === 200 || response.status === 201) {
     return { ok: successParser(responseData) }
   } else if (response.status === 400) {
     return { error: errorParser(responseData) }
@@ -70,4 +72,4 @@ const apiGet = <T>({
       }
     })
 
-export { apiGet, apiPost }
+export { apiGet, apiSend }

--- a/assets/src/disruptions/newDisruption.tsx
+++ b/assets/src/disruptions/newDisruption.tsx
@@ -6,7 +6,7 @@ import Button from "react-bootstrap/Button"
 import Form from "react-bootstrap/Form"
 import Alert from "react-bootstrap/Alert"
 
-import { apiGet, apiPost } from "../api"
+import { apiGet, apiSend } from "../api"
 import { toModelObject, JsonApiResponse, parseErrors } from "../jsonApi"
 import Disruption from "../models/disruption"
 import Adjustment from "../models/adjustment"
@@ -267,8 +267,9 @@ const NewDisruption = ({}): JSX.Element => {
   const createFn = async (args: ApiCreateDisruptionParams) => {
     const disruption = disruptionFromState(args)
 
-    const result = await apiPost({
+    const result = await apiSend({
       url: "/api/disruptions",
+      method: "POST",
       json: JSON.stringify(disruption.toJsonApi()),
       successParser: toModelObject,
       errorParser: parseErrors,

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -1,4 +1,4 @@
-import { apiGet, apiPost } from "../src/api"
+import { apiGet, apiSend } from "../src/api"
 
 declare global {
   interface Window {
@@ -18,12 +18,29 @@ const mockFetchFailure = () => {
   window.fetch = () => Promise.reject("network failure")
 }
 
-describe("apiPost", () => {
+describe("apiSend", () => {
   test("parses successful create", done => {
     mockFetch(201, { data: "success" })
     const successParse = jest.fn(() => "success")
-    apiPost({
+    apiSend({
       url: "/",
+      method: "POST",
+      json: "{}",
+      successParser: successParse,
+      errorParser: () => "error",
+    }).then(parsed => {
+      expect(successParse).toHaveBeenCalledWith({ data: "success" })
+      expect(parsed).toEqual({ ok: "success" })
+      done()
+    })
+  })
+
+  test("parses successful update", done => {
+    mockFetch(200, { data: "success" })
+    const successParse = jest.fn(() => "success")
+    apiSend({
+      url: "/",
+      method: "PATCH",
       json: "{}",
       successParser: successParse,
       errorParser: () => "error",
@@ -37,8 +54,9 @@ describe("apiPost", () => {
   test("parses error response", done => {
     mockFetch(400, { data: "error" })
     const errorParse = jest.fn(() => "error")
-    apiPost({
+    apiSend({
       url: "/",
+      method: "POST",
       json: "{}",
       successParser: () => "success",
       errorParser: errorParse,
@@ -52,8 +70,9 @@ describe("apiPost", () => {
   test("promise reject if there are errors", done => {
     mockFetchFailure()
 
-    apiPost({
+    apiSend({
       url: "/",
+      method: "POST",
       json: "{}",
       successParser: () => "success",
       errorParser: () => "error",
@@ -65,8 +84,9 @@ describe("apiPost", () => {
 
   test("promise reject if unexpected error code", done => {
     mockFetch(500, { data: "error" })
-    apiPost({
+    apiSend({
       url: "/",
+      method: "POST",
       json: "{}",
       successParser: () => "success",
       errorParser: () => "error",

--- a/assets/tests/disruptions/newDisruption.test.tsx
+++ b/assets/tests/disruptions/newDisruption.test.tsx
@@ -26,7 +26,7 @@ const withElement = (
 
 describe("NewDisruption", () => {
   let apiCallSpy: jest.SpyInstance
-  let apiPostSpy: jest.SpyInstance
+  let apiSendSpy: jest.SpyInstance
 
   beforeEach(() => {
     apiCallSpy = jest.spyOn(api, "apiGet").mockImplementation(() => {
@@ -49,7 +49,7 @@ describe("NewDisruption", () => {
 
   afterAll(() => {
     apiCallSpy.mockRestore()
-    apiPostSpy.mockRestore()
+    apiSendSpy.mockRestore()
   })
 
   test("header include link to homepage", async () => {
@@ -344,7 +344,7 @@ describe("NewDisruption", () => {
   })
 
   test("can create a disruption", async () => {
-    apiPostSpy = jest.spyOn(api, "apiPost").mockImplementation(() => {
+    apiSendSpy = jest.spyOn(api, "apiSend").mockImplementation(() => {
       return Promise.resolve({
         ok: {},
       })
@@ -386,18 +386,18 @@ describe("NewDisruption", () => {
     })
 
     await screen.findByText("Success!!!")
-    const apiPostCall = apiPostSpy.mock.calls[0][0]
-    const apiPostData = JSON.parse(apiPostCall.json)
-    expect(apiPostCall.url).toEqual("/api/disruptions")
-    expect(apiPostData.data.attributes.start_date).toEqual("2020-03-31")
-    expect(apiPostData.data.attributes.end_date).toEqual("2020-04-30")
+    const apiSendCall = apiSendSpy.mock.calls[0][0]
+    const apiSendData = JSON.parse(apiSendCall.json)
+    expect(apiSendCall.url).toEqual("/api/disruptions")
+    expect(apiSendData.data.attributes.start_date).toEqual("2020-03-31")
+    expect(apiSendData.data.attributes.end_date).toEqual("2020-04-30")
     expect(
-      apiPostData.data.relationships.adjustments.data[0].attributes.source_label
+      apiSendData.data.relationships.adjustments.data[0].attributes.source_label
     ).toEqual("Kenmore--Newton Highlands")
   })
 
   test("handles errors with disruptions", async () => {
-    apiPostSpy = jest.spyOn(api, "apiPost").mockImplementation(() => {
+    apiSendSpy = jest.spyOn(api, "apiSend").mockImplementation(() => {
       return Promise.resolve({
         error: ["Data is all wrong"],
       })

--- a/lib/arrow/adjustment.ex
+++ b/lib/arrow/adjustment.ex
@@ -20,6 +20,14 @@ defmodule Arrow.Adjustment do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          route_id: String.t() | nil,
+          source: String.t() | nil,
+          source_label: String.t() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
   schema "adjustments" do
     field :route_id, :string
     field :source, :string
@@ -29,6 +37,7 @@ defmodule Arrow.Adjustment do
   end
 
   @doc false
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(adjustment, attrs) do
     adjustment
     |> cast(attrs, [:source, :source_label, :route_id])
@@ -36,6 +45,7 @@ defmodule Arrow.Adjustment do
     |> unique_constraint(:source_label)
   end
 
+  @spec changeset_assoc(t(), map()) :: Ecto.Changeset.t()
   def changeset_assoc(adjustment, attrs) do
     cast(adjustment, attrs, [:id])
   end

--- a/lib/arrow/disruption.ex
+++ b/lib/arrow/disruption.ex
@@ -11,20 +11,67 @@ defmodule Arrow.Disruption do
 
   alias Arrow.Disruption.{DayOfWeek, Exception, TripShortName}
 
+  @type t :: %__MODULE__{
+          end_date: Date.t() | nil,
+          start_date: Date.t() | nil,
+          days_of_week: [DayOfWeek.t()] | Ecto.Association.NotLoaded.t(),
+          exceptions: [Exception.t()] | Ecto.Association.NotLoaded.t(),
+          trip_short_names: [TripShortName.t()] | Ecto.Association.NotLoaded.t(),
+          adjustments: [Arrow.Adjustment.t()] | Ecto.Association.NotLoaded.t(),
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
   schema "disruptions" do
     field :end_date, :date
     field :start_date, :date
 
-    has_many :days_of_week, DayOfWeek
-    has_many :exceptions, Exception
-    has_many :trip_short_names, TripShortName
+    has_many :days_of_week, DayOfWeek, on_replace: :delete
+    has_many :exceptions, Exception, on_replace: :delete
+    has_many :trip_short_names, TripShortName, on_replace: :delete
+
     many_to_many :adjustments, Arrow.Adjustment, join_through: "disruption_adjustments"
 
     timestamps(type: :utc_datetime)
   end
 
   @doc false
-  def changeset(disruption, attrs, adjustments) do
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(disruption, attrs) do
+    disruption
+    |> cast(attrs, [:id, :start_date, :end_date])
+    |> validate_required([:start_date, :end_date])
+  end
+
+  @doc false
+  @spec changeset_for_create(t(), map(), [Arrow.Adjustment.t()]) :: Ecto.Changeset.t()
+  def changeset_for_create(disruption, attrs, adjustments) do
+    {days_of_week, exceptions, trip_short_names} = assoc_changesets(attrs)
+
+    disruption
+    |> changeset(attrs)
+    |> put_assoc(:adjustments, adjustments)
+    |> validate_length(:adjustments, min: 1)
+    |> put_assoc(:days_of_week, days_of_week)
+    |> put_assoc(:exceptions, exceptions)
+    |> put_assoc(:trip_short_names, trip_short_names)
+  end
+
+  @doc false
+  @spec changeset_for_update(t(), map()) :: Ecto.Changeset.t()
+  def changeset_for_update(disruption, attrs) do
+    {days_of_week, exceptions, trip_short_names} = assoc_changesets(attrs)
+
+    disruption
+    |> changeset(attrs)
+    |> cast_assoc(:days_of_week, days_of_week)
+    |> cast_assoc(:exceptions, exceptions)
+    |> cast_assoc(:trip_short_names, trip_short_names)
+  end
+
+  @spec assoc_changesets(map()) ::
+          {[Ecto.Changeset.t()], [Ecto.Changeset.t()], [Ecto.Changeset.t()]}
+  defp assoc_changesets(attrs) do
     days_of_week =
       for dow <- attrs["days_of_week"] || [],
           do: DayOfWeek.changeset(%DayOfWeek{}, dow)
@@ -37,13 +84,6 @@ defmodule Arrow.Disruption do
       for name <- attrs["trip_short_names"] || [],
           do: TripShortName.changeset(%TripShortName{}, name)
 
-    disruption
-    |> cast(attrs, [:start_date, :end_date])
-    |> validate_required([:start_date, :end_date])
-    |> put_assoc(:adjustments, adjustments, with: &Arrow.Adjustment.changeset_assoc/2)
-    |> validate_length(:adjustments, min: 1)
-    |> put_assoc(:days_of_week, days_of_week)
-    |> put_assoc(:exceptions, exceptions)
-    |> put_assoc(:trip_short_names, trip_short_names)
+    {days_of_week, exceptions, trip_short_names}
   end
 end

--- a/lib/arrow/disruption/day_of_week.ex
+++ b/lib/arrow/disruption/day_of_week.ex
@@ -2,6 +2,15 @@ defmodule Arrow.Disruption.DayOfWeek do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          day_name: String.t() | nil,
+          start_time: Time.t() | nil,
+          end_time: Time.t() | nil,
+          disruption: Arrow.Disruption | Ecto.Association.NotLoaded.t(),
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
   schema "disruption_day_of_weeks" do
     field :day_name, :string
     field :start_time, :time
@@ -12,9 +21,10 @@ defmodule Arrow.Disruption.DayOfWeek do
   end
 
   @doc false
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(day_of_week, attrs) do
     day_of_week
-    |> cast(attrs, [:day_name, :start_time, :end_time])
+    |> cast(attrs, [:id, :day_name, :start_time, :end_time])
     |> validate_inclusion(:day_name, [
       "monday",
       "tuesday",

--- a/lib/arrow/disruption/exception.ex
+++ b/lib/arrow/disruption/exception.ex
@@ -2,6 +2,13 @@ defmodule Arrow.Disruption.Exception do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          excluded_date: Date.t() | nil,
+          disruption: Arrow.Disruption | Ecto.Association.NotLoaded.t(),
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
   schema "disruption_exceptions" do
     field :excluded_date, :date
     belongs_to :disruption, Arrow.Disruption
@@ -10,9 +17,10 @@ defmodule Arrow.Disruption.Exception do
   end
 
   @doc false
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(exception, attrs) do
     exception
-    |> cast(attrs, [:excluded_date])
+    |> cast(attrs, [:id, :excluded_date])
     |> validate_required([:excluded_date])
   end
 end

--- a/lib/arrow/disruption/trip_short_name.ex
+++ b/lib/arrow/disruption/trip_short_name.ex
@@ -2,6 +2,13 @@ defmodule Arrow.Disruption.TripShortName do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          trip_short_name: String.t() | nil,
+          disruption: Arrow.Disruption | Ecto.Association.NotLoaded.t(),
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
   schema "disruption_trip_short_names" do
     field :trip_short_name, :string
     belongs_to :disruption, Arrow.Disruption
@@ -10,9 +17,10 @@ defmodule Arrow.Disruption.TripShortName do
   end
 
   @doc false
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(trip_short_name, attrs) do
     trip_short_name
-    |> cast(attrs, [:trip_short_name])
+    |> cast(attrs, [:id, :trip_short_name])
     |> validate_required([:trip_short_name])
   end
 end

--- a/lib/arrow_web/controllers/api/disruption_controller.ex
+++ b/lib/arrow_web/controllers/api/disruption_controller.ex
@@ -27,7 +27,7 @@ defmodule ArrowWeb.API.DisruptionController do
     )
   end
 
-  @spec build_query([{String.t(), Date.t()}]) :: Ecto.Query.t()
+  @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def create(conn, params) do
     params_data = Map.get(params, "data", %{})
     params_relationships = Map.get(params_data, "relationships", %{})
@@ -59,6 +59,7 @@ defmodule ArrowWeb.API.DisruptionController do
     end
   end
 
+  @spec build_query([{String.t(), Date.t()}]) :: Ecto.Query.t()
   defp build_query(filters) do
     Enum.reduce(filters, from(d in Disruption), &compose_query/2)
   end

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -62,7 +62,7 @@ defmodule ArrowWeb.Router do
   scope "/api", ArrowWeb.API do
     pipe_through([:redirect_prod_http, :api, :auth, :ensure_auth, :ensure_arrow_group])
 
-    resources("/disruptions", DisruptionController, only: [:index, :show, :create])
+    resources("/disruptions", DisruptionController, only: [:index, :show, :create, :update])
     resources("/adjustments", AdjustmentController, only: [:index])
   end
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -127,5 +127,5 @@ for {attrs, adjustments} <- [
          "end_date" => ~D[2020-03-29]
        }, [Repo.get_by!(Adjustment, source_label: "ForgeParkSouthStation")]}
     ] do
-  Repo.insert!(Disruption.changeset(%Disruption{}, attrs, adjustments))
+  Repo.insert!(Disruption.changeset_for_create(%Disruption{}, attrs, adjustments))
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 API to edit disruption, frontend uses it](https://app.asana.com/0/584764604969369/1163421197919734/f)

Commits should be reviewable individually. ~`apiPatch` is largely the same as `apiPost`, but I wasn't sure if it would make sense to combine them into a single function and, if so, what that function's name should be.~ Update: I consolidated it to `apiSend` per @losvedir's suggestion.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
