### PR TITLE
feat: add nav links to toggle between published and draft disruption views

### DIFF
--- a/assets/css/_disruption_list_container.scss
+++ b/assets/css/_disruption_list_container.scss
@@ -1,0 +1,19 @@
+.m-disruption-list-container_nav-link {
+  color: inherit;
+  padding: inherit 0;
+  margin-right: 2em;
+  text-decoration: inherit;
+
+  &:hover {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  &.active {
+    border-bottom: 5px solid;
+  }
+
+  &:not(.active) {
+    color: grey;
+  }
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -9,6 +9,7 @@
 @import "disruption_times";
 @import "disruption_summary";
 @import "new_disruption_preview";
+@import "disruption_list_container";
 @import "disruption_table";
 @import "disruption_index";
 @import "datepicker";

--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -14,12 +14,18 @@ import EditDisruption from "./disruptions/editDisruption"
 import { NewDisruption } from "./disruptions/newDisruption"
 import ViewDisruption from "./disruptions/viewDisruption"
 import { DisruptionIndex } from "./disruptions/disruptionIndex"
+import { DisruptionNeedsReview } from "./disruptions/disruptionNeedsReview"
 
 const App = (): JSX.Element => {
   return (
     <BrowserRouter>
       <Switch>
         <Route exact={true} path="/" component={DisruptionIndex} />
+        <Route
+          exact={true}
+          path="/disruptions/needs_review"
+          component={DisruptionNeedsReview}
+        />
         <Route exact={true} path="/disruptions/new" component={NewDisruption} />
         <Route
           exact={true}

--- a/assets/src/disruptions/disruptionCalendar.tsx
+++ b/assets/src/disruptions/disruptionCalendar.tsx
@@ -121,7 +121,7 @@ export const DisruptionCalendar = ({
     return disruptionsToCalendarEvents(disruptions)
   }, [disruptions])
   return (
-    <div id="calendar" className="mb-3">
+    <div id="calendar" className="my-3">
       <FullCalendar
         initialDate={initialDate}
         timeZone="UTC"

--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -6,7 +6,6 @@ import classnames from "classnames"
 import Row from "react-bootstrap/Row"
 import Col from "react-bootstrap/Col"
 import Form from "react-bootstrap/Form"
-import Header from "../header"
 import Button from "react-bootstrap/Button"
 import Icon from "../icons"
 import { DisruptionTable } from "./disruptionTable"
@@ -14,6 +13,8 @@ import { DisruptionCalendar } from "./disruptionCalendar"
 import Disruption from "../models/disruption"
 import { apiGet } from "../api"
 import { JsonApiResponse, toModelObject } from "../jsonApi"
+import { Page } from "../page"
+import { DisruptionListContainer } from "./disruptionListContainer"
 
 export type Routes =
   | "Red"
@@ -202,63 +203,63 @@ const DisruptionIndexView = ({ disruptions }: DisruptionIndexProps) => {
   }, [disruptions, searchQuery, routeFilters, anyRouteFiltersActive])
 
   return (
-    <div>
-      <Header includeHomeLink={false} />
-      <h1>Disruptions</h1>
-      <Row>
-        <Col xs={9}>
-          {view === "table" ? (
-            <DisruptionTable disruptions={filteredDisruptions} />
-          ) : (
-            <DisruptionCalendar disruptions={filteredDisruptions} />
-          )}
-        </Col>
-        <Col>
-          <Button
-            id="view-toggle"
-            className="mb-3 border"
-            variant="light"
-            onClick={toggleView}
-          >
-            {view === "calendar" ? "list view" : "calendar view"}
-          </Button>
-          <Form.Control
-            className="mb-3"
-            type="text"
-            value={searchQuery}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setSearchQuery(e.target.value)
-            }
-            placeholder="Search Disruptions"
-          />
-          <h6>Filter by route</h6>
-          <RouteFilterToggleGroup
-            routes={["Blue", "Mattapan", "Orange", "Red"]}
-            toggleRouteFilterState={toggleRouteFilterState}
-            isRouteActive={isRouteActive}
-          />
-          <RouteFilterToggleGroup
-            routes={["Green-B", "Green-C", "Green-D", "Green-E"]}
-            toggleRouteFilterState={toggleRouteFilterState}
-            isRouteActive={isRouteActive}
-          />
-          <RouteFilterToggleGroup
-            routes={["Commuter"]}
-            toggleRouteFilterState={toggleRouteFilterState}
-            isRouteActive={isRouteActive}
-          />
-          {anyRouteFiltersActive && (
-            <a
-              className="m-disruption-index__clear_filter_button"
-              id="clear-filter"
-              onClick={clearRouteFilters}
+    <Page includeHomeLink={false}>
+      <DisruptionListContainer>
+        <Row>
+          <Col xs={9}>
+            {view === "table" ? (
+              <DisruptionTable disruptions={filteredDisruptions} />
+            ) : (
+              <DisruptionCalendar disruptions={filteredDisruptions} />
+            )}
+          </Col>
+          <Col>
+            <Button
+              id="view-toggle"
+              className="my-3 border"
+              variant="light"
+              onClick={toggleView}
             >
-              <FontAwesomeIcon icon={faTimes} className="mr-1" />
-              clear filter
-            </a>
-          )}
-        </Col>
-      </Row>
+              {view === "calendar" ? "list view" : "calendar view"}
+            </Button>
+            <Form.Control
+              className="mb-3"
+              type="text"
+              value={searchQuery}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setSearchQuery(e.target.value)
+              }
+              placeholder="Search Disruptions"
+            />
+            <h6>Filter by route</h6>
+            <RouteFilterToggleGroup
+              routes={["Blue", "Mattapan", "Orange", "Red"]}
+              toggleRouteFilterState={toggleRouteFilterState}
+              isRouteActive={isRouteActive}
+            />
+            <RouteFilterToggleGroup
+              routes={["Green-B", "Green-C", "Green-D", "Green-E"]}
+              toggleRouteFilterState={toggleRouteFilterState}
+              isRouteActive={isRouteActive}
+            />
+            <RouteFilterToggleGroup
+              routes={["Commuter"]}
+              toggleRouteFilterState={toggleRouteFilterState}
+              isRouteActive={isRouteActive}
+            />
+            {anyRouteFiltersActive && (
+              <a
+                className="m-disruption-index__clear_filter_button"
+                id="clear-filter"
+                onClick={clearRouteFilters}
+              >
+                <FontAwesomeIcon icon={faTimes} className="mr-1" />
+                clear filter
+              </a>
+            )}
+          </Col>
+        </Row>
+      </DisruptionListContainer>
       <Row>
         <Col>
           <Link to="/disruptions/new">
@@ -266,7 +267,7 @@ const DisruptionIndexView = ({ disruptions }: DisruptionIndexProps) => {
           </Link>
         </Col>
       </Row>
-    </div>
+    </Page>
   )
 }
 

--- a/assets/src/disruptions/disruptionListContainer.tsx
+++ b/assets/src/disruptions/disruptionListContainer.tsx
@@ -1,0 +1,33 @@
+import * as React from "react"
+import { withRouter, RouteComponentProps } from "react-router"
+import { NavLink } from "react-router-dom"
+
+const DisruptionListContainer = withRouter(
+  ({ children }: RouteComponentProps & { children: React.ReactNode }) => {
+    return (
+      <div>
+        <div className="d-flex border-bottom">
+          <NavLink
+            to="/"
+            exact={true}
+            className="m-disruption-list-container_nav-link"
+            activeClassName="active"
+          >
+            <h3>Disruptions</h3>
+          </NavLink>
+          <NavLink
+            to="/disruptions/needs_review"
+            exact={true}
+            className="m-disruption-list-container_nav-link"
+            activeClassName="active"
+          >
+            <h3>Needs Review</h3>
+          </NavLink>
+        </div>
+        {children}
+      </div>
+    )
+  }
+)
+
+export { DisruptionListContainer }

--- a/assets/src/disruptions/disruptionNeedsReview.tsx
+++ b/assets/src/disruptions/disruptionNeedsReview.tsx
@@ -1,0 +1,13 @@
+import * as React from "react"
+import { DisruptionListContainer } from "./disruptionListContainer"
+import { Page } from "../page"
+
+const DisruptionNeedsReview = () => {
+  return (
+    <Page includeHomeLink={false}>
+      <DisruptionListContainer>Needs Review Goes Here</DisruptionListContainer>
+    </Page>
+  )
+}
+
+export { DisruptionNeedsReview }

--- a/assets/src/disruptions/disruptionTable.tsx
+++ b/assets/src/disruptions/disruptionTable.tsx
@@ -22,7 +22,7 @@ const DisruptionTableHeader = ({
   onClick,
 }: DisruptionTableHeaderProps) => {
   return (
-    <th>
+    <th className="border-0">
       <span
         onClick={onClick}
         className={classnames({
@@ -93,7 +93,7 @@ const DisruptionTable = ({ disruptions }: DisruptionTableProps) => {
     [sortState]
   )
   return (
-    <Table striped>
+    <Table className="m-disruption-table" striped>
       <thead>
         <tr>
           <DisruptionTableHeader
@@ -111,7 +111,7 @@ const DisruptionTable = ({ disruptions }: DisruptionTableProps) => {
             onClick={() => handleChangeSort("startDate")}
           />
           <DisruptionTableHeader label="days + times" />
-          <th />
+          <th className="border-0" />
         </tr>
       </thead>
       <tbody>

--- a/assets/src/disruptions/editDisruption.tsx
+++ b/assets/src/disruptions/editDisruption.tsx
@@ -9,7 +9,6 @@ import { RouteComponentProps, Link } from "react-router-dom"
 
 import { apiGet, apiSend } from "../api"
 
-import Header from "../header"
 import Loading from "../loading"
 import { DisruptionSummary } from "./disruptionSummary"
 import {
@@ -26,6 +25,7 @@ import Disruption from "../models/disruption"
 import Exception from "../models/exception"
 import { JsonApiResponse, toModelObject, parseErrors } from "../jsonApi"
 import DayOfWeek from "../models/dayOfWeek"
+import { Page } from "../page"
 
 interface TParams {
   id: string
@@ -280,8 +280,7 @@ const EditDisruptionForm = ({
   validationErrors,
 }: EditDisruptionFormProps): JSX.Element => {
   return (
-    <div>
-      <Header />
+    <Page>
       {validationErrors.length > 0 && (
         <Alert variant="danger">
           <ul>
@@ -309,7 +308,7 @@ const EditDisruptionForm = ({
         />
       </fieldset>
       <SaveCancelButton disruptionId={disruptionId} saveFn={saveDisruption} />
-    </div>
+    </Page>
   )
 }
 

--- a/assets/src/disruptions/newDisruption.tsx
+++ b/assets/src/disruptions/newDisruption.tsx
@@ -14,12 +14,12 @@ import Adjustment from "../models/adjustment"
 import Exception from "../models/exception"
 import { DayOfWeekTimeRanges, dayOfWeekTimeRangesToDayOfWeeks } from "./time"
 
-import Header from "../header"
 import Loading from "../loading"
 import { DisruptionTimePicker } from "./disruptionTimePicker"
 import { TransitMode, modeForRoute } from "./disruptions"
 import { DisruptionPreview } from "./disruptionPreview"
 import TripShortName from "../models/tripShortName"
+import { Page } from "../page"
 
 interface AdjustmentModePickerProps {
   transitMode: TransitMode
@@ -275,8 +275,7 @@ const NewDisruption = ({}): JSX.Element => {
   }
 
   return (
-    <div>
-      <Header />
+    <Page>
       {isPreview ? (
         <DisruptionPreview
           adjustments={adjustments}
@@ -343,7 +342,7 @@ const NewDisruption = ({}): JSX.Element => {
           </Button>
         </>
       )}
-    </div>
+    </Page>
   )
 }
 

--- a/assets/src/disruptions/viewDisruption.tsx
+++ b/assets/src/disruptions/viewDisruption.tsx
@@ -5,13 +5,13 @@ import Button from "react-bootstrap/Button"
 
 import { apiGet, apiSend } from "../api"
 
-import Header from "../header"
 import Loading from "../loading"
 import { DisruptionPreview } from "./disruptionPreview"
 import { fromDaysOfWeek } from "./time"
 
 import Disruption from "../models/disruption"
 import { JsonApiResponse, toModelObject, parseErrors } from "../jsonApi"
+import { Page } from "../page"
 
 interface TParams {
   id: string
@@ -124,8 +124,7 @@ const ViewDisruptionForm = ({
 
     if (disruptionDaysOfWeek !== "error") {
       return (
-        <div>
-          <Header />
+        <Page>
           {deletionErrors.length > 0 && (
             <Alert variant="danger">
               <ul>
@@ -159,7 +158,7 @@ const ViewDisruptionForm = ({
                 />
               </div>
             )}
-        </div>
+        </Page>
       )
     } else {
       return <div>Error parsing day of week information.</div>

--- a/assets/src/page.tsx
+++ b/assets/src/page.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+import Header from "./header"
+
+interface PageProps {
+  children: React.ReactNode
+  includeHomeLink?: boolean
+}
+
+const Page = ({ children, includeHomeLink }: PageProps) => {
+  return (
+    <div>
+      <Header includeHomeLink={includeHomeLink} />
+      {children}
+    </div>
+  )
+}
+
+export { Page }

--- a/assets/tests/disruptions/__snapshots__/disruptionCalendar.test.tsx.snap
+++ b/assets/tests/disruptions/__snapshots__/disruptionCalendar.test.tsx.snap
@@ -6,7 +6,7 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="mb-3"
+        class="my-3"
         id="calendar"
       >
         <div
@@ -1546,7 +1546,7 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="mb-3"
+      class="my-3"
       id="calendar"
     >
       <div

--- a/assets/tests/disruptions/disruptionListContainer.test.tsx
+++ b/assets/tests/disruptions/disruptionListContainer.test.tsx
@@ -1,0 +1,45 @@
+import * as React from "react"
+import { render } from "@testing-library/react"
+import { DisruptionListContainer } from "../../src/disruptions/disruptionListContainer"
+import { Router } from "react-router-dom"
+import { createMemoryHistory } from "history"
+
+describe("DisruptionListContainer", () => {
+  test("renders nav links with indicator for active link", () => {
+    const history = createMemoryHistory()
+    const { container } = render(
+      <Router history={history}>
+        <DisruptionListContainer>content</DisruptionListContainer>
+      </Router>
+    )
+
+    let links = container.getElementsByClassName(
+      "m-disruption-list-container_nav-link"
+    )
+    expect(links.length).toEqual(2)
+    expect(links[0].textContent).toEqual("Disruptions")
+    expect(links[0].classList).toContain("active")
+    expect(links[1].textContent).toEqual("Needs Review")
+    expect(links[1].classList).not.toContain("active")
+
+    history.push("/disruptions/needs_review")
+    links = container.getElementsByClassName(
+      "m-disruption-list-container_nav-link"
+    )
+    expect(links.length).toEqual(2)
+    expect(links[0].textContent).toEqual("Disruptions")
+    expect(links[0].classList).not.toContain("active")
+    expect(links[1].textContent).toEqual("Needs Review")
+    expect(links[1].classList).toContain("active")
+  })
+
+  test("renders content", () => {
+    const history = createMemoryHistory()
+    const { container } = render(
+      <Router history={history}>
+        <DisruptionListContainer>My Content Here!</DisruptionListContainer>
+      </Router>
+    )
+    expect(container.textContent).toContain("My Content Here!")
+  })
+})

--- a/assets/tests/page.test.tsx
+++ b/assets/tests/page.test.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react"
+import { Page } from "../src/page"
+
+describe("Page", () => {
+  test("conditionally renders home link", () => {
+    const { container } = render(
+      <Page includeHomeLink={true}>
+        <div id="content">Your content here!!!</div>
+      </Page>
+    )
+    let link = container.getElementsByTagName("a")[0]
+    expect(link.textContent).toContain("back to home")
+
+    const { container: containerWithoutLink } = render(
+      <Page includeHomeLink={true}>
+        <div id="content">Your content here!!!</div>
+      </Page>
+    )
+    link = containerWithoutLink.getElementsByTagName("a")[0]
+    expect(link).not.toBeUndefined()
+  })
+  test("renders children", () => {
+    render(
+      <Page>
+        <div id="content">Your content here!!!</div>
+      </Page>
+    )
+    expect(screen.getByText("Your content here!!!")).toBeDefined()
+  })
+})


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Navigation bar with disruption and review pages ](https://app.asana.com/0/584764604969369/1185700222235219/f)

Changes:
* Added `DisruptionListContainer` component containing the new navigation links, which can wrap `DisruptionIndex`, the coming "Needs Review" page or any other page we'd want to have those links for
* Pulled out the logic we had rendering `Header` in each individual page into a `Page` wrapper that handles it for us
* Some small style tweaks 

![toggle](https://user-images.githubusercontent.com/18427346/90913032-a2e33980-e3a9-11ea-9460-aa79813eb601.gif)


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
