### PR TITLE
fix: do not show disruptions on calendar if they have no days_of_week

### DIFF
--- a/assets/src/disruptions/disruptionCalendar.tsx
+++ b/assets/src/disruptions/disruptionCalendar.tsx
@@ -53,6 +53,9 @@ export const disruptionsToCalendarEvents = (disruptions: Disruption[]) => {
       }[],
       disruption: Disruption
     ) => {
+      if (!disruption.daysOfWeek.length) {
+        return disruptionsAcc
+      }
       disruption.adjustments.forEach((adj) => {
         const ruleSet = new RRuleSet()
         ruleSet.rrule(

--- a/assets/tests/disruptions/disruptionCalendar.test.tsx
+++ b/assets/tests/disruptions/disruptionCalendar.test.tsx
@@ -67,6 +67,20 @@ const SAMPLE_DISRUPTIONS = [
     exceptions: [],
     tripShortNames: [],
   }),
+  new Disruption({
+    id: "4",
+    startDate: new Date("2019-11-15"),
+    endDate: new Date("2019-11-30"),
+    adjustments: [
+      new Adjustment({
+        routeId: "Green-D",
+        sourceLabel: "Kenmore-Newton Highlands",
+      }),
+    ],
+    daysOfWeek: [],
+    exceptions: [],
+    tripShortNames: [],
+  }),
 ]
 
 describe("DisruptionCalendar", () => {


### PR DESCRIPTION
Problem: the `rrule` library we use to make recurring calendar events will create an event for all days in a range if you supply an empty list for the `byweekday` option, which meant that disruptions created without days of week would be displayed for the entire range even though it would not be applied in `gtfs_creator`

Solution: simply do not create any calendar events if the disruption has no days of week.

Added a change to the sample test data and confirmed that no event was created or displayed on the calendar.

- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
