### PR TITLE
feat: Add Prudential–Heath Street shuttle

### DIFF
--- a/priv/repo/shuttles.json
+++ b/priv/repo/shuttles.json
@@ -1,1 +1,584 @@
-[{"id": "GreenDRevertHastusReservoir", "attributes": {"route_id": "Green-D"}}, {"id": "RedRevertHastusBraintree", "attributes": {"route_id": "Red"}}, {"id": "AlewifeHarvard", "attributes": {"route_id": "Red"}}, {"id": "AshmontJFK", "attributes": {"route_id": "Red"}}, {"id": "BraintreeNorthQuincy", "attributes": {"route_id": "Red"}}, {"id": "BraintreeQuincyCenter", "attributes": {"route_id": "Red"}}, {"id": "BraintreeQuincyCenterExtended", "attributes": {"route_id": "Red"}}, {"id": "NorthQuincyQuincyCenter", "attributes": {"route_id": "Red"}}, {"id": "ForestHillsRuggles", "attributes": {"route_id": "Orange"}}, {"id": "BackBayJacksonSquare", "attributes": {"route_id": "Orange"}}, {"id": "ForestHillsJacksonSquare", "attributes": {"route_id": "Orange"}}, {"id": "OakGroveWellington", "attributes": {"route_id": "Orange"}}, {"id": "BrooklineHillsReservoir", "attributes": {"route_id": "Green-D"}}, {"id": "KenmoreStMarysNotFenway", "attributes": {"route_id": "Green-C"}}, {"id": "KenmoreReservoir", "attributes": {"route_id": "Green-D"}}, {"id": "BrooklineHillsKenmore", "attributes": {"route_id": "Green-D"}}, {"id": "LittletonWachusett", "attributes": {"route_id": "CR-Fitchburg"}}, {"id": "LowellWellington", "attributes": {"route_id": "CR-Lowell"}}, {"id": "AndersonWoburnNorthStation", "attributes": {"route_id": "CR-Lowell"}}, {"id": "NorthStationWestMedford", "attributes": {"route_id": "CR-Lowell"}}, {"id": "TruncateAndersonWoburn", "attributes": {"route_id": "CR-Lowell"}}, {"id": "FitchburgStopAtPorter", "attributes": {"route_id": "CR-Fitchburg"}}, {"id": "KingstonStopAtBraintree", "attributes": {"route_id": "CR-Kingston"}}, {"id": "MiddleboroughStopAtBraintree", "attributes": {"route_id": "CR-Middleborough"}}, {"id": "GreenbushStopsAtBraintree", "attributes": {"route_id": "CR-Greenbush"}}, {"id": "HaverhillStopAtMalden", "attributes": {"route_id": "CR-Haverhill"}}, {"id": "BallardvaleMaldenCenter", "attributes": {"route_id": "CR-Haverhill"}}, {"id": "BallardvaleMaldenCenterOffset1", "attributes": {"route_id": "CR-Haverhill"}}, {"id": "BabcockBostonCollege", "attributes": {"route_id": "Green-B"}}, {"id": "BabcockStreetBlandfordStreet", "attributes": {"route_id": "Green-B"}}, {"id": "BlandfordStreetBostonCollege", "attributes": {"route_id": "Green-B"}}, {"id": "BlandfordStreetWashingtonStreet", "attributes": {"route_id": "Green-B"}}, {"id": "FenwayReservoir", "attributes": {"route_id": "Green-D"}}, {"id": "OakGroveSullivan", "attributes": {"route_id": "Orange"}}, {"id": "BostonCollegePackardsCorner", "attributes": {"route_id": "Green-B"}}, {"id": "KendallParkStreet", "attributes": {"route_id": "Red"}}, {"id": "BroadwayKendall", "attributes": {"route_id": "Red"}}, {"id": "BroadwayKendallOmitDTX", "attributes": {"route_id": "Red"}}, {"id": "BackBayRuggles", "attributes": {"route_id": "Orange"}}, {"id": "ReservoirRiverside", "attributes": {"route_id": "Green-D"}}, {"id": "ReservoirRiversideExtended", "attributes": {"route_id": "Green-D"}}, {"id": "BostonCollegeWashingtonStreet", "attributes": {"route_id": "Green-B"}}, {"id": "ClevelandCircleSaintMarys", "attributes": {"route_id": "Green-C"}}, {"id": "ClevelandCircleKenmore", "attributes": {"route_id": "Green-C"}}, {"id": "KenmoreRiverside", "attributes": {"route_id": "Green-D"}}, {"id": "KenmoreRiversideForReservoir", "attributes": {"route_id": "Green-D"}}, {"id": "KenmoreStMarysRiversideD", "attributes": {"route_id": "Green-D"}}, {"id": "KenmoreStMarysRiversideC", "attributes": {"route_id": "Green-C"}}, {"id": "KenmoreStMarysRiversideForReservoir", "attributes": {"route_id": "Green-D"}}, {"id": "CopleyRiversideExpress", "attributes": {"route_id": "Green-D"}}, {"id": "CopleyWoodlandExpressCR", "attributes": {"route_id": "CR-SouthShoreLtd"}}, {"id": "NewtonHighlandsRiverside", "attributes": {"route_id": "Green-D"}}, {"id": "NewtonHighlandsKenmoreExtended", "attributes": {"route_id": "Green-D"}}, {"id": "FenwayNewtonHighlands", "attributes": {"route_id": "Green-D"}}, {"id": "NewtonHighlandsKenmore", "attributes": {"route_id": "Green-D"}}, {"id": "NewtonHighlandsStMarysKenmoreC", "attributes": {"route_id": "Green-C"}}, {"id": "NewtonHighlandsStMarysKenmoreD", "attributes": {"route_id": "Green-D"}}, {"id": "NewtonHighlandsStMarysKenmoreExtended", "attributes": {"route_id": "Green-D"}}, {"id": "BrooklineHillsNewtonHighlands", "attributes": {"route_id": "Green-D"}}, {"id": "OrientHeightsWonderland", "attributes": {"route_id": "Blue"}}, {"id": "SuffolkDownsWonderland", "attributes": {"route_id": "Blue"}}, {"id": "AirportBowdoinLocal", "attributes": {"route_id": "Blue"}}, {"id": "AirportBowdoinExpress", "attributes": {"route_id": "Blue"}}, {"id": "AirportMaverick", "attributes": {"route_id": "Blue"}}, {"id": "BlueStopAtGovernmentCenter", "attributes": {"route_id": "Blue"}}, {"id": "AshmontMattapan", "attributes": {"route_id": "Mattapan"}}, {"id": "ForgeParkReadville", "attributes": {"route_id": "CR-Franklin"}}, {"id": "ForgeParkSouthStation", "attributes": {"route_id": "CR-Franklin"}}, {"id": "GreenBGovernmentCenterNorthStation", "attributes": {"route_id": "Green-B"}}, {"id": "GreenCGovernmentCenterNorthStation", "attributes": {"route_id": "Green-C"}}, {"id": "GreenDGovernmentCenterNorthStation", "attributes": {"route_id": "Green-D"}}, {"id": "GreenEGovernmentCenterNorthStation", "attributes": {"route_id": "Green-E"}}, {"id": "GreenBHaymarketParkStreet", "attributes": {"route_id": "Green-B"}}, {"id": "GreenCHaymarketParkStreet", "attributes": {"route_id": "Green-C"}}, {"id": "GreenDHaymarketParkStreet", "attributes": {"route_id": "Green-D"}}, {"id": "GreenEHaymarketParkStreet", "attributes": {"route_id": "Green-E"}}, {"id": "GreenBLechmereNorthStation", "attributes": {"route_id": "Green-B"}}, {"id": "GreenCLechmereNorthStation", "attributes": {"route_id": "Green-C"}}, {"id": "GreenDLechmereNorthStation", "attributes": {"route_id": "Green-D"}}, {"id": "GreenELechmereNorthStation", "attributes": {"route_id": "Green-E"}}, {"id": "SL1NoTransitway", "attributes": {"route_id": "741"}}, {"id": "SL2NoTransitwayAM", "attributes": {"route_id": "742"}}, {"id": "SL2NoTransitwayPM", "attributes": {"route_id": "742"}}, {"id": "SL2NoTransitwayPMNoBlackFalcon", "attributes": {"route_id": "742"}}, {"id": "SL3NoTransitway", "attributes": {"route_id": "743"}}, {"id": "SLWNoTransitway", "attributes": {"route_id": "746"}}, {"id": "HaymarketSullivanTufts", "attributes": {"route_id": "Orange"}}, {"id": "RugglesSullivan", "attributes": {"route_id": "Orange"}}, {"id": "OrangeSkipNorthStationNorthbound", "attributes": {"route_id": "Orange"}}, {"id": "OrangeSkipNorthStationSouthbound", "attributes": {"route_id": "Orange"}}, {"id": "BackBayFraminghamLocal", "attributes": {"route_id": "CR-Worcester"}}, {"id": "BackBayFraminghamExpress", "attributes": {"route_id": "CR-Worcester"}}, {"id": "BackBayFramingham", "attributes": {"route_id": "CR-Worcester"}}, {"id": "LowellBusReplacement", "attributes": {"route_id": "CR-Lowell"}}, {"id": "FranklinViaFairmount", "attributes": {"route_id": "CR-Franklin"}}, {"id": "GreenbushSouthStation", "attributes": {"route_id": "CR-Greenbush"}}]
+[
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "GreenDRevertHastusReservoir"
+  },
+  {
+    "attributes": {
+      "route_id": "Red"
+    },
+    "id": "RedRevertHastusBraintree"
+  },
+  {
+    "attributes": {
+      "route_id": "Red"
+    },
+    "id": "AlewifeHarvard"
+  },
+  {
+    "attributes": {
+      "route_id": "Red"
+    },
+    "id": "AshmontJFK"
+  },
+  {
+    "attributes": {
+      "route_id": "Red"
+    },
+    "id": "BraintreeNorthQuincy"
+  },
+  {
+    "attributes": {
+      "route_id": "Red"
+    },
+    "id": "BraintreeQuincyCenter"
+  },
+  {
+    "attributes": {
+      "route_id": "Red"
+    },
+    "id": "BraintreeQuincyCenterExtended"
+  },
+  {
+    "attributes": {
+      "route_id": "Red"
+    },
+    "id": "NorthQuincyQuincyCenter"
+  },
+  {
+    "attributes": {
+      "route_id": "Orange"
+    },
+    "id": "ForestHillsRuggles"
+  },
+  {
+    "attributes": {
+      "route_id": "Orange"
+    },
+    "id": "BackBayJacksonSquare"
+  },
+  {
+    "attributes": {
+      "route_id": "Orange"
+    },
+    "id": "ForestHillsJacksonSquare"
+  },
+  {
+    "attributes": {
+      "route_id": "Orange"
+    },
+    "id": "OakGroveWellington"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "BrooklineHillsReservoir"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-C"
+    },
+    "id": "KenmoreStMarysNotFenway"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "KenmoreReservoir"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "BrooklineHillsKenmore"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Fitchburg"
+    },
+    "id": "LittletonWachusett"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Lowell"
+    },
+    "id": "LowellWellington"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Lowell"
+    },
+    "id": "AndersonWoburnNorthStation"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Lowell"
+    },
+    "id": "NorthStationWestMedford"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Lowell"
+    },
+    "id": "TruncateAndersonWoburn"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Fitchburg"
+    },
+    "id": "FitchburgStopAtPorter"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Kingston"
+    },
+    "id": "KingstonStopAtBraintree"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Middleborough"
+    },
+    "id": "MiddleboroughStopAtBraintree"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Greenbush"
+    },
+    "id": "GreenbushStopsAtBraintree"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Haverhill"
+    },
+    "id": "HaverhillStopAtMalden"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Haverhill"
+    },
+    "id": "BallardvaleMaldenCenter"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Haverhill"
+    },
+    "id": "BallardvaleMaldenCenterOffset1"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-B"
+    },
+    "id": "BabcockBostonCollege"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-B"
+    },
+    "id": "BabcockStreetBlandfordStreet"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-B"
+    },
+    "id": "BlandfordStreetBostonCollege"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-B"
+    },
+    "id": "BlandfordStreetWashingtonStreet"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "FenwayReservoir"
+  },
+  {
+    "attributes": {
+      "route_id": "Orange"
+    },
+    "id": "OakGroveSullivan"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-B"
+    },
+    "id": "BostonCollegePackardsCorner"
+  },
+  {
+    "attributes": {
+      "route_id": "Red"
+    },
+    "id": "KendallParkStreet"
+  },
+  {
+    "attributes": {
+      "route_id": "Red"
+    },
+    "id": "BroadwayKendall"
+  },
+  {
+    "attributes": {
+      "route_id": "Red"
+    },
+    "id": "BroadwayKendallOmitDTX"
+  },
+  {
+    "attributes": {
+      "route_id": "Orange"
+    },
+    "id": "BackBayRuggles"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "ReservoirRiverside"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "ReservoirRiversideExtended"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-B"
+    },
+    "id": "BostonCollegeWashingtonStreet"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-C"
+    },
+    "id": "ClevelandCircleSaintMarys"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-C"
+    },
+    "id": "ClevelandCircleKenmore"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "KenmoreRiverside"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "KenmoreRiversideForReservoir"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "KenmoreStMarysRiversideD"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-C"
+    },
+    "id": "KenmoreStMarysRiversideC"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "KenmoreStMarysRiversideForReservoir"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "CopleyRiversideExpress"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-SouthShoreLtd"
+    },
+    "id": "CopleyWoodlandExpressCR"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "NewtonHighlandsRiverside"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "NewtonHighlandsKenmoreExtended"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "FenwayNewtonHighlands"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "NewtonHighlandsKenmore"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-C"
+    },
+    "id": "NewtonHighlandsStMarysKenmoreC"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "NewtonHighlandsStMarysKenmoreD"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "NewtonHighlandsStMarysKenmoreExtended"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "BrooklineHillsNewtonHighlands"
+  },
+  {
+    "attributes": {
+      "route_id": "Blue"
+    },
+    "id": "OrientHeightsWonderland"
+  },
+  {
+    "attributes": {
+      "route_id": "Blue"
+    },
+    "id": "SuffolkDownsWonderland"
+  },
+  {
+    "attributes": {
+      "route_id": "Blue"
+    },
+    "id": "AirportBowdoinLocal"
+  },
+  {
+    "attributes": {
+      "route_id": "Blue"
+    },
+    "id": "AirportBowdoinExpress"
+  },
+  {
+    "attributes": {
+      "route_id": "Blue"
+    },
+    "id": "AirportMaverick"
+  },
+  {
+    "attributes": {
+      "route_id": "Blue"
+    },
+    "id": "BlueStopAtGovernmentCenter"
+  },
+  {
+    "attributes": {
+      "route_id": "Mattapan"
+    },
+    "id": "AshmontMattapan"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Franklin"
+    },
+    "id": "ForgeParkReadville"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Franklin"
+    },
+    "id": "ForgeParkSouthStation"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-B"
+    },
+    "id": "GreenBGovernmentCenterNorthStation"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-C"
+    },
+    "id": "GreenCGovernmentCenterNorthStation"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "GreenDGovernmentCenterNorthStation"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-E"
+    },
+    "id": "GreenEGovernmentCenterNorthStation"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-B"
+    },
+    "id": "GreenBHaymarketParkStreet"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-C"
+    },
+    "id": "GreenCHaymarketParkStreet"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "GreenDHaymarketParkStreet"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-E"
+    },
+    "id": "GreenEHaymarketParkStreet"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-B"
+    },
+    "id": "GreenBLechmereNorthStation"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-C"
+    },
+    "id": "GreenCLechmereNorthStation"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-D"
+    },
+    "id": "GreenDLechmereNorthStation"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-E"
+    },
+    "id": "GreenELechmereNorthStation"
+  },
+  {
+    "attributes": {
+      "route_id": "741"
+    },
+    "id": "SL1NoTransitway"
+  },
+  {
+    "attributes": {
+      "route_id": "742"
+    },
+    "id": "SL2NoTransitwayAM"
+  },
+  {
+    "attributes": {
+      "route_id": "742"
+    },
+    "id": "SL2NoTransitwayPM"
+  },
+  {
+    "attributes": {
+      "route_id": "742"
+    },
+    "id": "SL2NoTransitwayPMNoBlackFalcon"
+  },
+  {
+    "attributes": {
+      "route_id": "743"
+    },
+    "id": "SL3NoTransitway"
+  },
+  {
+    "attributes": {
+      "route_id": "746"
+    },
+    "id": "SLWNoTransitway"
+  },
+  {
+    "attributes": {
+      "route_id": "Orange"
+    },
+    "id": "HaymarketSullivanTufts"
+  },
+  {
+    "attributes": {
+      "route_id": "Orange"
+    },
+    "id": "RugglesSullivan"
+  },
+  {
+    "attributes": {
+      "route_id": "Orange"
+    },
+    "id": "OrangeSkipNorthStationNorthbound"
+  },
+  {
+    "attributes": {
+      "route_id": "Orange"
+    },
+    "id": "OrangeSkipNorthStationSouthbound"
+  },
+  {
+    "attributes": {
+      "route_id": "Green-E"
+    },
+    "id": "HeathStreetPrudential"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Worcester"
+    },
+    "id": "BackBayFraminghamLocal"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Worcester"
+    },
+    "id": "BackBayFraminghamExpress"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Worcester"
+    },
+    "id": "BackBayFramingham"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Lowell"
+    },
+    "id": "LowellBusReplacement"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Franklin"
+    },
+    "id": "FranklinViaFairmount"
+  },
+  {
+    "attributes": {
+      "route_id": "CR-Greenbush"
+    },
+    "id": "GreenbushSouthStation"
+  }
+]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Partial fulfilment of [🚧 Green-E shuttle August](https://app.asana.com/0/584764604969369/1185335758800835/f)

Related gtfs_creator pull request: https://github.com/mbta/gtfs_creator/pull/967.

Wish we could see just the diff.

Here's what was added:
```
{"id": "HeathStreetPrudential", "attributes": {"route_id": "Green-E"}},
```

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
