### PR TITLE
fix: remove Python from .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,3 @@
 elixir 1.9.4-otp-22
 erlang 22.2.1
 nodejs 13.6.0
-python 3.8.1


### PR DESCRIPTION
This was accidentally introduced in 1a3ab6c3.