### PR TITLE
test: remove Enzyme, move existing tests to React Testing Library

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1466,15 +1466,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/cheerio": {
-      "version": "0.22.16",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.16.tgz",
-      "integrity": "sha512-bSbnU/D4yzFdzLpp3+rcDj0aQQMIRUBNJU7azPxdqMpnexjUSvGJyDuOBQBHeOZh1mMKgsJm6Dy+LLh80Ew4tQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/classnames": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.10.tgz",
@@ -1486,25 +1477,6 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
-    },
-    "@types/enzyme": {
-      "version": "3.10.5",
-      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.5.tgz",
-      "integrity": "sha512-R+phe509UuUYy9Tk0YlSbipRpfVtIzb/9BHn5pTEtjJTF5LXvUjrIQcZvNyANNEyFrd2YGs196PniNT1fgvOQA==",
-      "dev": true,
-      "requires": {
-        "@types/cheerio": "*",
-        "@types/react": "*"
-      }
-    },
-    "@types/enzyme-adapter-react-16": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.6.tgz",
-      "integrity": "sha512-VonDkZ15jzqDWL8mPFIQnnLtjwebuL9YnDkqeCDYnB4IVgwUm0mwKkqhrxLL6mb05xm7qqa3IE95m8CZE9imCg==",
-      "dev": true,
-      "requires": {
-        "@types/enzyme": "*"
-      }
     },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
@@ -1639,12 +1611,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "13.1.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
-      "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg==",
       "dev": true
     },
     "@types/prettier": {
@@ -2098,24 +2064,6 @@
         }
       }
     },
-    "airbnb-prop-types": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz",
-      "integrity": "sha512-jUh2/hfKsRjNFC4XONQrxo/n/3GG4Tn6Hl0WlFQN5PY9OMC9loSCoAYKnZsWaP8wEfd5xcrPloK0Zg6iS1xwVA==",
-      "dev": true,
-      "requires": {
-        "array.prototype.find": "^2.1.0",
-        "function.prototype.name": "^1.1.1",
-        "has": "^1.0.3",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.0",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.9.0"
-      }
-    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -2262,12 +2210,6 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
-    "array-filter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
-      "dev": true
-    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -2367,88 +2309,6 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
-    },
-    "array.prototype.find": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
-      "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.13.0"
-      }
-    },
-    "array.prototype.flat": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
-      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.2.tgz",
-          "integrity": "sha512-YoKuru3Lyoy7yVTBSH2j7UxTqe/je3dWAruC0sHvZX1GNd5zX8SSLvQqEgO9b3Ex8IW+goFI9arEEsFIbulhOw==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "string.prototype.trimleft": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-          "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        },
-        "string.prototype.trimright": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-          "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        }
-      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -3182,75 +3042,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "cheerio": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
-      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
-      "dev": true,
-      "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.1",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash": "^4.15.0",
-        "parse5": "^3.0.1"
-      },
-      "dependencies": {
-        "css-select": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-          "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-          "dev": true,
-          "requires": {
-            "boolbase": "~1.0.0",
-            "css-what": "2.1",
-            "domutils": "1.5.1",
-            "nth-check": "~1.0.1"
-          }
-        },
-        "css-what": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-          "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
-          "dev": true
-        },
-        "dom-serializer": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-          "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^1.3.0",
-            "entities": "^1.1.1"
-          }
-        },
-        "domutils": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-          "dev": true,
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
-        "entities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-          "dev": true
-        },
-        "parse5": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        }
-      }
     },
     "chokidar": {
       "version": "2.1.8",
@@ -4136,12 +3927,6 @@
         "path-type": "^3.0.0"
       }
     },
-    "discontinuous-range": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
-      "dev": true
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4218,15 +4003,6 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
-      }
-    },
-    "domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -4340,225 +4116,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
       "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
       "dev": true
-    },
-    "enzyme": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-      "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-      "dev": true,
-      "requires": {
-        "array.prototype.flat": "^1.2.3",
-        "cheerio": "^1.0.0-rc.3",
-        "enzyme-shallow-equal": "^1.0.1",
-        "function.prototype.name": "^1.1.2",
-        "has": "^1.0.3",
-        "html-element-map": "^1.2.0",
-        "is-boolean-object": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-number-object": "^1.0.4",
-        "is-regex": "^1.0.5",
-        "is-string": "^1.0.5",
-        "is-subset": "^0.1.1",
-        "lodash.escape": "^4.0.1",
-        "lodash.isequal": "^4.5.0",
-        "object-inspect": "^1.7.0",
-        "object-is": "^1.0.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.1",
-        "object.values": "^1.1.1",
-        "raf": "^3.4.1",
-        "rst-selector-parser": "^2.2.3",
-        "string.prototype.trim": "^1.2.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.2.tgz",
-          "integrity": "sha512-YoKuru3Lyoy7yVTBSH2j7UxTqe/je3dWAruC0sHvZX1GNd5zX8SSLvQqEgO9b3Ex8IW+goFI9arEEsFIbulhOw==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "object.values": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
-          "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0-next.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3"
-          }
-        },
-        "string.prototype.trimleft": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-          "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        },
-        "string.prototype.trimright": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-          "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        }
-      }
-    },
-    "enzyme-adapter-react-16": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.2.tgz",
-      "integrity": "sha512-SkvDrb8xU3lSxID8Qic9rB8pvevDbLybxPK6D/vW7PrT0s2Cl/zJYuXvsd1EBTz0q4o3iqG3FJhpYz3nUNpM2Q==",
-      "dev": true,
-      "requires": {
-        "enzyme-adapter-utils": "^1.13.0",
-        "enzyme-shallow-equal": "^1.0.1",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "object.values": "^1.1.1",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.12.0",
-        "react-test-renderer": "^16.0.0-0",
-        "semver": "^5.7.0"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.2.tgz",
-          "integrity": "sha512-YoKuru3Lyoy7yVTBSH2j7UxTqe/je3dWAruC0sHvZX1GNd5zX8SSLvQqEgO9b3Ex8IW+goFI9arEEsFIbulhOw==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "object.values": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
-          "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0-next.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3"
-          }
-        },
-        "string.prototype.trimleft": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-          "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        },
-        "string.prototype.trimright": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-          "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        }
-      }
-    },
-    "enzyme-adapter-utils": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.13.0.tgz",
-      "integrity": "sha512-YuEtfQp76Lj5TG1NvtP2eGJnFKogk/zT70fyYHXK2j3v6CtuHqc8YmgH/vaiBfL8K1SgVVbQXtTcgQZFwzTVyQ==",
-      "dev": true,
-      "requires": {
-        "airbnb-prop-types": "^2.15.0",
-        "function.prototype.name": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.fromentries": "^2.0.2",
-        "prop-types": "^15.7.2",
-        "semver": "^5.7.1"
-      }
-    },
-    "enzyme-shallow-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.1.tgz",
-      "integrity": "sha512-hGA3i1so8OrYOZSM9whlkNmVHOicJpsjgTzC+wn2JMJXhq1oO4kA4bJ5MsfzSIcC71aLDKzJ6gZpIxrqt3QTAQ==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3",
-        "object-is": "^1.0.2"
-      }
     },
     "errno": {
       "version": "0.1.7",
@@ -6039,89 +5596,10 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
-    "function.prototype.name": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.2.tgz",
-      "integrity": "sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "functions-have-names": "^1.2.0"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.2.tgz",
-          "integrity": "sha512-YoKuru3Lyoy7yVTBSH2j7UxTqe/je3dWAruC0sHvZX1GNd5zX8SSLvQqEgO9b3Ex8IW+goFI9arEEsFIbulhOw==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "string.prototype.trimleft": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-          "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        },
-        "string.prototype.trimright": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-          "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        }
-      }
-    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
-    },
-    "functions-have-names": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.0.tgz",
-      "integrity": "sha512-zKXyzksTeaCSw5wIX79iCA40YAa6CJMJgNg9wdkU/ERBrIdPSimPICYiLp65lRbSBqtiHql/HZfS2DyI/AH6tQ==",
       "dev": true
     },
     "gauge": {
@@ -6548,15 +6026,6 @@
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
       "dev": true
     },
