### PR TITLE
fix: use UTC dates for calendar

### DIFF
--- a/assets/src/disruptions/disruptionCalendar.tsx
+++ b/assets/src/disruptions/disruptionCalendar.tsx
@@ -38,15 +38,6 @@ export const dayNameToInt = (day: DayOfWeek["dayName"]): number => {
   }
 }
 
-const toUTCDate = (date?: Date): Date | undefined => {
-  return (
-    date &&
-    new Date(
-      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
-    )
-  )
-}
-
 const addDay = (date: Date): Date => {
   return new Date(date.setTime(date.getTime() + 60 * 60 * 24 * 1000))
 }
@@ -76,12 +67,12 @@ export const disruptionsToCalendarEvents = (disruptions: Disruption[]) => {
             byweekday: disruption.daysOfWeek?.map((x) =>
               dayNameToInt(x.dayName)
             ),
-            dtstart: toUTCDate(disruption.startDate),
-            until: toUTCDate(disruption.endDate),
+            dtstart: disruption.startDate,
+            until: disruption.endDate,
           })
         )
         disruption.exceptions.forEach((x) => {
-          const excludedDate = toUTCDate(x.excludedDate)
+          const excludedDate = x.excludedDate
           if (excludedDate) {
             ruleSet.exdate(excludedDate)
           }

--- a/assets/src/disruptions/disruptionCalendar.tsx
+++ b/assets/src/disruptions/disruptionCalendar.tsx
@@ -72,9 +72,8 @@ export const disruptionsToCalendarEvents = (disruptions: Disruption[]) => {
           })
         )
         disruption.exceptions.forEach((x) => {
-          const excludedDate = x.excludedDate
-          if (excludedDate) {
-            ruleSet.exdate(excludedDate)
+          if (x.excludedDate) {
+            ruleSet.exdate(x.excludedDate)
           }
         })
 

--- a/assets/src/jsonApi.ts
+++ b/assets/src/jsonApi.ts
@@ -13,6 +13,13 @@ type ModelObject =
 
 type JsonApiResponse = ModelObject | ModelObject[] | "error"
 
+const toUTCDate = (dateStr: string): Date => {
+  const [year, month, date] = dateStr.split("-")
+  return new Date(
+    Date.UTC(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(date, 10))
+  )
+}
+
 const toModelObject = (response: any): JsonApiResponse => {
   const includedObjects: {
     [key: string]: ModelObject | "error"
@@ -111,4 +118,4 @@ const modelFromJsonApiResource = (
   return "error"
 }
 
-export { ModelObject, JsonApiResponse, toModelObject, parseErrors }
+export { ModelObject, JsonApiResponse, toModelObject, parseErrors, toUTCDate }

--- a/assets/src/models/disruption.ts
+++ b/assets/src/models/disruption.ts
@@ -1,6 +1,6 @@
 import { JsonApiResource, JsonApiResourceData } from "../jsonApiResource"
 import JsonApiResourceObject from "../jsonApiResourceObject"
-import { ModelObject } from "../jsonApi"
+import { ModelObject, toUTCDate } from "../jsonApi"
 
 import Adjustment from "./adjustment"
 import DayOfWeek from "./dayOfWeek"
@@ -85,10 +85,10 @@ class Disruption extends JsonApiResourceObject {
       return new Disruption({
         id: raw.id,
         ...(raw.attributes.start_date && {
-          startDate: new Date(raw.attributes.start_date + "T00:00:00"),
+          startDate: toUTCDate(raw.attributes.start_date),
         }),
         ...(raw.attributes.end_date && {
-          endDate: new Date(raw.attributes.end_date + "T00:00:00"),
+          endDate: toUTCDate(raw.attributes.end_date),
         }),
         adjustments: included.filter(Adjustment.isOfType),
         daysOfWeek: included.filter(DayOfWeek.isOfType),

--- a/assets/src/models/exception.ts
+++ b/assets/src/models/exception.ts
@@ -1,6 +1,6 @@
 import { JsonApiResource, JsonApiResourceData } from "../jsonApiResource"
 import JsonApiResourceObject from "../jsonApiResourceObject"
-import { ModelObject } from "../jsonApi"
+import { ModelObject, toUTCDate } from "../jsonApi"
 
 class Exception extends JsonApiResourceObject {
   id?: string
@@ -35,7 +35,7 @@ class Exception extends JsonApiResourceObject {
       return new Exception({
         id: raw.id,
         ...(raw.attributes.excluded_date && {
-          excludedDate: new Date(raw.attributes.excluded_date + "T00:00:00"),
+          excludedDate: toUTCDate(raw.attributes.excluded_date),
         }),
       })
     }

--- a/assets/tests/disruptions/disruptionCalendar.test.tsx
+++ b/assets/tests/disruptions/disruptionCalendar.test.tsx
@@ -9,12 +9,13 @@ import Disruption from "../../src/models/disruption"
 import Adjustment from "../../src/models/adjustment"
 import DayOfWeek from "../../src/models/dayOfWeek"
 import Exception from "../../src/models/exception"
+import { toUTCDate } from "../../src/jsonApi"
 
 const SAMPLE_DISRUPTIONS = [
   new Disruption({
     id: "1",
-    startDate: new Date("2019-10-31"),
-    endDate: new Date("2019-11-15"),
+    startDate: toUTCDate("2019-10-31"),
+    endDate: toUTCDate("2019-11-15"),
     adjustments: [
       new Adjustment({
         routeId: "Red",
@@ -36,13 +37,13 @@ const SAMPLE_DISRUPTIONS = [
         dayName: "sunday",
       }),
     ],
-    exceptions: [new Exception({ excludedDate: new Date("2019-11-01") })],
+    exceptions: [new Exception({ excludedDate: toUTCDate("2019-11-01") })],
     tripShortNames: [],
   }),
   new Disruption({
     id: "3",
-    startDate: new Date("2019-11-15"),
-    endDate: new Date("2019-11-30"),
+    startDate: toUTCDate("2019-11-15"),
+    endDate: toUTCDate("2019-11-30"),
     adjustments: [
       new Adjustment({
         routeId: "Green-D",
@@ -69,8 +70,8 @@ const SAMPLE_DISRUPTIONS = [
   }),
   new Disruption({
     id: "4",
-    startDate: new Date("2019-11-15"),
-    endDate: new Date("2019-11-30"),
+    startDate: toUTCDate("2019-11-15"),
+    endDate: toUTCDate("2019-11-30"),
     adjustments: [
       new Adjustment({
         routeId: "Green-D",
@@ -105,8 +106,8 @@ describe("DisruptionCalendar", () => {
           id: "1",
           title: "AlewifeHarvard",
           backgroundColor: "#da291c",
-          start: new Date("2019-11-02T00:00:00.000Z"),
-          end: new Date("2019-11-04T00:00:00.000Z"),
+          start: toUTCDate("2019-11-02"),
+          end: toUTCDate("2019-11-04"),
           url: "/disruptions/1",
           eventDisplay: "block",
           allDay: true,
@@ -115,8 +116,8 @@ describe("DisruptionCalendar", () => {
           id: "1",
           title: "AlewifeHarvard",
           backgroundColor: "#da291c",
-          start: new Date("2019-11-08T00:00:00.000Z"),
-          end: new Date("2019-11-11T00:00:00.000Z"),
+          start: toUTCDate("2019-11-08"),
+          end: toUTCDate("2019-11-11"),
           url: "/disruptions/1",
           eventDisplay: "block",
           allDay: true,
@@ -125,8 +126,8 @@ describe("DisruptionCalendar", () => {
           id: "1",
           title: "AlewifeHarvard",
           backgroundColor: "#da291c",
-          start: new Date("2019-11-15T00:00:00.000Z"),
-          end: new Date("2019-11-15T00:00:00.000Z"),
+          start: toUTCDate("2019-11-15"),
+          end: toUTCDate("2019-11-15"),
           url: "/disruptions/1",
           eventDisplay: "block",
           allDay: true,
@@ -135,8 +136,8 @@ describe("DisruptionCalendar", () => {
           id: "3",
           title: "Kenmore-Newton Highlands",
           backgroundColor: "#00843d",
-          start: new Date("2019-11-15T00:00:00.000Z"),
-          end: new Date("2019-11-18T00:00:00.000Z"),
+          start: toUTCDate("2019-11-15"),
+          end: toUTCDate("2019-11-18"),
           url: "/disruptions/3",
           eventDisplay: "block",
           allDay: true,
@@ -145,8 +146,8 @@ describe("DisruptionCalendar", () => {
           id: "3",
           title: "Kenmore-Newton Highlands",
           backgroundColor: "#00843d",
-          start: new Date("2019-11-22T00:00:00.000Z"),
-          end: new Date("2019-11-25T00:00:00.000Z"),
+          start: toUTCDate("2019-11-22"),
+          end: toUTCDate("2019-11-25"),
           url: "/disruptions/3",
           eventDisplay: "block",
           allDay: true,
@@ -155,8 +156,8 @@ describe("DisruptionCalendar", () => {
           id: "3",
           title: "Kenmore-Newton Highlands",
           backgroundColor: "#00843d",
-          start: new Date("2019-11-29T00:00:00.000Z"),
-          end: new Date("2019-12-01T00:00:00.000Z"),
+          start: toUTCDate("2019-11-29"),
+          end: toUTCDate("2019-12-01"),
           url: "/disruptions/3",
           eventDisplay: "block",
           allDay: true,
@@ -169,8 +170,8 @@ describe("DisruptionCalendar", () => {
         disruptionsToCalendarEvents([
           new Disruption({
             id: "1",
-            startDate: new Date("2020-07-01"),
-            endDate: new Date("2020-07-02"),
+            startDate: toUTCDate("2020-07-01"),
+            endDate: toUTCDate("2020-07-02"),
             adjustments: [
               new Adjustment({
                 routeId: "Red",
@@ -195,12 +196,12 @@ describe("DisruptionCalendar", () => {
   test("handles daylight savings correctly", () => {
     const { container } = render(
       <DisruptionCalendar
-        initialDate={new Date("2020-11-15")}
+        initialDate={toUTCDate("2020-11-15")}
         disruptions={[
           new Disruption({
             id: "1",
-            startDate: new Date("2020-10-30"),
-            endDate: new Date("2020-11-22"),
+            startDate: toUTCDate("2020-10-30"),
+            endDate: toUTCDate("2020-11-22"),
             adjustments: [
               new Adjustment({
                 routeId: "Red",
@@ -223,7 +224,7 @@ describe("DisruptionCalendar", () => {
               }),
             ],
             exceptions: [
-              new Exception({ excludedDate: new Date("2020-11-15") }),
+              new Exception({ excludedDate: toUTCDate("2020-11-15") }),
             ],
             tripShortNames: [],
           }),
@@ -249,7 +250,7 @@ describe("DisruptionCalendar", () => {
   test("renders correctly", () => {
     const tree = render(
       <DisruptionCalendar
-        initialDate={new Date("2019-11-15")}
+        initialDate={toUTCDate("2019-11-15")}
         disruptions={SAMPLE_DISRUPTIONS}
       />
     )

--- a/assets/tests/disruptions/disruptionCalendar.test.tsx
+++ b/assets/tests/disruptions/disruptionCalendar.test.tsx
@@ -192,11 +192,64 @@ describe("DisruptionCalendar", () => {
     })
   })
 
+  test("handles daylight savings correctly", () => {
+    const { container } = render(
+      <DisruptionCalendar
+        initialDate={new Date("2020-11-15")}
+        disruptions={[
+          new Disruption({
+            id: "1",
+            startDate: new Date("2020-10-30"),
+            endDate: new Date("2020-11-22"),
+            adjustments: [
+              new Adjustment({
+                routeId: "Red",
+                sourceLabel: "AlewifeHarvard",
+              }),
+            ],
+            daysOfWeek: [
+              new DayOfWeek({
+                id: "1",
+                startTime: "20:45:00",
+                dayName: "friday",
+              }),
+              new DayOfWeek({
+                id: "2",
+                dayName: "saturday",
+              }),
+              new DayOfWeek({
+                id: "3",
+                dayName: "sunday",
+              }),
+            ],
+            exceptions: [
+              new Exception({ excludedDate: new Date("2020-11-15") }),
+            ],
+            tripShortNames: [],
+          }),
+        ]}
+      />
+    )
+
+    const activeDays = ["01", "06", "08", "13", "20", "22"]
+
+    activeDays.forEach((day) => {
+      expect(
+        container.querySelector(
+          `[data-date="2020-11-${day}"] .fc-daygrid-event`
+        )
+      ).not.toBeNull()
+    })
+
+    expect(
+      container.querySelector('[data-date="2020-11-15"] .fc-daygrid-event')
+    ).toBeNull()
+  })
+
   test("renders correctly", () => {
     const tree = render(
       <DisruptionCalendar
         initialDate={new Date("2019-11-15")}
-        timeZone="UTC"
         disruptions={SAMPLE_DISRUPTIONS}
       />
     )

--- a/assets/tests/jsonApi.test.ts
+++ b/assets/tests/jsonApi.test.ts
@@ -106,8 +106,8 @@ describe("toModelObject", () => {
     ).toEqual(
       new Disruption({
         id: "1",
-        startDate: new Date("2019-12-20T00:00:00"),
-        endDate: new Date("2020-01-12T00:00:00"),
+        startDate: new Date("2019-12-20T00:00:00Z"),
+        endDate: new Date("2020-01-12T00:00:00Z"),
         adjustments: [
           new Adjustment({
             id: "12",
@@ -145,7 +145,7 @@ describe("toModelObject", () => {
     ).toEqual(
       new Exception({
         id: "1",
-        excludedDate: new Date("2019-12-20T00:00:00"),
+        excludedDate: new Date("2019-12-20T00:00:00Z"),
       })
     )
   })
@@ -297,8 +297,8 @@ describe("toModelObject", () => {
     ).toEqual([
       new Disruption({
         id: "1",
-        startDate: new Date("2019-12-20T00:00:00"),
-        endDate: new Date("2020-01-12T00:00:00"),
+        startDate: new Date("2019-12-20T00:00:00Z"),
+        endDate: new Date("2020-01-12T00:00:00Z"),
         adjustments: [
           new Adjustment({
             id: "12",
@@ -313,8 +313,8 @@ describe("toModelObject", () => {
       }),
       new Disruption({
         id: "2",
-        startDate: new Date("2019-12-25T00:00:00"),
-        endDate: new Date("2020-01-15T00:00:00"),
+        startDate: new Date("2019-12-25T00:00:00Z"),
+        endDate: new Date("2020-01-15T00:00:00Z"),
         adjustments: [
           new Adjustment({
             id: "13",

--- a/assets/tests/models/disruption.test.ts
+++ b/assets/tests/models/disruption.test.ts
@@ -67,8 +67,8 @@ describe("Disruption", () => {
     ).toEqual(
       new Disruption({
         id: "1",
-        startDate: new Date("2019-12-20T00:00:00"),
-        endDate: new Date("2020-01-12T00:00:00"),
+        startDate: new Date("2019-12-20T00:00:00Z"),
+        endDate: new Date("2020-01-12T00:00:00Z"),
         adjustments: [],
         daysOfWeek: [
           new DayOfWeek({

--- a/assets/tests/models/exception.test.ts
+++ b/assets/tests/models/exception.test.ts
@@ -26,7 +26,7 @@ describe("Exception", () => {
         attributes: { excluded_date: "2020-03-30" },
       })
     ).toEqual(
-      new Exception({ id: "1", excludedDate: new Date("2020-03-30T00:00:00") })
+      new Exception({ id: "1", excludedDate: new Date("2020-03-30T00:00:00Z") })
     )
   })
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] fix bug in Arrow calendar dates after 11/1](https://app.asana.com/0/584764604969369/1188024321662505/f)

Problem: We were not handling the quirks of the [`rrule`](https://github.com/jakubroztocil/rrule#important-use-utc-dates) library correctly, which caused dates to be off after daylight savings on 11/1/2020.

> The bottom line is the returned "UTC" dates are always meant to be interpreted as dates in your local timezone. This may mean you have to do additional conversion to get the "correct" local time with offset applied.

Solution: convert dates provided to `rrule` following the example in the library's README
```
// RIGHT: Will produce dates with recurrences at the correct time
new RRule({
  freq: RRule.MONTHLY,
  dtstart: new Date(Date.UTC(2018, 1, 1, 10, 30)),
  until: new Date(Date.UTC(2018, 2, 31))
}).all()

[ '2018-02-01T10:30:00.000Z', '2018-03-01T10:30:00.000Z' ]
```

## SEPTEMBER BEFORE
![Screen Shot 2020-08-07 at 2 39 49 PM](https://user-images.githubusercontent.com/18427346/89677834-2128e180-d8bc-11ea-9fc7-24040796565c.png)


## SEPTEMBER AFTER (SHOULD BE THE SAME AS IT WAS CORRECT BEFORE)
![Screen Shot 2020-08-07 at 2 40 29 PM](https://user-images.githubusercontent.com/18427346/89677861-27b75900-d8bc-11ea-9616-d70022c98f3a.png)


## NOVEMBER BEFORE
![Screen Shot 2020-08-07 at 2 39 59 PM](https://user-images.githubusercontent.com/18427346/89677914-4158a080-d8bc-11ea-85d2-0d8b0ddd9d69.png)


## NOVEMBER AFTER
![Screen Shot 2020-08-07 at 2 40 36 PM](https://user-images.githubusercontent.com/18427346/89677927-46b5eb00-d8bc-11ea-8757-cdf3444f7766.png)


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
