### PR TITLE
Delete disruption

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -28,7 +28,7 @@ const apiSend = async <T, E>({
   errorParser,
 }: {
   url: string
-  method: "POST" | "PATCH"
+  method: "POST" | "PATCH" | "DELETE"
   json: any
   successParser: (json: any) => T
   errorParser: (json: any) => E
@@ -40,10 +40,15 @@ const apiSend = async <T, E>({
     body: json,
   })
   redirectIfUnauthorized(response.status)
+
+  if (response.status === 204) {
+    return { ok: successParser(null) }
+  }
+
   const responseData = await response.json()
   if (response.status === 200 || response.status === 201) {
     return { ok: successParser(responseData) }
-  } else if (response.status === 400) {
+  } else if (Math.floor(response.status / 100) === 4) {
     return { error: errorParser(responseData) }
   }
 

--- a/assets/src/disruptions/viewDisruption.tsx
+++ b/assets/src/disruptions/viewDisruption.tsx
@@ -1,7 +1,9 @@
 import * as React from "react"
-import { RouteComponentProps, Link } from "react-router-dom"
+import { RouteComponentProps, Link, Redirect } from "react-router-dom"
+import Alert from "react-bootstrap/Alert"
+import Button from "react-bootstrap/Button"
 
-import { apiGet } from "../api"
+import { apiGet, apiSend } from "../api"
 
 import Header from "../header"
 import Loading from "../loading"
@@ -9,7 +11,7 @@ import { DisruptionPreview } from "./disruptionPreview"
 import { fromDaysOfWeek } from "./time"
 
 import Disruption from "../models/disruption"
-import { JsonApiResponse, toModelObject } from "../jsonApi"
+import { JsonApiResponse, toModelObject, parseErrors } from "../jsonApi"
 
 interface TParams {
   id: string
@@ -33,6 +35,46 @@ const EditDisruptionButton = ({
   )
 }
 
+interface DeleteDisruptionButtonProps {
+  disruptionId: string
+  setDoRedirect: React.Dispatch<React.SetStateAction<boolean>>
+  setDeletionErrors: React.Dispatch<React.SetStateAction<string[]>>
+}
+
+const DeleteDisruptionButton = ({
+  disruptionId,
+  setDoRedirect,
+  setDeletionErrors,
+}: DeleteDisruptionButtonProps): JSX.Element => {
+  return (
+    <Button
+      variant="light"
+      onClick={async () => {
+        if (window.confirm("Really delete this disruption?")) {
+          const result = await apiSend({
+            url: "/api/disruptions/" + encodeURIComponent(disruptionId),
+            method: "DELETE",
+            json: "",
+            successParser: () => {
+              return true
+            },
+            errorParser: parseErrors,
+          })
+
+          if (result.ok) {
+            setDoRedirect(true)
+          } else if (result.error) {
+            setDeletionErrors(result.error)
+          }
+        }
+      }}
+      id="delete-disruption-button"
+    >
+      delete disruption
+    </Button>
+  )
+}
+
 const ViewDisruption = ({
   match,
 }: RouteComponentProps<TParams>): JSX.Element => {
@@ -49,6 +91,8 @@ const ViewDisruptionForm = ({
   const [disruption, setDisruption] = React.useState<
     Disruption | "error" | null
   >(null)
+  const [doRedirect, setDoRedirect] = React.useState<boolean>(false)
+  const [deletionErrors, setDeletionErrors] = React.useState<string[]>([])
 
   React.useEffect(() => {
     apiGet<JsonApiResponse>({
@@ -64,6 +108,10 @@ const ViewDisruptionForm = ({
     })
   }, [disruptionId])
 
+  if (doRedirect) {
+    return <Redirect to={`/`} />
+  }
+
   if (disruption && disruption !== "error" && disruption.id) {
     const exceptionDates = disruption.exceptions
       .map((exception) => exception.excludedDate)
@@ -78,6 +126,15 @@ const ViewDisruptionForm = ({
       return (
         <div>
           <Header />
+          {deletionErrors.length > 0 && (
+            <Alert variant="danger">
+              <ul>
+                {deletionErrors.map((err) => (
+                  <li key={err}>{err} </li>
+                ))}
+              </ul>
+            </Alert>
+          )}
           <DisruptionPreview
             disruptionId={disruption.id}
             adjustments={disruption.adjustments}
@@ -86,7 +143,19 @@ const ViewDisruptionForm = ({
             exceptionDates={exceptionDates}
             disruptionDaysOfWeek={disruptionDaysOfWeek}
           />
-          <EditDisruptionButton disruptionId={disruption.id} />
+          <div>
+            <EditDisruptionButton disruptionId={disruption.id} />
+          </div>
+          {disruption.startDate &&
+            disruption.startDate >= new Date(new Date().toDateString()) && (
+              <div>
+                <DeleteDisruptionButton
+                  disruptionId={disruption.id}
+                  setDoRedirect={setDoRedirect}
+                  setDeletionErrors={setDeletionErrors}
+                />
+              </div>
+            )}
         </div>
       )
     } else {

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -51,6 +51,26 @@ describe("apiSend", () => {
     })
   })
 
+  test("handles 204 response", (done) => {
+    window.fetch = () =>
+      Promise.resolve({
+        status: 204,
+      } as Response)
+
+    const successParse = jest.fn(() => "success")
+    apiSend({
+      url: "/",
+      method: "DELETE",
+      json: "",
+      successParser: successParse,
+      errorParser: () => "error",
+    }).then((parsed) => {
+      expect(successParse).toHaveBeenCalledWith(null)
+      expect(parsed).toEqual({ ok: "success" })
+      done()
+    })
+  })
+
   test("parses error response", (done) => {
     mockFetch(400, { data: "error" })
     const errorParse = jest.fn(() => "error")

--- a/assets/tests/disruptions/viewDisruption.test.tsx
+++ b/assets/tests/disruptions/viewDisruption.test.tsx
@@ -2,8 +2,12 @@ import { createBrowserHistory } from "history"
 import * as React from "react"
 import { BrowserRouter } from "react-router-dom"
 import { act } from "react-dom/test-utils"
+import { MemoryRouter, Route, Switch } from "react-router-dom"
 import * as ReactDOM from "react-dom"
 import * as api from "../../src/api"
+
+import { render, fireEvent, screen } from "@testing-library/react"
+import { waitForElementToBeRemoved } from "@testing-library/dom"
 
 import ViewDisruption from "../../src/disruptions/viewDisruption"
 import Adjustment from "../../src/models/adjustment"
@@ -244,5 +248,223 @@ describe("ViewDisruption", () => {
     expect(document.body.textContent).toMatch(
       "Error parsing day of week information."
     )
+  })
+
+  test("doesn't display delete button for disruption that started in the past", async () => {
+    let startDate = new Date()
+    startDate.setTime(startDate.getTime() - 24 * 60 * 60 * 1000)
+    startDate = new Date(startDate.toDateString())
+
+    const endDate = new Date(new Date().toDateString())
+
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
+      return Promise.resolve(
+        new Disruption({
+          id: "1",
+          startDate,
+          endDate,
+          adjustments: [
+            new Adjustment({
+              id: "1",
+              routeId: "Green-D",
+              source: "gtfs_creator",
+              sourceLabel: "NewtonHighlandsKenmore",
+            }),
+          ],
+          daysOfWeek: [
+            new DayOfWeek({
+              id: "1",
+              startTime: "20:45:00",
+              dayName: "friday",
+            }),
+          ],
+          exceptions: [],
+          tripShortNames: [],
+        })
+      )
+    })
+
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/1"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/"
+            component={ViewDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    const deleteButton = container.querySelector("#delete-disruption-button")
+
+    expect(deleteButton).toBeNull()
+  })
+
+  test("can delete a disruption", async () => {
+    let startDate = new Date()
+    startDate.setTime(startDate.getTime() + 24 * 60 * 60 * 1000)
+    startDate = new Date(startDate.toDateString())
+
+    let endDate = new Date()
+    startDate.setTime(startDate.getTime() + 2 * 24 * 60 * 60 * 1000)
+    endDate = new Date(endDate.toDateString())
+
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
+      return Promise.resolve(
+        new Disruption({
+          id: "1",
+          startDate,
+          endDate,
+          adjustments: [
+            new Adjustment({
+              id: "1",
+              routeId: "Green-D",
+              source: "gtfs_creator",
+              sourceLabel: "NewtonHighlandsKenmore",
+            }),
+          ],
+          daysOfWeek: [
+            new DayOfWeek({
+              id: "1",
+              startTime: "20:45:00",
+              dayName: "friday",
+            }),
+          ],
+          exceptions: [],
+          tripShortNames: [],
+        })
+      )
+    })
+
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/1"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/"
+            component={ViewDisruption}
+          />
+          <Route exact={true} path="/" render={() => <div>Success!!!</div>} />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    const deleteButton = container.querySelector(
+      "#delete-disruption-button"
+    ) as Element
+
+    const apiSendSpy = jest
+      .spyOn(api, "apiSend")
+      .mockImplementationOnce(({ successParser }) => {
+        return Promise.resolve({
+          ok: successParser(null),
+        })
+      })
+
+    jest.spyOn(window, "confirm").mockImplementationOnce(() => {
+      return true
+    })
+
+    if (deleteButton) {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      await act(async () => {
+        fireEvent.click(deleteButton)
+      })
+    } else {
+      throw new Error("delete button not found")
+    }
+
+    expect(apiSendSpy).toBeCalled()
+
+    expect(screen.queryByText("Success!!!")).not.toBeNull()
+  })
+
+  test("handles errors from deleting a disruption", async () => {
+    let startDate = new Date()
+    startDate.setTime(startDate.getTime() + 24 * 60 * 60 * 1000)
+    startDate = new Date(startDate.toDateString())
+
+    let endDate = new Date()
+    startDate.setTime(startDate.getTime() + 2 * 24 * 60 * 60 * 1000)
+    endDate = new Date(endDate.toDateString())
+
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
+      return Promise.resolve(
+        new Disruption({
+          id: "1",
+          startDate,
+          endDate,
+          adjustments: [
+            new Adjustment({
+              id: "1",
+              routeId: "Green-D",
+              source: "gtfs_creator",
+              sourceLabel: "NewtonHighlandsKenmore",
+            }),
+          ],
+          daysOfWeek: [
+            new DayOfWeek({
+              id: "1",
+              startTime: "20:45:00",
+              dayName: "friday",
+            }),
+          ],
+          exceptions: [],
+          tripShortNames: [],
+        })
+      )
+    })
+
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/1"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/"
+            component={ViewDisruption}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    const deleteButton = container.querySelector(
+      "#delete-disruption-button"
+    ) as Element
+
+    const apiSendSpy = jest.spyOn(api, "apiSend").mockImplementationOnce(() => {
+      return Promise.resolve({
+        error: ["Test error"],
+      })
+    })
+
+    jest.spyOn(window, "confirm").mockImplementationOnce(() => {
+      return true
+    })
+
+    if (deleteButton) {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      await act(async () => {
+        fireEvent.click(deleteButton)
+      })
+    } else {
+      throw new Error("delete button not found")
+    }
+
+    expect(apiSendSpy).toBeCalled()
+
+    expect(screen.getByText("Test error")).not.toBeNull()
   })
 })

--- a/lib/arrow/disruption.ex
+++ b/lib/arrow/disruption.ex
@@ -82,6 +82,16 @@ defmodule Arrow.Disruption do
   end
 
   @doc false
+  @spec changeset_for_delete(t(), DateTime.t()) :: Ecto.Changeset.t(t())
+  def changeset_for_delete(disruption, current_time) do
+    today = DateTime.to_date(current_time)
+
+    disruption
+    |> changeset(%{}, today)
+    |> validate_start_date_not_in_past(today)
+  end
+
+  @doc false
   @spec changeset(t(), map(), Date.t()) :: Ecto.Changeset.t(t())
   defp changeset(disruption, attrs, today) do
     disruption
@@ -226,6 +236,17 @@ defmodule Arrow.Disruption do
       changeset
     else
       add_error(changeset, :exceptions, "should be applicable to days of week")
+    end
+  end
+
+  @spec validate_start_date_not_in_past(Ecto.Changeset.t(t()), Date.t()) :: Ecto.Changeset.t(t())
+  defp validate_start_date_not_in_past(changeset, today) do
+    start_date = get_field(changeset, :start_date, [])
+
+    if not is_nil(start_date) and Date.compare(start_date, today) == :lt do
+      add_error(changeset, :start_date, "can't be deleted when start date is in the past")
+    else
+      changeset
     end
   end
 end

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -74,7 +74,10 @@ defmodule ArrowWeb.Router do
       :ensure_arrow_group
     ])
 
-    resources("/disruptions", DisruptionController, only: [:index, :show, :create, :update])
+    resources("/disruptions", DisruptionController,
+      only: [:index, :show, :create, :update, :delete]
+    )
+
     resources("/adjustments", AdjustmentController, only: [:index])
   end
 

--- a/test/arrow/disruption_test.exs
+++ b/test/arrow/disruption_test.exs
@@ -649,5 +649,31 @@ defmodule Arrow.DisruptionTest do
 
       assert Keyword.get(errors, :days_of_week) == {"should fall between start and end dates", []}
     end
+
+    test "can delete a disruption" do
+      {:ok, disruption} = build_disruption() |> Repo.insert()
+
+      assert {:ok, %Disruption{}} =
+               disruption
+               |> Disruption.changeset_for_delete(@current_time)
+               |> Repo.delete()
+    end
+
+    test "can't delete a disruption with a start date in the past" do
+      {:ok, disruption} =
+        build_disruption(%Disruption{
+          start_date: @current_time |> DateTime.to_date() |> Date.add(-1)
+        })
+        |> Repo.insert()
+
+      assert {:error, changeset} =
+               disruption
+               |> Disruption.changeset_for_delete(@current_time)
+               |> Repo.delete()
+
+      assert changeset.errors == [
+               start_date: {"can't be deleted when start date is in the past", []}
+             ]
+    end
   end
 end

--- a/test/arrow_web/controllers/api/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/api/disruption_controller_test.exs
@@ -5,12 +5,6 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
 
   @current_time DateTime.from_naive!(~N[2019-04-15 12:00:00], "America/New_York")
 
-  def future_date() do
-    {:ok, now} = DateTime.now(Application.get_env(:arrow, :time_zone))
-    today = DateTime.to_date(now)
-    Date.add(today, 10)
-  end
-
   describe "index/2" do
     @tag :authenticated
     test "returns 200", %{conn: conn} do
@@ -172,104 +166,6 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
                  200
                )
     end
-  end
-
-  defp insert_adjustment(opts) do
-    source_label = Keyword.get(opts, :source_label)
-    route_id = Keyword.get(opts, :route_id)
-    source = Keyword.get(opts, :source)
-
-    Repo.insert!(
-      Adjustment.changeset(%Adjustment{}, %{
-        source: source,
-        source_label: source_label,
-        route_id: route_id
-      })
-    )
-  end
-
-  defp insert_disruption(opts) do
-    start_date = Keyword.get(opts, :start_date)
-    end_date = Keyword.get(opts, :end_date)
-
-    exceptions =
-      opts
-      |> Keyword.get(:exceptions, [])
-      |> Enum.map(&%{"excluded_date" => &1})
-
-    trip_short_names =
-      opts
-      |> Keyword.get(:trip_short_names, [])
-      |> Enum.map(&%{"trip_short_name" => &1})
-
-    days_of_week =
-      opts
-      |> Keyword.get(:days_of_week, [])
-      |> Enum.map(
-        &%{
-          day_name: Map.get(&1, :day_name),
-          start_time: Map.get(&1, :start_time),
-          end_time: Map.get(&1, :end_time)
-        }
-      )
-
-    adjustments = Keyword.get(opts, :adjustments, [])
-    current_time = Keyword.get(opts, :current_time)
-
-    Repo.insert!(
-      Disruption.changeset_for_create(
-        %Disruption{},
-        %{
-          "start_date" => start_date,
-          "end_date" => end_date,
-          "exceptions" => exceptions,
-          "trip_short_names" => trip_short_names,
-          "days_of_week" => days_of_week
-        },
-        adjustments,
-        current_time
-      )
-    )
-  end
-
-  defp insert_disruptions do
-    adjustment_1 =
-      insert_adjustment(
-        source_label: "test_adjustment_1",
-        route_id: "test_route_1",
-        source: "arrow"
-      )
-
-    disruption_1 =
-      insert_disruption(
-        start_date: ~D[2019-10-10],
-        end_date: future_date(),
-        days_of_week: [
-          %{day_name: DayOfWeek.date_to_day_name(future_date()), start_time: ~T[20:30:00]}
-        ],
-        exceptions: [future_date()],
-        trip_short_names: ["006"],
-        adjustments: [adjustment_1],
-        current_time: @current_time
-      )
-
-    adjustment_2 =
-      insert_adjustment(
-        source_label: "test_adjustment_2",
-        route_id: "test_route_2",
-        source: "gtfs_creator"
-      )
-
-    disruption_2 =
-      insert_disruption(
-        start_date: ~D[2019-11-15],
-        end_date: Date.add(future_date(), 5),
-        days_of_week: [%{day_name: "friday", start_time: ~T[20:30:00]}],
-        adjustments: [adjustment_2],
-        current_time: @current_time
-      )
-
-    {disruption_1, disruption_2}
   end
 
   describe "create/2" do
@@ -495,5 +391,178 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
 
       assert resp = json_response(conn, 400)
     end
+  end
+
+  describe "delete/2" do
+    @tag :authenticated
+    test "can delete a disruption", %{conn: conn} do
+      adjustment =
+        insert_adjustment(
+          source_label: "test_adjustment_1",
+          route_id: "test_route_1",
+          source: "arrow"
+        )
+
+      disruption =
+        insert_disruption(
+          start_date: future_date(),
+          end_date: Date.add(future_date(), 7),
+          adjustments: [adjustment],
+          current_time: @current_time
+        )
+
+      conn = delete(conn, ArrowWeb.Router.Helpers.disruption_path(conn, :delete, disruption.id))
+
+      response = response(conn, 204)
+
+      assert response == ""
+    end
+
+    @tag :authenticated
+    test "returns 404 when no disruption by given ID exists", %{conn: conn} do
+      conn = delete(conn, ArrowWeb.Router.Helpers.disruption_path(conn, :delete, 1))
+
+      response = json_response(conn, 404)
+
+      assert response["errors"] == [
+               %{"detail" => "Not found"}
+             ]
+    end
+
+    @tag :authenticated
+    test "can't delete a disruption that started in the past", %{conn: conn} do
+      adjustment =
+        insert_adjustment(
+          source_label: "test_adjustment_1",
+          route_id: "test_route_1",
+          source: "arrow"
+        )
+
+      disruption =
+        insert_disruption(
+          start_date: past_date(),
+          end_date: future_date(),
+          adjustments: [adjustment],
+          current_time: @current_time
+        )
+
+      conn = delete(conn, ArrowWeb.Router.Helpers.disruption_path(conn, :delete, disruption.id))
+
+      response = json_response(conn, 400)
+
+      assert response["errors"] == [
+               %{"detail" => "Start date can't be deleted when start date is in the past"}
+             ]
+    end
+  end
+
+  def future_date() do
+    {:ok, now} = DateTime.now(Application.get_env(:arrow, :time_zone))
+    today = DateTime.to_date(now)
+    Date.add(today, 10)
+  end
+
+  def past_date() do
+    {:ok, now} = DateTime.now(Application.get_env(:arrow, :time_zone))
+    today = DateTime.to_date(now)
+    Date.add(today, -10)
+  end
+
+  defp insert_adjustment(opts) do
+    source_label = Keyword.get(opts, :source_label)
+    route_id = Keyword.get(opts, :route_id)
+    source = Keyword.get(opts, :source)
+
+    Repo.insert!(
+      Adjustment.changeset(%Adjustment{}, %{
+        source: source,
+        source_label: source_label,
+        route_id: route_id
+      })
+    )
+  end
+
+  defp insert_disruption(opts) do
+    start_date = Keyword.get(opts, :start_date)
+    end_date = Keyword.get(opts, :end_date)
+
+    exceptions =
+      opts
+      |> Keyword.get(:exceptions, [])
+      |> Enum.map(&%{"excluded_date" => &1})
+
+    trip_short_names =
+      opts
+      |> Keyword.get(:trip_short_names, [])
+      |> Enum.map(&%{"trip_short_name" => &1})
+
+    days_of_week =
+      opts
+      |> Keyword.get(:days_of_week, [])
+      |> Enum.map(
+        &%{
+          day_name: Map.get(&1, :day_name),
+          start_time: Map.get(&1, :start_time),
+          end_time: Map.get(&1, :end_time)
+        }
+      )
+
+    adjustments = Keyword.get(opts, :adjustments, [])
+    current_time = Keyword.get(opts, :current_time)
+
+    Repo.insert!(
+      Disruption.changeset_for_create(
+        %Disruption{},
+        %{
+          "start_date" => start_date,
+          "end_date" => end_date,
+          "exceptions" => exceptions,
+          "trip_short_names" => trip_short_names,
+          "days_of_week" => days_of_week
+        },
+        adjustments,
+        current_time
+      )
+    )
+  end
+
+  defp insert_disruptions do
+    adjustment_1 =
+      insert_adjustment(
+        source_label: "test_adjustment_1",
+        route_id: "test_route_1",
+        source: "arrow"
+      )
+
+    disruption_1 =
+      insert_disruption(
+        start_date: ~D[2019-10-10],
+        end_date: future_date(),
+        days_of_week: [
+          %{day_name: DayOfWeek.date_to_day_name(future_date()), start_time: ~T[20:30:00]}
+        ],
+        exceptions: [future_date()],
+        trip_short_names: ["006"],
+        adjustments: [adjustment_1],
+        current_time: @current_time
+      )
+
+    adjustment_2 =
+      insert_adjustment(
+        source_label: "test_adjustment_2",
+        route_id: "test_route_2",
+        source: "gtfs_creator"
+      )
+
+    disruption_2 =
+      insert_disruption(
+        start_date: ~D[2019-11-15],
+        end_date: Date.add(future_date(), 5),
+        days_of_week: [%{day_name: "friday", start_time: ~T[20:30:00]}],
+        adjustments: [adjustment_2],
+        current_time: @current_time
+      )
+
+    {disruption_1, disruption_2}
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Disruption can be deleted in Arrow](https://app.asana.com/0/584764604969369/1170294334212195/f)

The two commits should be reviewable separately. We only allow users to delete disruptions with a start date in the past, and this is enforced both on the front-end (the button isn't displayed for disruptions that start in the past) and the back-end (it will trigger a 400 error if you try to delete a disruption that began in the past).

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
