### PR TITLE
fix: convert all dates provided to DatePicker component into UTC dates

### DIFF
--- a/assets/src/datePicker.tsx
+++ b/assets/src/datePicker.tsx
@@ -4,13 +4,24 @@ import ReactDatePicker, { ReactDatePickerProps } from "react-datepicker"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faCalendar } from "@fortawesome/free-solid-svg-icons"
 
-const DatePicker = (props: ReactDatePickerProps): JSX.Element => {
+const DatePicker = ({
+  selected,
+  ...rest
+}: ReactDatePickerProps): JSX.Element => {
   return (
     <div className="m-datepicker__container">
       <ReactDatePicker
         className="m-datepicker__react"
         placeholderText="__ / __ / ____"
-        {...props}
+        selected={
+          selected &&
+          new Date(
+            selected.getUTCFullYear(),
+            selected.getUTCMonth(),
+            selected.getUTCDate()
+          )
+        }
+        {...rest}
       />
       <div className="m-datepicker__icon">
         <FontAwesomeIcon icon={faCalendar} />

--- a/assets/src/disruptions/disruptionTimePicker.tsx
+++ b/assets/src/disruptions/disruptionTimePicker.tsx
@@ -323,13 +323,7 @@ const DisruptionExceptionDateList = ({
           <Row>
             <Col md="auto">
               <DatePicker
-                selected={
-                  new Date(
-                    date.getUTCFullYear(),
-                    date.getUTCMonth(),
-                    date.getUTCDate()
-                  )
-                }
+                selected={date}
                 onChange={(newDate) => {
                   if (newDate !== null) {
                     setExceptionDates(


### PR DESCRIPTION
#### Summary of changes
Follow up to https://github.com/mbta/arrow/pull/392, applying the same fix to Disruption date range inputs, this time just moving the date conversion into the logic our wrapper component.

### Actual Disruption
<img width="311" alt="Screen Shot 2020-08-20 at 2 54 20 PM" src="https://user-images.githubusercontent.com/18427346/90813309-6b1aba00-e2f5-11ea-8edd-7a0d73091527.png">


### Edit Page Before
<img width="518" alt="Screen Shot 2020-08-20 at 2 54 47 PM" src="https://user-images.githubusercontent.com/18427346/90813330-7241c800-e2f5-11ea-954c-5325b66df885.png">

### Edit Page After
<img width="495" alt="Screen Shot 2020-08-20 at 2 54 26 PM" src="https://user-images.githubusercontent.com/18427346/90813345-7837a900-e2f5-11ea-933c-4f37805e1de6.png">

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
