### PR TITLE
fix: linter error

### DIFF
--- a/assets/tests/disruptions/disruptionCalendar.test.tsx
+++ b/assets/tests/disruptions/disruptionCalendar.test.tsx
@@ -208,6 +208,7 @@ describe("DisruptionCalendar", () => {
             endDate: toUTCDate("2020-11-22"),
             adjustments: [
               new Adjustment({
+                id: "1",
                 routeId: "Red",
                 sourceLabel: "AlewifeHarvard",
               }),


### PR DESCRIPTION
Merged in an out-of-date branch and missed adding an `id` after making it required in a prior commit.