### PR TITLE
fix: Can't modify relationships if disruption start date is in past

### DIFF
--- a/test/arrow/disruption_test.exs
+++ b/test/arrow/disruption_test.exs
@@ -363,5 +363,53 @@ defmodule Arrow.DisruptionTest do
       refute changeset.valid?
       assert %{exceptions: ["can't be deleted from the past."]} = errors_on(changeset)
     end
+
+    test "Can't change days of week for disruption in past" do
+      disruption = build_disruption()
+
+      disruption =
+        put_in(disruption.days_of_week, [%Arrow.Disruption.DayOfWeek{day_name: "tuesday"}])
+
+      disruption = put_in(disruption.start_date, ~D[2020-04-01])
+
+      now = DateTime.from_naive!(~N[2020-04-15 12:00:00], "America/New_York")
+
+      changeset =
+        Disruption.changeset_for_update(
+          disruption,
+          %{"days_of_week" => [%{"day_name" => "monday"}]},
+          now
+        )
+
+      refute changeset.valid?
+
+      assert %{days_of_week: ["can't be changed because start date is in the past."]} =
+               errors_on(changeset)
+    end
+
+    test "Can't change trip short names for disruption in past" do
+      disruption = build_disruption()
+
+      disruption =
+        put_in(disruption.trip_short_names, [
+          %Arrow.Disruption.TripShortName{trip_short_name: "short"}
+        ])
+
+      disruption = put_in(disruption.start_date, ~D[2020-04-01])
+
+      now = DateTime.from_naive!(~N[2020-04-15 12:00:00], "America/New_York")
+
+      changeset =
+        Disruption.changeset_for_update(
+          disruption,
+          %{"trip_short_names" => []},
+          now
+        )
+
+      refute changeset.valid?
+
+      assert %{trip_short_names: ["can't be changed because start date is in the past."]} =
+               errors_on(changeset)
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Arrow - can't change days of week or trip short names, for disruption in past](https://app.asana.com/0/584764604969369/1172248816606377)

I realized another thing that should be immutable in the past: if the disruption's start date is in the past, then we shouldn't be able to change the days of week or trip short names on the disruption.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