-    "html-element-map": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.2.0.tgz",
-      "integrity": "sha512-0uXq8HsuG1v2TmQ8QkIhzbrqeskE4kn52Q18QJ9iAA/SnHoEKXWiUxHQtclRsCFWEUD2So34X+0+pZZu862nnw==",
-      "dev": true,
-      "requires": {
-        "array-filter": "^1.0.0"
-      }
-    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -6571,39 +6040,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
-    },
-    "htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -6995,12 +6431,6 @@
         "binary-extensions": "^1.0.0"
       }
     },
-    "is-boolean-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
-      "integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==",
-      "dev": true
-    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -7147,12 +6577,6 @@
         }
       }
     },
-    "is-number-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
-      "dev": true
-    },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
@@ -7204,12 +6628,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
       "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-      "dev": true
-    },
-    "is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
       "dev": true
     },
     "is-svg": {
@@ -10201,24 +9619,6 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
       "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
-    "lodash.escape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
-      "dev": true
-    },
-    "lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-      "dev": true
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -10618,12 +10018,6 @@
         }
       }
     },
-    "moo": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
-      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
-      "dev": true
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -10680,19 +10074,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "nearley": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.1.tgz",
-      "integrity": "sha512-xq47GIUGXxU9vQg7g/y1o1xuKnkO7ev4nRWqftmQrLkfnE/FjRqDaGOUakM8XHPn/6pW3bGjU2wgoJyId90rqg==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.19.0",
-        "moo": "^0.5.0",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6",
-        "semver": "^5.4.1"
-      }
     },
     "neo-async": {
       "version": "2.6.1",
@@ -12157,17 +11538,6 @@
         "react-is": "^16.8.1"
       }
     },
-    "prop-types-exact": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
-      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "prop-types-extra": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
@@ -12269,31 +11639,6 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
-    },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
-    "railroad-diagrams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
-      "dev": true
-    },
-    "randexp": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dev": true,
-      "requires": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -12452,18 +11797,6 @@
         "tiny-warning": "^1.0.0"
       }
     },
-    "react-test-renderer": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.12.0.tgz",
-      "integrity": "sha512-Vj/teSqt2oayaWxkbhQ6gKis+t5JrknXfPVo+aIJ8QwYAqMPH77uptOdrlphyxl8eQI/rtkOYg86i/UWkpFu0w==",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.18.0"
-      }
-    },
     "react-transition-group": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
@@ -12577,12 +11910,6 @@
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
       }
-    },
-    "reflect.ownkeys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
-      "dev": true
     },
     "regenerator-runtime": {
       "version": "0.13.3",
@@ -12862,16 +12189,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "rst-selector-parser": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-      "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
-      "dev": true,
-      "requires": {
-        "lodash.flattendeep": "^4.4.0",
-        "nearley": "^2.7.10"
-      }
-    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -13141,16 +12458,6 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.1.1"
-      }
-    },
-    "scheduler": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-      "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "schema-utils": {
@@ -13786,79 +13093,6 @@
           "version": "1.17.5",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
           "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "string.prototype.trimleft": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-          "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        },
-        "string.prototype.trimright": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-          "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
-          }
-        }
-      }
-    },
-    "string.prototype.trim": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
-      "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.2.tgz",
-          "integrity": "sha512-YoKuru3Lyoy7yVTBSH2j7UxTqe/je3dWAruC0sHvZX1GNd5zX8SSLvQqEgO9b3Ex8IW+goFI9arEEsFIbulhOw==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -29,8 +29,6 @@
     "@testing-library/dom": "^7.2.1",
     "@testing-library/react": "^10.0.2",
     "@types/classnames": "^2.2.10",
-    "@types/enzyme": "^3.10.5",
-    "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^25.2.1",
     "@types/react": "^16.9.34",
     "@types/react-datepicker": "^2.11.0",
@@ -42,8 +40,6 @@
     "@typescript-eslint/parser": "^2.27.0",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.5.1",
