### PR TITLE
Get user groups from Cognito API when using API token

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -16,7 +16,8 @@ config :arrow,
   migrate_synchronously?: false,
   redirect_http?: true,
   cognito_group: "arrow-admin",
-  time_zone: "America/New_York"
+  time_zone: "America/New_York",
+  ex_aws_requester: {Fake.ExAws, :arrow_group_request}
 
 # Configures the endpoint
 config :arrow, ArrowWeb.Endpoint,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -21,7 +21,8 @@ config :arrow, ArrowWeb.AuthManager, secret_key: {System, :get_env, ["ARROW_AUTH
 config :logger, level: :info
 
 config :arrow,
-  run_migrations_at_startup?: true
+  run_migrations_at_startup?: true,
+  ex_aws_requester: {ExAws, :request}
 
 config :arrow, Arrow.Repo, ssl: true
 

--- a/lib/arrow_web/try_api_token_auth.ex
+++ b/lib/arrow_web/try_api_token_auth.ex
@@ -1,5 +1,8 @@
 defmodule ArrowWeb.TryApiTokenAuth do
   import Plug.Conn
+  require Logger
+
+  @aws_cognito_target "AWSCognitoIdentityProviderService"
 
   def init(options), do: options
 
@@ -15,16 +18,50 @@ defmodule ArrowWeb.TryApiTokenAuth do
       auth_token = Arrow.Repo.get_by(Arrow.AuthToken, token: token)
 
       if is_nil(auth_token) do
-        send_resp(conn, 401, "unauthenticated")
+        conn |> send_resp(401, "unauthenticated") |> halt()
       else
+        user_pool_id =
+          :ueberauth
+          |> Application.get_env(Ueberauth.Strategy.Cognito)
+          |> Keyword.get(:user_pool_id)
+          |> config_value
+
+        data = %{
+          "Username" => auth_token.username,
+          "UserPoolId" => user_pool_id
+        }
+
+        headers = [
+          {"x-amz-target", "#{@aws_cognito_target}.AdminListGroupsForUser"},
+          {"content-type", "application/x-amz-json-1.1"}
+        ]
+
+        operation = ExAws.Operation.JSON.new(:"cognito-idp", data: data, headers: headers)
+
+        {module, function} = Application.get_env(:arrow, :ex_aws_requester)
+
+        group_names =
+          case apply(module, function, [operation]) do
+            {:ok, %{"Groups" => groups}} ->
+              Enum.map(groups, & &1["GroupName"])
+
+            response ->
+              :ok = Logger.warn("unexpected_aws_api_response: #{inspect(response)}")
+              []
+          end
+
         conn
         |> Guardian.Plug.sign_in(
           ArrowWeb.AuthManager,
           auth_token.username,
-          %{groups: ["arrow-admin"]}
+          %{groups: group_names}
         )
         |> Plug.Conn.put_session(:arrow_username, auth_token.username)
       end
     end
   end
+
+  @spec config_value(binary() | {module(), atom(), [any()]}) :: any()
+  defp config_value(value) when is_binary(value), do: value
+  defp config_value({m, f, a}), do: apply(m, f, a)
 end

--- a/lib/fake/ex_aws.ex
+++ b/lib/fake/ex_aws.ex
@@ -1,0 +1,9 @@
+defmodule Fake.ExAws do
+  def arrow_group_request(_operation) do
+    {:ok, %{"Groups" => [%{"GroupName" => Application.get_env(:arrow, :cognito_group)}]}}
+  end
+
+  def unexpected_response(_operation) do
+    {:error, :something_went_wrong}
+  end
+end

--- a/test/arrow_web/utilities_test.exs
+++ b/test/arrow_web/utilities_test.exs
@@ -1,7 +1,7 @@
 defmodule ArrowWeb.UtilitiesTest do
   use ExUnit.Case, async: true
   import ArrowWeb.Utilities
-  alias Arrow.{Disruption, Adjustment}
+  alias Arrow.Disruption
 
   describe "get_json_api_relationships/1" do
     test "parses the data correctly" do

--- a/test/support/helper.ex
+++ b/test/support/helper.ex
@@ -1,0 +1,12 @@
+defmodule Test.Support.Helpers do
+  defmacro reassign_env(var, value) do
+    quote do
+      old_value = Application.get_env(:arrow, unquote(var))
+      Application.put_env(:arrow, unquote(var), unquote(value))
+
+      on_exit(fn ->
+        Application.put_env(:arrow, unquote(var), old_value)
+      end)
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 When authenticating with API token, check that user is still in arrow-admin groupE](https://app.asana.com/0/584764604969369/1184693457899858/f)

Gets the list of groups from the API and passes it along. Steps further along the authentication pipeline will make sure that the `arrow-admin` group is present if needed. I ended up referencing the somewhat-dusty `ex_aws_cognito` library code [here](https://github.com/omt-tech/ex_aws_cognito/blob/master/lib/ex_aws/cognito_idp.ex#L390-L397) as inspiration (thanks @ianwestcott for pointing me to that file).

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
