### PR TITLE
chore: remove authentication on Disruption index route

### DIFF
--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -62,8 +62,14 @@ defmodule ArrowWeb.Router do
   scope "/api", ArrowWeb.API do
     pipe_through([:redirect_prod_http, :api, :auth, :ensure_auth, :ensure_arrow_group])
 
-    resources("/disruptions", DisruptionController, only: [:index, :show, :create, :update])
+    resources("/disruptions", DisruptionController, only: [:show, :create, :update])
     resources("/adjustments", AdjustmentController, only: [:index])
+  end
+
+  scope "/api", ArrowWeb.API do
+    pipe_through([:redirect_prod_http, :api])
+
+    resources("/disruptions", DisruptionController, only: [:index])
   end
 
   # Other scopes may use custom stacks.

--- a/test/arrow_web/controllers/api/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/api/disruption_controller_test.exs
@@ -12,12 +12,10 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
   end
 
   describe "index/2" do
-    @tag :authenticated
     test "returns 200", %{conn: conn} do
       assert %{status: 200} = get(conn, "/api/disruptions")
     end
 
-    @tag :authenticated
     test "includes all fields by default", %{conn: conn} do
       insert_disruptions()
 
@@ -68,7 +66,6 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
       end)
     end
 
-    @tag :authenticated
     test "can include only specified relationships", %{conn: conn} do
       insert_disruptions()
 
@@ -132,7 +129,6 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
                     } = res
     end
 
-    @tag :authenticated
     test "can filter by dates", %{conn: conn} do
       {%{id: disruption_1_id}, %{id: disruption_2_id}} = insert_disruptions()
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 move arrow /disruptions route out of authenticated pipeline](https://app.asana.com/0/584764604969369/1183529627515231/f)