-    "enzyme": "^3.11.0",
-    "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^6.8.0",
     "eslint-plugin-prefer-arrow": "^1.2.0",
     "eslint-plugin-react": "^7.19.0",
@@ -81,9 +77,7 @@
       "json",
       "node"
     ],
-    "setupFilesAfterEnv": [
-      "<rootDir>/tests/setup.ts"
-    ],
+    "setupFilesAfterEnv": [],
     "collectCoverage": true,
     "globals": {
       "ts-jest": {

--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -65,6 +65,7 @@ const RouteFilterToggle = React.memo(
         className={classnames("mr-2 m-disruption-index__route_filter", {
           active,
         })}
+        id={"route-filter-toggle-" + route}
         onClick={() => onClick(route)}
       >
         <Icon type={ROUTE_ICONS[route]} />

--- a/assets/tests/disruptions/disruptionPreview.test.tsx
+++ b/assets/tests/disruptions/disruptionPreview.test.tsx
@@ -1,10 +1,10 @@
-import { mount } from "enzyme"
+import { render, fireEvent, screen } from "@testing-library/react"
 import * as React from "react"
 import { DisruptionPreview } from "../../src/disruptions/disruptionPreview"
 
 describe("DisruptionPreview", () => {
   test("includes formatted from and to dates", () => {
-    const text = mount(
+    render(
       <DisruptionPreview
         adjustments={[]}
         setIsPreview={() => null}
@@ -13,14 +13,13 @@ describe("DisruptionPreview", () => {
         disruptionDaysOfWeek={[null, null, null, null, null, null, null]}
         exceptionDates={[]}
       />
-    ).text()
+    )
 
-    expect(text).toMatch("1/1/2020")
-    expect(text).toMatch("1/15/2020")
+    expect(screen.queryByText("1/1/2020 – 1/15/2020")).not.toBeNull()
   })
 
   test("includes formatted exception dates", () => {
-    const text = mount(
+    render(
       <DisruptionPreview
         adjustments={[]}
         setIsPreview={() => null}
@@ -29,13 +28,13 @@ describe("DisruptionPreview", () => {
         disruptionDaysOfWeek={[null, null, null, null, null, null, null]}
         exceptionDates={[new Date(2020, 0, 10)]}
       />
-    ).text()
+    )
 
-    expect(text).toMatch("1/10/2020")
+    expect(screen.queryByText("1/10/2020")).not.toBeNull()
   })
 
   test("Days of week are included and translated", () => {
-    let text = mount(
+    render(
       <DisruptionPreview
         adjustments={[]}
         setIsPreview={() => null}
@@ -52,12 +51,14 @@ describe("DisruptionPreview", () => {
         ]}
         exceptionDates={[new Date(2020, 0, 10)]}
       />
-    ).text()
+    )
 
-    expect(text).toMatch("Wednesday")
-    expect(text).toMatch("Start of service – End of service")
+    expect(screen.queryByText("Wednesday")).not.toBeNull()
+    expect(
+      screen.queryByText("Start of service – End of service")
+    ).not.toBeNull()
 
-    text = mount(
+    render(
       <DisruptionPreview
         adjustments={[]}
         setIsPreview={() => null}
@@ -77,14 +78,14 @@ describe("DisruptionPreview", () => {
         ]}
         exceptionDates={[new Date(2020, 0, 10)]}
       />
-    ).text()
+    )
 
-    expect(text).toMatch("Thursday")
-    expect(text).toMatch("12:30AM – 9:30PM")
+    expect(screen.queryByText("Thursday")).not.toBeNull()
+    expect(screen.queryByText("12:30AM – 9:30PM")).not.toBeNull()
   })
 
   test("includes back to edit link when setIsPreview is provided", () => {
-    const wrapper = mount(
+    const { container } = render(
       <DisruptionPreview
         adjustments={[]}
         setIsPreview={() => null}
@@ -95,11 +96,11 @@ describe("DisruptionPreview", () => {
       />
     )
 
-    expect(wrapper.find("#back-to-edit-link").length).toEqual(1)
+    expect(container.querySelector("#back-to-edit-link")).not.toBeNull()
   })
 
   test("doesn't include back to edit link when setIsPreview is omitted", () => {
-    const wrapper = mount(
+    const { container } = render(
       <DisruptionPreview
         adjustments={[]}
         fromDate={null}
@@ -109,7 +110,7 @@ describe("DisruptionPreview", () => {
       />
     )
 
-    expect(wrapper.find("#back-to-edit-link").length).toEqual(0)
+    expect(container.querySelector("#back-to-edit-link")).toBeNull()
   })
 
   test("create callback is invoked", () => {
@@ -117,7 +118,7 @@ describe("DisruptionPreview", () => {
     const createFn = (args: any) => {
       requests.push(args)
     }
-    const wrapper = mount(
+    const { container } = render(
       <DisruptionPreview
         adjustments={[]}
         fromDate={null}
@@ -127,7 +128,14 @@ describe("DisruptionPreview", () => {
         createFn={createFn}
       />
     )
-    wrapper.find("button#disruption-preview-create").simulate("click")
+    const createButton = container.querySelector(
+      "button#disruption-preview-create"
+    )
+    if (!createButton) {
+      throw new Error("create button not found")
+    }
+
+    fireEvent.click(createButton)
 
     expect(requests.length).toEqual(1)
   })

--- a/assets/tests/disruptions/disruptionSummary.test.tsx
+++ b/assets/tests/disruptions/disruptionSummary.test.tsx
@@ -1,13 +1,12 @@
 import * as React from "react"
-import { mount } from "enzyme"
-import * as renderer from "react-test-renderer"
+import { render, screen } from "@testing-library/react"
 import { DisruptionSummary } from "../../src/disruptions/disruptionSummary"
 
 import Adjustment from "../../src/models/adjustment"
 
 describe("DisruptionSummary", () => {
   test("renders the adjustments onto the page", () => {
-    const summary = (
+    const { container } = render(
       <DisruptionSummary
         adjustments={[
           new Adjustment({ routeId: "route1", sourceLabel: "adjustment1" }),
@@ -16,12 +15,11 @@ describe("DisruptionSummary", () => {
       />
     )
 
-    const testInstance = renderer.create(summary).root
-    expect(testInstance.findAllByType("li").length).toEqual(2)
+    expect(container.querySelectorAll("li").length).toEqual(2)
   })
 
   test("renders the disruption ID if present", () => {
-    const text = mount(
+    render(
       <DisruptionSummary
         disruptionId={"123"}
         adjustments={[
@@ -29,8 +27,8 @@ describe("DisruptionSummary", () => {
           new Adjustment({ routeId: "route2", sourceLabel: "adjustment2" }),
         ]}
       />
-    ).text()
+    )
 
-    expect(text).toMatch("Disruption ID: 123")
+    expect(screen.queryAllByText("Disruption ID: 123")).not.toBeNull()
   })
 })

--- a/assets/tests/disruptions/disruptionTable.test.tsx
+++ b/assets/tests/disruptions/disruptionTable.test.tsx
@@ -1,10 +1,7 @@
 import * as React from "react"
 import { BrowserRouter } from "react-router-dom"
-import { mount } from "enzyme"
-import {
-  DisruptionTable,
-  DisruptionTableHeader,
-} from "../../src/disruptions/disruptionTable"
+import { render, fireEvent, screen } from "@testing-library/react"
+import { DisruptionTable } from "../../src/disruptions/disruptionTable"
 
 const DisruptionTableWithRouter = () => {
   return (
@@ -42,47 +39,57 @@ const DisruptionTableWithRouter = () => {
 
 describe("DisruptionTable", () => {
   test("can sort table by 'stops' or 'dates'", () => {
-    const wrapper = mount(<DisruptionTableWithRouter />)
-    let tableRows = wrapper.find("tbody tr")
+    const { container } = render(<DisruptionTableWithRouter />)
+    let tableRows = container.querySelectorAll("tbody tr")
     expect(tableRows.length).toEqual(3)
-    let firstRow = tableRows.at(0)
-    let firstRowData = firstRow.find("td")
-    expect(firstRowData.at(0).text()).toEqual("Kenmore—Newton Highlands")
-    expect(firstRowData.at(1).text()).toEqual("10/23/2019 - 10/24/2019")
-    expect(firstRowData.at(2).text()).toEqual("Weekends, starting Friday 845")
-    expect(firstRowData.at(3).find("a[href='/disruptions/2']").length).toEqual(
-      1
+    let firstRow = tableRows.item(0)
+    let firstRowData = firstRow.querySelectorAll("td")
+    expect(firstRowData.item(0).textContent).toEqual("Kenmore—Newton Highlands")
+    expect(firstRowData.item(1).textContent).toEqual("10/23/2019 - 10/24/2019")
+    expect(firstRowData.item(2).textContent).toEqual(
+      "Weekends, starting Friday 845"
     )
-    let activeSortToggle = wrapper
-      .find(DisruptionTableHeader)
-      .find({ active: true })
-    expect(activeSortToggle.text()).toEqual("stops")
-    expect(activeSortToggle.props().sortOrder).toEqual("asc")
+    expect(
+      firstRowData.item(3).querySelectorAll("a[href='/disruptions/2']").length
+    ).toEqual(1)
+    let activeSortToggle = container.querySelector(
+      ".m-disruption-table__sortable.asc, .m-disruption-table__sortable.desc"
+    )
+    if (!activeSortToggle) {
+      throw new Error("active sort toggle not found")
+    }
+    expect(activeSortToggle.textContent).toEqual("stops")
+    expect(activeSortToggle.className).toMatch("asc")
 
-    activeSortToggle.find(".m-disruption-table__sortable").simulate("click")
-    tableRows = wrapper.find("tbody tr")
-    firstRow = tableRows.at(0)
-    firstRowData = firstRow.find("td")
+    fireEvent.click(activeSortToggle)
+    tableRows = container.querySelectorAll("tbody tr")
+    firstRow = tableRows.item(0)
+    firstRowData = firstRow.querySelectorAll("td")
 
-    activeSortToggle = wrapper
-      .find(DisruptionTableHeader)
-      .find({ active: true })
-    expect(activeSortToggle.text()).toEqual("stops")
-    expect(activeSortToggle.props().sortOrder).toEqual("desc")
-    expect(firstRowData.at(0).text()).toEqual("")
+    activeSortToggle = container.querySelector(
+      ".m-disruption-table__sortable.asc, .m-disruption-table__sortable.desc"
+    )
+    if (!activeSortToggle) {
+      throw new Error("active sort toggle not found")
+    }
+    expect(activeSortToggle.textContent).toEqual("stops")
+    expect(activeSortToggle.className).toMatch("desc")
+    expect(firstRowData.item(0).textContent).toEqual("")
 
-    wrapper
-      .find(".m-disruption-table__sortable[children='dates']")
-      .simulate("click")
-    activeSortToggle = wrapper
-      .find(DisruptionTableHeader)
-      .find({ active: true })
-    tableRows = wrapper.find("tbody tr")
-    firstRow = tableRows.at(0)
-    firstRowData = firstRow.find("td")
-    expect(activeSortToggle.text()).toEqual("dates")
-    expect(activeSortToggle.props().sortOrder).toEqual("asc")
-    expect(firstRowData.at(0).text()).toEqual("Kenmore—Newton Highlands")
-    expect(firstRowData.at(1).text()).toEqual("9/22/2019 - 10/22/2019")
+    const dateSort = screen.getByText("dates")
+    fireEvent.click(dateSort)
+    activeSortToggle = container.querySelector(
+      ".m-disruption-table__sortable.asc, .m-disruption-table__sortable.desc"
+    )
+    if (!activeSortToggle) {
+      throw new Error("active sort toggle not found")
+    }
+    tableRows = container.querySelectorAll("tbody tr")
+    firstRow = tableRows.item(0)
+    firstRowData = firstRow.querySelectorAll("td")
+    expect(activeSortToggle.textContent).toEqual("dates")
+    expect(activeSortToggle.className).toMatch("asc")
+    expect(firstRowData.item(0).textContent).toEqual("Kenmore—Newton Highlands")
+    expect(firstRowData.item(1).textContent).toEqual("9/22/2019 - 10/22/2019")
   })
 })

--- a/assets/tests/disruptions/disruptionTimePicker.test.tsx
+++ b/assets/tests/disruptions/disruptionTimePicker.test.tsx
@@ -1,4 +1,4 @@
-import { mount } from "enzyme"
+import { render, fireEvent } from "@testing-library/react"
 import * as React from "react"
 
 import { DayOfWeekTimeRanges } from "../../src/disruptions/time"
@@ -28,334 +28,364 @@ const DisruptionTimePickerWithProps = ({}): JSX.Element => {
 
 describe("DisruptionTimePicker", () => {
   test("can set the date range", () => {
-    const wrapper = mount(<DisruptionTimePickerWithProps />)
+    const { container } = render(<DisruptionTimePickerWithProps />)
 
-    wrapper
-      .find("#disruption-date-range-start")
-      .find("input")
-      .simulate("change", { target: { value: "01/01/2020" } })
-    wrapper
-      .find("#disruption-date-range-end")
-      .find("input")
-      .simulate("change", { target: { value: "01/02/2020" } })
+    const rangeStartInput = container.querySelector(
+      "#disruption-date-range-start"
+    )
+    if (!rangeStartInput) {
+      throw new Error("range start input not found")
+    }
+    fireEvent.change(rangeStartInput, { target: { value: "01/01/2020" } })
+    const rangeEndInput = container.querySelector("#disruption-date-range-end")
+    if (!rangeEndInput) {
+      throw new Error("range end input not found")
+    }
+    fireEvent.change(rangeEndInput, { target: { value: "01/02/2020" } })
 
     expect(
-      wrapper
-        .find("#disruption-date-range-start")
-        .find("input")
-        .props().value
+      (container.querySelector(
+        "#disruption-date-range-start"
+      ) as HTMLInputElement).value
     ).toEqual("01/01/2020")
 
     expect(
-      wrapper
-        .find("#disruption-date-range-end")
-        .find("input")
-        .props().value
+      (container.querySelector(
+        "#disruption-date-range-end"
+      ) as HTMLInputElement).value
     ).toEqual("01/02/2020")
   })
 
   test("selecting a day of the week enables updating time range", () => {
-    const wrapper = mount(<DisruptionTimePickerWithProps />)
+    const { container } = render(<DisruptionTimePickerWithProps />)
 
-    wrapper.find("input#day-of-week-M").simulate("change")
+    const mondayCheck = container.querySelector("input#day-of-week-M")
+    if (!mondayCheck) {
+      throw new Error("Monday checkbox not found")
+    }
+    fireEvent.click(mondayCheck)
 
-    expect(
-      wrapper.find(DisruptionTimePicker).props().disruptionDaysOfWeek
-    ).toStrictEqual([[null, null], null, null, null, null, null, null])
+    const mondayStartTypeCheck = container.querySelector(
+      "input#time-of-day-start-type-0"
+    )
+    if (!mondayStartTypeCheck) {
+      throw new Error("Monday start time type checkbox not found")
+    }
+    fireEvent.click(mondayStartTypeCheck)
 
-    wrapper
-      .find("input#time-of-day-start-type-0")
-      .simulate("change", { target: { checked: false } })
+    const mondayEndTypeCheck = container.querySelector(
+      "input#time-of-day-end-type-0"
+    )
+    if (!mondayEndTypeCheck) {
+      throw new Error("Monday end time type checkbox not found")
+    }
+    fireEvent.click(mondayEndTypeCheck)
 
-    wrapper
-      .find("input#time-of-day-end-type-0")
-      .simulate("change", { target: { checked: false } })
+    const mondayStartHourSelect = container.querySelector(
+      "select#time-of-day-start-hour-0"
+    )
+    if (!mondayStartHourSelect) {
+      throw new Error("Monday start hour select not found")
+    }
+    fireEvent.change(mondayStartHourSelect, { target: { value: "9" } })
 
-    expect(
-      wrapper.find(DisruptionTimePicker).props().disruptionDaysOfWeek
-    ).toStrictEqual([
-      [
-        { hour: "12", minute: "00", period: "AM" },
-        { hour: "12", minute: "00", period: "AM" },
-      ],
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-    ])
+    const mondayEndMinuteSelect = container.querySelector(
+      "select#time-of-day-end-minute-0"
+    )
+    if (!mondayEndMinuteSelect) {
+      throw new Error("Monday end minute select not found")
+    }
+    fireEvent.change(mondayEndMinuteSelect, { target: { value: "30" } })
 
-    wrapper
-      .find("select#time-of-day-start-hour-0")
-      .simulate("change", { target: { value: "9" } })
+    const mondayEndPeriodSelect = container.querySelector(
+      "select#time-of-day-end-period-0"
+    )
+    if (!mondayEndPeriodSelect) {
+      throw new Error("Monday end period select not found")
+    }
+    fireEvent.change(mondayEndPeriodSelect, { target: { value: "PM" } })
 
-    wrapper
-      .find("select#time-of-day-end-minute-0")
-      .simulate("change", { target: { value: "30" } })
+    fireEvent.click(mondayEndTypeCheck)
 
-    wrapper
-      .find("select#time-of-day-end-period-0")
-      .simulate("change", { target: { value: "PM" } })
-
-    expect(
-      wrapper.find(DisruptionTimePicker).props().disruptionDaysOfWeek
-    ).toStrictEqual([
-      [
-        { hour: "9", minute: "00", period: "AM" },
-        { hour: "12", minute: "30", period: "PM" },
-      ],
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-    ])
-
-    wrapper
-      .find("input#time-of-day-end-type-0")
-      .simulate("change", { target: { checked: true } })
+    fireEvent.click(mondayCheck)
 
     expect(
-      wrapper.find(DisruptionTimePicker).props().disruptionDaysOfWeek
-    ).toStrictEqual([
-      [{ hour: "9", minute: "00", period: "AM" }, null],
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-    ])
-
-    wrapper.find("input#day-of-week-M").simulate("change")
-
+      container.querySelector("select#time-of-day-start-hour-0")
+    ).toBeNull()
     expect(
-      wrapper.find(DisruptionTimePicker).props().disruptionDaysOfWeek
-    ).toStrictEqual([null, null, null, null, null, null, null])
+      container.querySelector("select#time-of-day-start-minute-0")
+    ).toBeNull()
+    expect(
+      container.querySelector("select#time-of-day-start-period-0")
+    ).toBeNull()
+    expect(container.querySelector("select#time-of-day-end-hour-0")).toBeNull()
+    expect(
+      container.querySelector("select#time-of-day-end-minute-0")
+    ).toBeNull()
+    expect(
+      container.querySelector("select#time-of-day-end-period-0")
+    ).toBeNull()
   })
 
   test("enabling date exceptions shows a field for entering a date", () => {
-    const wrapper = mount(<DisruptionTimePickerWithProps />)
+    const { container } = render(<DisruptionTimePickerWithProps />)
 
-    wrapper
-      .find("#date-exceptions-yes")
-      .find("input")
-      .simulate("change")
+    const dateExceptionsCheck = container.querySelector("#date-exceptions-yes")
+    if (!dateExceptionsCheck) {
+      throw new Error('date exception "yes" checkbox not found')
+    }
+    fireEvent.click(dateExceptionsCheck)
 
-    expect(wrapper.exists("#date-exception-new")).toBe(true)
-    expect(wrapper.exists("#date-exception-add-link")).toBe(false)
+    expect(container.querySelector("#date-exception-new")).not.toBeNull()
+    expect(container.querySelector("#date-exception-add-link")).toBeNull()
   })
 
   test("entering one date exception allows adding another", () => {
-    const wrapper = mount(<DisruptionTimePickerWithProps />)
+    const { container } = render(<DisruptionTimePickerWithProps />)
 
-    wrapper
-      .find("#date-exceptions-yes")
-      .find("input")
-      .simulate("change")
+    const dateExceptionsCheck = container.querySelector("#date-exceptions-yes")
+    if (!dateExceptionsCheck) {
+      throw new Error('date exception "yes" checkbox not found')
+    }
+    fireEvent.click(dateExceptionsCheck)
 
-    wrapper
-      .find("#date-exception-new")
-      .find("input")
-      .simulate("change", { target: { value: "01/01/2020" } })
+    const newDateExceptionInput = container.querySelector(
+      "#date-exception-new input"
+    )
+    if (!newDateExceptionInput) {
+      throw new Error("new date exception input not found")
+    }
+    fireEvent.change(newDateExceptionInput, { target: { value: "01/01/2020" } })
 
-    expect(wrapper.exists("#date-exception-add-link")).toBe(true)
+    expect(container.querySelector("#date-exception-add-link")).not.toBeNull()
 
-    wrapper.find("#date-exception-add-link").simulate("click")
+    const addExceptionLink = container.querySelector("#date-exception-add-link")
+    if (!addExceptionLink) {
+      throw new Error("add exception link not found")
+    }
+    fireEvent.click(addExceptionLink)
 
-    expect(wrapper.exists("#date-exception-new")).toBe(true)
+    expect(container.querySelector("#date-exception-new")).not.toBeNull()
   })
 
   test("can delete a not-yet-added exception date field", () => {
-    const wrapper = mount(<DisruptionTimePickerWithProps />)
+    const { container } = render(<DisruptionTimePickerWithProps />)
 
-    wrapper
-      .find("#date-exceptions-yes")
-      .find("input")
-      .simulate("change")
+    const dateExceptionsCheck = container.querySelector("#date-exceptions-yes")
+    if (!dateExceptionsCheck) {
+      throw new Error('date exception "yes" checkbox not found')
+    }
+    fireEvent.click(dateExceptionsCheck)
 
-    wrapper
-      .find("#date-exception-new")
-      .find("button")
-      .simulate("click")
+    const deleteExceptionButton = container.querySelector(
+      "#date-exception-new button"
+    )
+    if (!deleteExceptionButton) {
+      throw new Error("delete exception button not found")
+    }
+    fireEvent.click(deleteExceptionButton)
 
-    expect(wrapper.exists("#date-exception-new")).toBe(false)
+    expect(container.querySelector("#date-exception-new")).toBeNull()
     expect(
-      wrapper
-        .find("#date-exceptions-yes")
-        .find("input")
-        .props().checked
+      (container.querySelector("#date-exceptions-yes") as HTMLInputElement)
+        .checked
     ).toBe(false)
     expect(
-      wrapper
-        .find("#date-exceptions-no")
-        .find("input")
-        .props().checked
+      (container.querySelector("#date-exceptions-no") as HTMLInputElement)
+        .checked
     ).toBe(true)
   })
 
   test("safely ignores leaving the new exception date input empty", () => {
-    const wrapper = mount(<DisruptionTimePickerWithProps />)
+    const { container } = render(<DisruptionTimePickerWithProps />)
 
-    wrapper
-      .find("#date-exceptions-yes")
-      .find("input")
-      .simulate("change")
+    const dateExceptionsCheck = container.querySelector("#date-exceptions-yes")
+    if (!dateExceptionsCheck) {
+      throw new Error('date exception "yes" checkbox not found')
+    }
+    fireEvent.click(dateExceptionsCheck)
 
-    wrapper
-      .find("#date-exception-new")
-      .find("input")
-      .simulate("change", { target: { value: "invalid" } })
+    const newDateExceptionInput = container.querySelector(
+      "#date-exception-new input"
+    )
+    if (!newDateExceptionInput) {
+      throw new Error("new date exception input not found")
+    }
+    fireEvent.change(newDateExceptionInput, { target: { value: "invalid" } })
   })
 
   test("can delete the only exception date", () => {
-    const wrapper = mount(<DisruptionTimePickerWithProps />)
+    const { container } = render(<DisruptionTimePickerWithProps />)
 
-    wrapper
-      .find("#date-exceptions-yes")
-      .find("input")
-      .simulate("change")
+    const dateExceptionsCheck = container.querySelector("#date-exceptions-yes")
+    if (!dateExceptionsCheck) {
+      throw new Error('date exception "yes" checkbox not found')
+    }
+    fireEvent.click(dateExceptionsCheck)
 
-    wrapper
-      .find("#date-exception-new")
-      .find("input")
-      .simulate("change", { target: { value: "01/01/2020" } })
+    const newDateExceptionInput = container.querySelector(
+      "#date-exception-new input"
+    )
+    if (!newDateExceptionInput) {
+      throw new Error("new date exception input not found")
+    }
+    fireEvent.change(newDateExceptionInput, { target: { value: "01/01/2020" } })
 
-    wrapper
-      .find("#date-exception-row-0")
-      .find("button")
-      .simulate("click")
+    const deleteExceptionButton = container.querySelector(
+      "#date-exception-row-0 button"
+    )
+    if (!deleteExceptionButton) {
+      throw new Error("delete exception button not found")
+    }
+    fireEvent.click(deleteExceptionButton)
 
-    expect(wrapper.exists("#date-exception-row-0")).toBe(false)
+    expect(container.querySelector("#date-exception-row-0")).toBeNull()
     expect(
-      wrapper
-        .find("#date-exceptions-yes")
-        .find("input")
-        .props().checked
+      (container.querySelector("#date-exceptions-yes") as HTMLInputElement)
+        .checked
     ).toBe(false)
     expect(
-      wrapper
-        .find("#date-exceptions-no")
-        .find("input")
-        .props().checked
+      (container.querySelector("#date-exceptions-no") as HTMLInputElement)
+        .checked
     ).toBe(true)
   })
 
   test("can edit and then delete one of several exception dates", () => {
-    const wrapper = mount(<DisruptionTimePickerWithProps />)
+    const { container } = render(<DisruptionTimePickerWithProps />)
 
-    wrapper
-      .find("#date-exceptions-yes")
-      .find("input")
-      .simulate("change")
+    const dateExceptionsCheck = container.querySelector("#date-exceptions-yes")
+    if (!dateExceptionsCheck) {
+      throw new Error('date exception "yes" checkbox not found')
+    }
+    fireEvent.click(dateExceptionsCheck)
 
-    wrapper
-      .find("#date-exception-new")
-      .find("input")
-      .simulate("change", { target: { value: "01/01/2020" } })
+    let newDateExceptionInput = container.querySelector(
+      "#date-exception-new input"
+    )
+    if (!newDateExceptionInput) {
+      throw new Error("new date exception input not found")
+    }
+    fireEvent.change(newDateExceptionInput, { target: { value: "01/01/2020" } })
 
     expect(
-      wrapper
-        .find("#date-exception-row-0")
-        .find("input")
-        .props().value
+      (container.querySelector(
+        "#date-exception-row-0 input"
+      ) as HTMLInputElement).value
     ).toEqual("01/01/2020")
 
-    wrapper
-      .find("#date-exception-row-0")
-      .find("input")
-      .simulate("change", { target: { value: "01/05/2020" } })
+    const dateException0Input = container.querySelector(
+      "#date-exception-row-0 input"
+    )
+    if (!dateException0Input) {
+      throw new Error("date exception row 0 input not found")
+    }
+    fireEvent.change(dateException0Input, { target: { value: "01/05/2020" } })
 
     expect(
-      wrapper
-        .find("#date-exception-row-0")
-        .find("input")
-        .props().value
+      (container.querySelector(
+        "#date-exception-row-0 input"
+      ) as HTMLInputElement).value
     ).toEqual("01/05/2020")
 
-    wrapper.find("#date-exception-add-link").simulate("click")
+    const addDateExceptionLink = container.querySelector(
+      "#date-exception-add-link"
+    )
+    if (!addDateExceptionLink) {
+      throw new Error("add date exception link not found")
+    }
+    fireEvent.click(addDateExceptionLink)
 
-    wrapper
-      .find("#date-exception-new")
-      .find("input")
-      .simulate("change", { target: { value: "01/02/2020" } })
+    newDateExceptionInput = container.querySelector("#date-exception-new input")
+    if (!newDateExceptionInput) {
+      throw new Error("new date exception input not found")
+    }
+    fireEvent.change(newDateExceptionInput, { target: { value: "01/02/2020" } })
 
-    wrapper
-      .find("#date-exception-row-0")
-      .find("button")
-      .simulate("click")
+    const deleteExceptionButton = container.querySelector(
+      "#date-exception-row-0 button"
+    )
+    if (!deleteExceptionButton) {
+      throw new Error("delete exception button not found")
+    }
+    fireEvent.click(deleteExceptionButton)
 
-    expect(wrapper.exists("#date-exception-row-0")).toBe(true)
-    expect(wrapper.exists("#date-exception-row-1")).toBe(false)
+    expect(container.querySelector("#date-exception-row-0")).not.toBeNull()
+    expect(container.querySelector("#date-exception-row-1")).toBeNull()
     expect(
-      wrapper
-        .find("#date-exceptions-yes")
-        .find("input")
-        .props().checked
+      (container.querySelector("#date-exceptions-yes") as HTMLInputElement)
+        .checked
     ).toBe(true)
     expect(
-      wrapper
-        .find("#date-exceptions-no")
-        .find("input")
-        .props().checked
+      (container.querySelector("#date-exceptions-no") as HTMLInputElement)
+        .checked
     ).toBe(false)
   })
 
   test("can delete an exception date by deleting the text in the input", () => {
-    const wrapper = mount(<DisruptionTimePickerWithProps />)
+    const { container } = render(<DisruptionTimePickerWithProps />)
 
-    wrapper
-      .find("#date-exceptions-yes")
-      .find("input")
-      .simulate("change")
+    const dateExceptionsCheck = container.querySelector("#date-exceptions-yes")
+    if (!dateExceptionsCheck) {
+      throw new Error('date exception "yes" checkbox not found')
+    }
+    fireEvent.click(dateExceptionsCheck)
 
-    wrapper
-      .find("#date-exception-new")
-      .find("input")
-      .simulate("change", { target: { value: "01/01/2020" } })
+    const newDateExceptionInput = container.querySelector(
+      "#date-exception-new input"
+    )
+    if (!newDateExceptionInput) {
+      throw new Error("new date exception input not found")
+    }
+    fireEvent.change(newDateExceptionInput, { target: { value: "01/01/2020" } })
 
     expect(
-      wrapper
-        .find("#date-exception-row-0")
-        .find("input")
-        .props().value
+      (container.querySelector(
+        "#date-exception-row-0 input"
+      ) as HTMLInputElement).value
     ).toEqual("01/01/2020")
 
-    wrapper
-      .find("#date-exception-row-0")
-      .find("input")
-      .simulate("change", { target: { value: "" } })
+    const dateException0Input = container.querySelector(
+      "#date-exception-row-0 input"
+    )
+    if (!dateException0Input) {
+      throw new Error("date exception row 0 input not found")
+    }
+    fireEvent.change(dateException0Input, { target: { value: "" } })
 
-    expect(wrapper.exists("#date-exception-row-0")).toBe(false)
+    expect(container.querySelector("#date-exception-row-0")).toBeNull()
   })
 
   test("changing date exceptions back to 'no' clears selections", () => {
-    const wrapper = mount(<DisruptionTimePickerWithProps />)
+    const { container } = render(<DisruptionTimePickerWithProps />)
 
-    wrapper
-      .find("#date-exceptions-yes")
-      .find("input")
-      .simulate("change")
+    const dateExceptionsYesCheck = container.querySelector(
+      "#date-exceptions-yes"
+    )
+    if (!dateExceptionsYesCheck) {
+      throw new Error('date exception "yes" checkbox not found')
+    }
+    fireEvent.click(dateExceptionsYesCheck)
 
-    wrapper
-      .find("#date-exception-new")
-      .find("input")
-      .simulate("change", { target: { value: "01/01/2020" } })
+    const newDateExceptionInput = container.querySelector(
+      "#date-exception-new input"
+    )
+    if (!newDateExceptionInput) {
+      throw new Error("new date exception input not found")
+    }
+    fireEvent.change(newDateExceptionInput, { target: { value: "01/01/2020" } })
 
     expect(
-      wrapper
-        .find("#date-exception-row-0")
-        .find("input")
-        .props().value
+      (container.querySelector(
+        "#date-exception-row-0 input"
+      ) as HTMLInputElement).value
     ).toEqual("01/01/2020")
 
-    wrapper
-      .find("#date-exceptions-no")
-      .find("input")
-      .simulate("change")
+    const dateExceptionsNoCheck = container.querySelector("#date-exceptions-no")
+    if (!dateExceptionsNoCheck) {
+      throw new Error('date exception "no" checkbox not found')
+    }
+    fireEvent.click(dateExceptionsNoCheck)
 
-    expect(wrapper.exists("#date-exception-row-0")).toBe(false)
+    expect(container.querySelector("#date-exception-row-0")).toBeNull()
   })
 })

--- a/assets/tests/header.test.tsx
+++ b/assets/tests/header.test.tsx
@@ -1,18 +1,17 @@
 import * as React from "react"
-import * as renderer from "react-test-renderer"
+import { render } from "@testing-library/react"
 import Header from "../src/header"
 
 describe("Header", () => {
   test("includes link to homepage when includeHomeLink set", () => {
-    const testInstance = renderer.create(<Header includeHomeLink={true} />).root
+    const { container } = render(<Header includeHomeLink={true} />)
 
-    expect(testInstance.findAllByType("a").length).toBe(1)
+    expect(container.querySelectorAll("a").length).toBe(1)
   })
 
   test("doesn't include link to homepage when includeHomeLink not set", () => {
-    const testInstance = renderer.create(<Header includeHomeLink={false} />)
-      .root
+    const { container } = render(<Header includeHomeLink={false} />)
 
-    expect(testInstance.findAllByType("a").length).toBe(0)
+    expect(container.querySelectorAll("a").length).toBe(0)
   })
 })

--- a/assets/tests/loading.test.tsx
+++ b/assets/tests/loading.test.tsx
@@ -1,11 +1,11 @@
 import * as React from "react"
-import { mount } from "enzyme"
+import { render, screen } from "@testing-library/react"
 import Loading from "../src/loading"
 
 describe("Loading", () => {
   test('says "Loading"', () => {
-    const text = mount(<Loading />).text()
+    render(<Loading />)
 
-    expect(text).toMatch("Loading")
+    expect(screen.queryByText("Loading…")).not.toBeNull()
   })
 })

--- a/assets/tests/setup.ts
+++ b/assets/tests/setup.ts
@@ -1,3 +1,0 @@
-import { configure } from "enzyme"
-import Adapter from "enzyme-adapter-react-16"
-configure({ adapter: new Adapter() })

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -5,7 +5,7 @@
     /* Basic Options */
     "target": "es5",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "es2015",                    /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["dom", "es2015"],              /* Specify library files to be included in the compilation. */
+    "lib": ["dom", "es2017"],              /* Specify library files to be included in the compilation. */
     // "allowJs": true,                    /* Allow javascript files to be compiled. */
     // "checkJs": true,                    /* Report errors in .js files. */
     "jsx": "react",                        /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Transition existing Arrow tests from Enzyme to React Testing Library](https://app.asana.com/0/584764604969369/1170122874093785/f)

This is mostly pretty rote replacement of Enzyme with React Testing Library. The one bit I'm still not super happy with is the test `selecting a day of the week enables updating time range`. It used to do a lot of asserting based on the props of the component to make sure it was doing the right thing with the day of week time ranges. However, React Testing Library is a lot more opinionated about not really letting you pry into the contents of React components and instead preferring you to strictly test the front-end. I'm open to suggestions on how to re-do that test in a nicer way if anyone has any.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
