### PR TITLE
feat: add ability to add trip short names to disruption

### DIFF
--- a/assets/src/disruptions/disruptionPreview.tsx
+++ b/assets/src/disruptions/disruptionPreview.tsx
@@ -39,6 +39,7 @@ interface DisruptionPreviewProps {
   toDate: Date | null
   disruptionDaysOfWeek: DayOfWeekTimeRanges
   exceptionDates: Date[]
+  tripShortNames: string
   createFn?: any
 }
 
@@ -50,6 +51,7 @@ const DisruptionPreview = ({
   toDate,
   disruptionDaysOfWeek,
   exceptionDates,
+  tripShortNames,
   createFn,
 }: DisruptionPreviewProps): JSX.Element => {
   const listedDays: JSX.Element[] = []
@@ -77,6 +79,7 @@ const DisruptionPreview = ({
       toDate,
       disruptionDaysOfWeek,
       exceptionDates,
+      tripShortNames,
     })
   }, [
     createFn,
@@ -85,6 +88,7 @@ const DisruptionPreview = ({
     toDate,
     disruptionDaysOfWeek,
     exceptionDates,
+    tripShortNames,
   ])
 
   return (
@@ -94,6 +98,7 @@ const DisruptionPreview = ({
         adjustments={adjustments}
       />
       <h2>When</h2>
+      {tripShortNames && <p>Trips: {tripShortNames}</p>}
       <p>
         {formatDisruptionDate(fromDate)} &ndash; {formatDisruptionDate(toDate)}
       </p>

--- a/assets/src/disruptions/newDisruption.tsx
+++ b/assets/src/disruptions/newDisruption.tsx
@@ -202,7 +202,7 @@ const TripShortNamesForm = ({
 }: TripShortNamesFormProps) => {
   return (
     <div>
-      <Form.Group controlId="formTransitMode">
+      <Form.Group>
         <Form.Check
           type="radio"
           id="trips-all"
@@ -225,6 +225,7 @@ const TripShortNamesForm = ({
         {whichTrips === "some" && (
           <Form.Control
             className="mb-3"
+            id="trip-short-names"
             type="text"
             value={tripShortNames}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>

--- a/assets/src/disruptions/newDisruption.tsx
+++ b/assets/src/disruptions/newDisruption.tsx
@@ -18,6 +18,7 @@ import Loading from "../loading"
 import { DisruptionTimePicker } from "./disruptionTimePicker"
 import { TransitMode, modeForRoute } from "./disruptions"
 import { DisruptionPreview } from "./disruptionPreview"
+import TripShortName from "../models/tripShortName"
 
 interface AdjustmentModePickerProps {
   transitMode: TransitMode
@@ -186,40 +187,53 @@ const AdjustmentsPicker = ({
   )
 }
 
-interface AdjustmentFormProps {
-  adjustments: Adjustment[]
-  setAdjustments: React.Dispatch<Adjustment[]>
-  allAdjustments: Adjustment[]
+interface TripShortNamesFormProps {
+  tripShortNames: string
+  setTripShortNames: React.Dispatch<string>
+  whichTrips: "all" | "some"
+  setWhichTrips: React.Dispatch<"all" | "some">
 }
 
-const AdjustmentForm = ({
-  adjustments,
-  setAdjustments,
-  allAdjustments,
-}: AdjustmentFormProps): JSX.Element => {
-  const [transitMode, setTransitMode] = React.useState<TransitMode>(
-    TransitMode.Subway
-  )
-  const [isAddingAdjustment, setIsAddingAdjustment] = React.useState<boolean>(
-    adjustments.length === 0
-  )
-
+const TripShortNamesForm = ({
+  tripShortNames,
+  setTripShortNames,
+  whichTrips,
+  setWhichTrips,
+}: TripShortNamesFormProps) => {
   return (
     <div>
-      <AdjustmentModePicker
-        transitMode={transitMode}
-        setTransitMode={setTransitMode}
-        setAdjustments={setAdjustments}
-        setIsAddingAdjustment={setIsAddingAdjustment}
-      />
-      <AdjustmentsPicker
-        adjustments={adjustments}
-        setAdjustments={setAdjustments}
-        allAdjustments={allAdjustments}
-        transitMode={transitMode}
-        isAddingAdjustment={isAddingAdjustment}
-        setIsAddingAdjustment={setIsAddingAdjustment}
-      />
+      <Form.Group controlId="formTransitMode">
+        <Form.Check
+          type="radio"
+          id="trips-all"
+          label="All Trips"
+          name="which-trips"
+          checked={whichTrips === "all"}
+          onChange={() => {
+            setWhichTrips("all")
+            setTripShortNames("")
+          }}
+        />
+        <Form.Check
+          type="radio"
+          id="trips-some"
+          label="Some Trips"
+          name="which-trips"
+          checked={whichTrips === "some"}
+          onChange={() => setWhichTrips("some")}
+        />
+        {whichTrips === "some" && (
+          <Form.Control
+            className="mb-3"
+            type="text"
+            value={tripShortNames}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setTripShortNames(e.target.value)
+            }
+            placeholder="Enter comma separated trip short names "
+          />
+        )}
+      </Form.Group>
     </div>
   )
 }
@@ -230,6 +244,7 @@ interface ApiCreateDisruptionParams {
   toDate: Date | null
   disruptionDaysOfWeek: DayOfWeekTimeRanges
   exceptionDates: Date[]
+  tripShortNames: string
 }
 
 const disruptionFromState = ({
@@ -238,6 +253,7 @@ const disruptionFromState = ({
   toDate,
   disruptionDaysOfWeek,
   exceptionDates,
+  tripShortNames,
 }: ApiCreateDisruptionParams): Disruption => {
   return new Disruption({
     ...(fromDate && { startDate: fromDate }),
@@ -245,7 +261,11 @@ const disruptionFromState = ({
     adjustments,
     daysOfWeek: dayOfWeekTimeRangesToDayOfWeeks(disruptionDaysOfWeek),
     exceptions: Exception.fromDates(exceptionDates),
-    tripShortNames: [],
+    tripShortNames: tripShortNames
+      ? tripShortNames
+          .split(/\s*,\s*/)
+          .map((tripShortName) => new TripShortName({ tripShortName }))
+      : [],
   })
 }
 
@@ -257,12 +277,20 @@ const NewDisruption = ({}): JSX.Element => {
     DayOfWeekTimeRanges
   >([null, null, null, null, null, null, null])
   const [exceptionDates, setExceptionDates] = React.useState<Date[]>([])
+  const [tripShortNames, setTripShortNames] = React.useState<string>("")
   const [isPreview, setIsPreview] = React.useState<boolean>(false)
   const [allAdjustments, setAllAdjustments] = React.useState<
     Adjustment[] | "error" | null
   >(null)
   const [validationErrors, setValidationErrors] = React.useState<string[]>([])
   const [doRedirect, setDoRedirect] = React.useState<boolean>(false)
+  const [transitMode, setTransitMode] = React.useState<TransitMode>(
+    TransitMode.Subway
+  )
+  const [isAddingAdjustment, setIsAddingAdjustment] = React.useState<boolean>(
+    adjustments.length === 0
+  )
+  const [whichTrips, setWhichTrips] = React.useState<"all" | "some">("all")
 
   const createFn = async (args: ApiCreateDisruptionParams) => {
     const disruption = disruptionFromState(args)
@@ -323,6 +351,7 @@ const NewDisruption = ({}): JSX.Element => {
           toDate={toDate}
           disruptionDaysOfWeek={disruptionDaysOfWeek}
           exceptionDates={exceptionDates}
+          tripShortNames={tripShortNames}
           createFn={createFn}
         />
       ) : (
@@ -337,11 +366,30 @@ const NewDisruption = ({}): JSX.Element => {
             </Alert>
           )}
           <h1>Create new disruption</h1>
-          <AdjustmentForm
-            adjustments={adjustments}
-            setAdjustments={setAdjustments}
-            allAdjustments={allAdjustments}
-          />
+          <div>
+            <AdjustmentModePicker
+              transitMode={transitMode}
+              setTransitMode={setTransitMode}
+              setAdjustments={setAdjustments}
+              setIsAddingAdjustment={setIsAddingAdjustment}
+            />
+            <AdjustmentsPicker
+              adjustments={adjustments}
+              setAdjustments={setAdjustments}
+              allAdjustments={allAdjustments}
+              transitMode={transitMode}
+              isAddingAdjustment={isAddingAdjustment}
+              setIsAddingAdjustment={setIsAddingAdjustment}
+            />
+            {transitMode === TransitMode.CommuterRail && (
+              <TripShortNamesForm
+                whichTrips={whichTrips}
+                setWhichTrips={setWhichTrips}
+                tripShortNames={tripShortNames}
+                setTripShortNames={setTripShortNames}
+              />
+            )}
+          </div>
           <fieldset>
             <legend>During what time?</legend>
             <DisruptionTimePicker

--- a/assets/src/disruptions/viewDisruption.tsx
+++ b/assets/src/disruptions/viewDisruption.tsx
@@ -142,6 +142,9 @@ const ViewDisruptionForm = ({
             toDate={disruption.endDate || null}
             exceptionDates={exceptionDates}
             disruptionDaysOfWeek={disruptionDaysOfWeek}
+            tripShortNames={disruption.tripShortNames
+              .map((tsn) => tsn.tripShortName)
+              .join(", ")}
           />
           <div>
             <EditDisruptionButton disruptionId={disruption.id} />

--- a/assets/tests/disruptions/disruptionPreview.test.tsx
+++ b/assets/tests/disruptions/disruptionPreview.test.tsx
@@ -12,6 +12,7 @@ describe("DisruptionPreview", () => {
         toDate={new Date(2020, 0, 15)}
         disruptionDaysOfWeek={[null, null, null, null, null, null, null]}
         exceptionDates={[]}
+        tripShortNames=""
       />
     )
 
@@ -27,6 +28,7 @@ describe("DisruptionPreview", () => {
         toDate={null}
         disruptionDaysOfWeek={[null, null, null, null, null, null, null]}
         exceptionDates={[new Date(2020, 0, 10)]}
+        tripShortNames=""
       />
     )
 
@@ -50,6 +52,7 @@ describe("DisruptionPreview", () => {
           null,
         ]}
         exceptionDates={[new Date(2020, 0, 10)]}
+        tripShortNames=""
       />
     )
 
@@ -77,6 +80,7 @@ describe("DisruptionPreview", () => {
           null,
         ]}
         exceptionDates={[new Date(2020, 0, 10)]}
+        tripShortNames=""
       />
     )
 
@@ -93,6 +97,7 @@ describe("DisruptionPreview", () => {
         toDate={null}
         disruptionDaysOfWeek={[null, null, null, null, null, null, null]}
         exceptionDates={[]}
+        tripShortNames=""
       />
     )
 
@@ -107,10 +112,26 @@ describe("DisruptionPreview", () => {
         toDate={null}
         disruptionDaysOfWeek={[null, null, null, null, null, null, null]}
         exceptionDates={[]}
+        tripShortNames=""
       />
     )
 
     expect(container.querySelector("#back-to-edit-link")).toBeNull()
+  })
+
+  test("shows trip short names", () => {
+    render(
+      <DisruptionPreview
+        adjustments={[]}
+        fromDate={null}
+        toDate={null}
+        disruptionDaysOfWeek={[null, null, null, null, null, null, null]}
+        exceptionDates={[]}
+        tripShortNames="123,456,789"
+      />
+    )
+
+    expect(screen.queryByText("Trips: 123,456,789")).not.toBeNull()
   })
 
   test("create callback is invoked", () => {
@@ -126,6 +147,7 @@ describe("DisruptionPreview", () => {
         disruptionDaysOfWeek={[null, null, null, null, null, null, null]}
         exceptionDates={[]}
         createFn={createFn}
+        tripShortNames=""
       />
     )
     const createButton = container.querySelector(

--- a/assets/tests/disruptions/newDisruption.test.tsx
+++ b/assets/tests/disruptions/newDisruption.test.tsx
@@ -364,8 +364,12 @@ describe("NewDisruption", () => {
         document.querySelector("#loading-indicator")
       )
 
+      withElement(container, "#mode-commuter-rail", (el) => {
+        fireEvent.click(el)
+      })
+
       withElement(container, "#adjustment-select-0", (el) => {
-        fireEvent.change(el, { target: { value: "Kenmore--Newton Highlands" } })
+        fireEvent.change(el, { target: { value: "Fairmount--Newmarket" } })
       })
 
       withElement(container, "#disruption-date-range-start", (el) => {
@@ -374,6 +378,14 @@ describe("NewDisruption", () => {
 
       withElement(container, "#disruption-date-range-end", (el) => {
         fireEvent.change(el, { target: { value: "2020-04-30" } })
+      })
+
+      withElement(container, "#trips-some", (el) => {
+        fireEvent.click(el)
+      })
+
+      withElement(container, "#trip-short-names", (el) => {
+        fireEvent.change(el, { target: { value: "123,456" } })
       })
 
       withElement(container, "#preview-disruption-button", (el) => {
@@ -391,9 +403,13 @@ describe("NewDisruption", () => {
     expect(apiSendCall.url).toEqual("/api/disruptions")
     expect(apiSendData.data.attributes.start_date).toEqual("2020-03-31")
     expect(apiSendData.data.attributes.end_date).toEqual("2020-04-30")
+    expect(apiSendData.data.relationships.trip_short_names.data).toEqual([
+      { attributes: { trip_short_name: "123" }, type: "trip_short_name" },
+      { attributes: { trip_short_name: "456" }, type: "trip_short_name" },
+    ])
     expect(
       apiSendData.data.relationships.adjustments.data[0].attributes.source_label
-    ).toEqual("Kenmore--Newton Highlands")
+    ).toEqual("Fairmount--Newmarket")
   })
 
   test("handles errors with disruptions", async () => {

--- a/assets/tests/disruptions/newDisruption.test.tsx
+++ b/assets/tests/disruptions/newDisruption.test.tsx
@@ -385,6 +385,18 @@ describe("NewDisruption", () => {
       })
 
       withElement(container, "#trip-short-names", (el) => {
+        fireEvent.change(el, { target: { value: "999,888" } })
+      })
+
+      withElement(container, "#trips-all", (el) => {
+        fireEvent.click(el)
+      })
+
+      withElement(container, "#trips-some", (el) => {
+        fireEvent.click(el)
+      })
+
+      withElement(container, "#trip-short-names", (el) => {
         fireEvent.change(el, { target: { value: "123,456" } })
       })
 

--- a/assets/tests/disruptions/viewDisruption.test.tsx
+++ b/assets/tests/disruptions/viewDisruption.test.tsx
@@ -14,6 +14,7 @@ import Adjustment from "../../src/models/adjustment"
 import DayOfWeek from "../../src/models/dayOfWeek"
 import Disruption from "../../src/models/disruption"
 import Exception from "../../src/models/exception"
+import TripShortName from "../../src/models/tripShortName"
 
 describe("ViewDisruption", () => {
   test("loads and displays disruption from the API", async () => {
@@ -44,7 +45,10 @@ describe("ViewDisruption", () => {
               excludedDate: new Date("2020-01-20"),
             }),
           ],
-          tripShortNames: [],
+          tripShortNames: [
+            new TripShortName({ tripShortName: "123" }),
+            new TripShortName({ tripShortName: "456" }),
+          ],
         })
       )
     })
@@ -84,6 +88,7 @@ describe("ViewDisruption", () => {
     expect(document.body.textContent).toMatch("1/20/2020")
     expect(document.body.textContent).toMatch("Friday")
     expect(document.body.textContent).toMatch("8:45PM")
+    expect(document.body.textContent).toMatch("Trips: 123, 456")
     expect(document.body.textContent).toMatch("End of service")
   })
 

--- a/lib/arrow_web/utilities.ex
+++ b/lib/arrow_web/utilities.ex
@@ -57,11 +57,11 @@ defmodule ArrowWeb.Utilities do
 
   @spec take_errors(map()) :: [key: String.t()]
   defp take_errors(errors) do
-    Enum.flat_map(errors, fn {field, [err | _]} ->
+    Enum.flat_map(errors, fn {field, [err | _] = field_errors} ->
       if is_binary(err) do
         [{field, err}]
       else
-        take_errors(err)
+        Enum.flat_map(field_errors, fn x -> take_errors(x) end)
       end
     end)
   end
@@ -69,7 +69,9 @@ defmodule ArrowWeb.Utilities do
   @spec format_errors(Ecto.Changeset.t()) :: [map()]
   def format_errors(changeset) do
     changeset
-    |> Ecto.Changeset.traverse_errors(fn err -> format_error_message(err) end)
+    |> Ecto.Changeset.traverse_errors(fn err ->
+      format_error_message(err)
+    end)
     |> take_errors()
     |> Enum.map(fn {field, msg} ->
       %{detail: "#{format_field_name(field)} #{msg}"}

--- a/test/arrow/disruption_test.exs
+++ b/test/arrow/disruption_test.exs
@@ -650,6 +650,46 @@ defmodule Arrow.DisruptionTest do
       assert Keyword.get(errors, :days_of_week) == {"should fall between start and end dates", []}
     end
 
+    test "can't insert a disruption with a blank trip short name" do
+      adj = %Adjustment{
+        source: "testing",
+        source_label: "test_insert_disruption",
+        route_id: "test_route"
+      }
+
+      {:ok, new_adj} = Repo.insert(adj)
+
+      assert {:error,
+              %{
+                changes: %{
+                  trip_short_names: [
+                    %{
+                      changes: %{},
+                      errors: [trip_short_name: {"can't be blank", [validation: :required]}],
+                      valid?: false
+                    }
+                  ]
+                },
+                errors: []
+              }} =
+               Repo.insert(
+                 Disruption.changeset_for_create(
+                   %Disruption{},
+                   %{
+                     "start_date" => @start_date,
+                     "end_date" => @end_date,
+                     "trip_short_names" => [
+                       %{
+                         "trip_short_name" => ""
+                       }
+                     ]
+                   },
+                   [new_adj],
+                   @current_time
+                 )
+               )
+    end
+
     test "can delete a disruption" do
       {:ok, disruption} = build_disruption() |> Repo.insert()
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Ability to add trip short names for CR disruptions in Arrow](https://app.asana.com/0/584764604969369/1173526948047141/f)

### With error
<img width="872" alt="Screen Shot 2020-07-22 at 2 44 38 PM" src="https://user-images.githubusercontent.com/18427346/88219107-166d1c00-cc2f-11ea-8e30-e694744ee28f.png">


### On preview/success
<img width="916" alt="Screen Shot 2020-07-22 at 3 07 25 PM" src="https://user-images.githubusercontent.com/18427346/88219122-1bca6680-cc2f-11ea-80e4-a2e04a69a1ad.png">

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
