### PR TITLE
fix: Regenerate AWS IAM auth token on connect

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -1,0 +1,18 @@
+import Config
+
+pool_size =
+  case System.get_env("DATABASE_POOL_SIZE") do
+    nil -> 10
+    val -> String.to_integer(val)
+  end
+
+port = System.get_env("DATABASE_PORT") |> String.to_integer()
+
+config :arrow, Arrow.Repo,
+  username: System.get_env("DATABASE_USER"),
+  database: System.get_env("DATABASE_NAME"),
+  hostname: System.get_env("DATABASE_HOST"),
+  port: port,
+  pool_size: pool_size,
+  # password set by `configure` callback below
+  configure: {Arrow.Repo, :before_connect, []}

--- a/lib/arrow/repo.ex
+++ b/lib/arrow/repo.ex
@@ -3,39 +3,23 @@ defmodule Arrow.Repo do
     otp_app: :arrow,
     adapter: Ecto.Adapters.Postgres
 
-  @default_pool_size 10
+  require Logger
 
-  def init(_context, config) do
-    pool_size_env = System.get_env("DATABASE_POOL_SIZE")
-    pool_size_env = if pool_size_env, do: String.to_integer(pool_size_env)
-    pool_size = pool_size_env || Keyword.get(config, :pool_size) || @default_pool_size
-    config = Keyword.put(config, :pool_size, pool_size)
+  @doc """
+  Set via the `:configure` option in the Arrow.Repo configuration, a function
+  invoked prior to each DB connection. `config` is the configured connection values
+  and it returns a new set of config values to be used when connecting.
+  """
+  def before_connect(config) do
+    :ok = Logger.info("generating_aws_rds_iam_auth_token")
+    username = Keyword.fetch!(config, :username)
+    hostname = Keyword.fetch!(config, :hostname)
+    port = Keyword.fetch!(config, :port)
 
-    config =
-      if Keyword.take(config, [:database, :username, :password, :hostname]) == [] do
-        username = System.get_env("DATABASE_USER")
-        database = System.get_env("DATABASE_NAME")
-        hostname = System.get_env("DATABASE_HOST")
-        port = "DATABASE_PORT" |> System.get_env() |> String.to_integer()
+    mod = Application.get_env(:arrow, :aws_rds_mod)
+    token = apply(mod, :generate_db_auth_token, [hostname, username, port, %{}])
+    :ok = Logger.info("generated_aws_rds_iam_auth_token")
 
-        if !username, do: raise("missing DATABASE_USER environment variable")
-        if !database, do: raise("missing DATABASE_NAME environment variable")
-        if !hostname, do: raise("missing DATABASE_HOST environment variable")
-
-        mod = Application.get_env(:arrow, :aws_rds_mod)
-        token = apply(mod, :generate_db_auth_token, [hostname, username, port, %{}])
-
-        Keyword.merge(config,
-          database: database,
-          username: username,
-          hostname: hostname,
-          password: token,
-          port: port
-        )
-      else
-        config
-      end
-
-    {:ok, config}
+    Keyword.put(config, :password, token)
   end
 end

--- a/semaphore/credo.sh
+++ b/semaphore/credo.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -ex
 
+mix compile --force --warnings-as-errors
 mix credo --strict

--- a/test/arrow/repo_test.exs
+++ b/test/arrow/repo_test.exs
@@ -1,5 +1,6 @@
 defmodule Arrow.RepoTest do
   use ExUnit.Case, async: false
+  import Test.Support.Helpers
 
   defmodule FakeAwsRds do
     def generate_db_auth_token(_, _, _, _) do
@@ -7,70 +8,11 @@ defmodule Arrow.RepoTest do
     end
   end
 
-  @default_config [
-    pool_size: 8,
-    database: "test"
-  ]
-
-  describe "init/2" do
-    test "fills in :pool_size based on ENV" do
-      System.put_env("DATABASE_POOL_SIZE", "9")
-      on_exit(fn -> System.delete_env("DATABASE_POOL_SIZE") end)
-
-      config = Keyword.put(@default_config, :pool_size, 5)
-      assert {:ok, config} = Arrow.Repo.init(:supervisor, config)
-
-      assert Keyword.get(config, :pool_size) == 9
-    end
-
-    test "leaves existing :pool_size in there" do
-      config = Keyword.put(@default_config, :pool_size, 5)
-      assert {:ok, config} = Arrow.Repo.init(:supervisor, config)
-
-      assert Keyword.get(config, :pool_size) == 5
-    end
-
-    test "provides default :pool_size" do
-      config = Keyword.delete(@default_config, :pool_size)
-      assert {:ok, config} = Arrow.Repo.init(:supervisor, config)
-
-      assert Keyword.get(config, :pool_size) == 10
-    end
-
-    test "keeps DB credentials if provided" do
-      config = Keyword.put(@default_config, :username, "test_user")
-      assert {:ok, config} = Arrow.Repo.init(:supervisor, config)
-      assert Keyword.get(config, :username) == "test_user"
-    end
-
-    test "raises an exception if empty credentials and no ENV vars" do
-      config = Keyword.delete(@default_config, :database)
-
-      assert_raise(ArgumentError, fn ->
-        Arrow.Repo.init(:supervisor, config)
-      end)
-    end
-
-    test "gets password token for RDS IAM auth" do
-      previous_rds_mod = Application.get_env(:arrow, :aws_rds_mod)
-      Application.put_env(:arrow, :aws_rds_mod, FakeAwsRds)
-      System.put_env("DATABASE_USER", "db_user")
-      System.put_env("DATABASE_HOST", "db_host")
-      System.put_env("DATABASE_NAME", "db_name")
-      System.put_env("DATABASE_PORT", "9999")
-
-      on_exit(fn ->
-        Application.put_env(:arrow, :aws_rds_mod, previous_rds_mod)
-        System.delete_env("DATABASE_USER")
-        System.delete_env("DATABASE_HOST")
-        System.delete_env("DATABASE_NAME")
-        System.delete_env("DATABASE_PORT")
-      end)
-
-      config = Keyword.delete(@default_config, :database)
-
-      assert {:ok, config} = Arrow.Repo.init(:supervisor, config)
-      assert Keyword.get(config, :password) == "iam_token"
+  describe "before_connect/1" do
+    test "generates RDS IAM auth token" do
+      reassign_env(:aws_rds_mod, FakeAwsRds)
+      config = Arrow.Repo.before_connect(username: "u", hostname: "h", port: 4000)
+      assert Keyword.fetch!(config, :password) == "iam_token"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Reconnect after DB authentication changes](https://app.asana.com/0/584764604969369/1186678199122409)

The fix here is actually pretty simple. `Ecto.Repo` options are passed to the `Postgrex` adaptor which are passed to [`DBConnection`](https://hexdocs.pm/db_connection/DBConnection.html#start_link/2), which has a nice `:configure` option which takes a MFA tuple for a function it should call before each time it tries to connect.

By moving the `ex_aws_rds` logic into that function, the actual configuration of the DB can now be done with the usual, simple `config :arrow, Arrow.Repo, ...` approach. Since the prod environment will pull from environment variables, I made a `releases.exs` file for `mix release` to use.

I confirmed that I could induce the `PAM authentication failed` error on arrow-dev running the master branch by rebooting the RDS instance from the AWS console, at least [15 minutes](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) after the last deploy. With this branch running when I reboot the RDS instance it works fine, and I see the `generating_token` log message.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
