### PR TITLE
fix: sort exception dates

### DIFF
--- a/assets/src/disruptions/disruptionTimePicker.tsx
+++ b/assets/src/disruptions/disruptionTimePicker.tsx
@@ -323,7 +323,13 @@ const DisruptionExceptionDateList = ({
           <Row>
             <Col md="auto">
               <DatePicker
-                selected={date}
+                selected={
+                  new Date(
+                    date.getUTCFullYear(),
+                    date.getUTCMonth(),
+                    date.getUTCDate()
+                  )
+                }
                 onChange={(newDate) => {
                   if (newDate !== null) {
                     setExceptionDates(

--- a/assets/src/disruptions/editDisruption.tsx
+++ b/assets/src/disruptions/editDisruption.tsx
@@ -170,11 +170,10 @@ const setExceptionDatesForDisruption = (
     const newExceptionDatesAsTimes = newExceptionDates.map((date) =>
       date.getTime()
     )
-    const currentExceptionDates = (disruption.exceptions
+    const currentExceptionDates = disruption.exceptions
       .map((exception) => exception.excludedDate)
-      .filter((maybeDate) => maybeDate instanceof Date) as Date[]).map((date) =>
-      date.getTime()
-    )
+      .filter((maybeDate) => maybeDate instanceof Date)
+      .map((date) => date.getTime())
 
     const addedDates = newExceptionDatesAsTimes.filter(
       (date) => !currentExceptionDates.includes(date)

--- a/assets/src/models/disruption.ts
+++ b/assets/src/models/disruption.ts
@@ -92,7 +92,9 @@ class Disruption extends JsonApiResourceObject {
         }),
         adjustments: included.filter(Adjustment.isOfType),
         daysOfWeek: included.filter(DayOfWeek.isOfType),
-        exceptions: included.filter(Exception.isOfType),
+        exceptions: included
+          .filter(Exception.isOfType)
+          .sort((a, b) => a.excludedDate.getTime() - b.excludedDate.getTime()),
         tripShortNames: included.filter(TripShortName.isOfType),
       })
     }

--- a/assets/src/models/exception.ts
+++ b/assets/src/models/exception.ts
@@ -4,9 +4,9 @@ import { ModelObject, toUTCDate } from "../jsonApi"
 
 class Exception extends JsonApiResourceObject {
   id?: string
-  excludedDate?: Date
+  excludedDate: Date
 
-  constructor({ id, excludedDate }: { id?: string; excludedDate?: Date }) {
+  constructor({ id, excludedDate }: { id?: string; excludedDate: Date }) {
     super()
     this.id = id
     this.excludedDate = excludedDate

--- a/assets/tests/models/disruption.test.ts
+++ b/assets/tests/models/disruption.test.ts
@@ -18,7 +18,9 @@ describe("Disruption", () => {
         }),
       ],
       daysOfWeek: [new DayOfWeek({ id: "2", dayName: "friday" })],
-      exceptions: [new Exception({ id: "3" })],
+      exceptions: [
+        new Exception({ id: "3", excludedDate: new Date(2020, 0, 2) }),
+      ],
       tripShortNames: [new TripShortName({ id: "4" })],
     })
 
@@ -50,7 +52,13 @@ describe("Disruption", () => {
             ],
           },
           exceptions: {
-            data: [{ id: "3", type: "exception", attributes: {} }],
+            data: [
+              {
+                id: "3",
+                type: "exception",
+                attributes: { excluded_date: "2020-01-02" },
+              },
+            ],
           },
           trip_short_names: {
             data: [{ id: "4", type: "trip_short_name", attributes: {} }],
@@ -74,6 +82,14 @@ describe("Disruption", () => {
             startTime: "20:45:00",
             dayName: "friday",
           }),
+          new Exception({
+            id: "2",
+            excludedDate: new Date(2020, 1, 1),
+          }),
+          new Exception({
+            id: "1",
+            excludedDate: new Date(2020, 2, 1),
+          }),
         ]
       )
     ).toEqual(
@@ -89,7 +105,16 @@ describe("Disruption", () => {
             dayName: "friday",
           }),
         ],
-        exceptions: [],
+        exceptions: [
+          new Exception({
+            id: "2",
+            excludedDate: new Date(2020, 1, 1),
+          }),
+          new Exception({
+            id: "1",
+            excludedDate: new Date(2020, 2, 1),
+          }),
+        ],
         tripShortNames: [],
       })
     )
@@ -115,6 +140,8 @@ describe("Disruption", () => {
       )
     ).toBe(true)
 
-    expect(Disruption.isOfType(new Exception({}))).toBe(false)
+    expect(
+      Disruption.isOfType(new Exception({ excludedDate: new Date() }))
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Sort exception dates when displaying / editing disruptions](https://app.asana.com/0/584764604969369/1188017252062513/f)

Changes:
* sort `Exceptions` in `Disruption.fromJsonObject`, which flows through to the detail and edit pages
* Also noticed and fixed an issue introduced by https://github.com/mbta/arrow/pull/380, converting dates back from UTC when providing them to `DatePicker` component (the `react-datepicker` library appears to [rely on the local timezone](https://github.com/gpbl/react-day-picker/issues/130)).

### Before
<img width="897" alt="Screen Shot 2020-08-18 at 4 13 04 PM" src="https://user-images.githubusercontent.com/18427346/90562115-b1dea780-e16f-11ea-9424-a2cb0a8fc961.png">

<img width="488" alt="Screen Shot 2020-08-18 at 4 14 06 PM" src="https://user-images.githubusercontent.com/18427346/90562144-bd31d300-e16f-11ea-99dc-1ee9f32a8175.png">

### After
<img width="347" alt="Screen Shot 2020-08-18 at 4 14 36 PM" src="https://user-images.githubusercontent.com/18427346/90562261-eb171780-e16f-11ea-9a1a-85ecd319ebea.png">

<img width="503" alt="Screen Shot 2020-08-18 at 4 14 44 PM" src="https://user-images.githubusercontent.com/18427346/90562282-f10cf880-e16f-11ea-860a-a3adda09c96c.png">


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
