### PR TITLE
Distinguish published / draft disruptions

### DIFF
--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -277,7 +277,7 @@ const DisruptionIndex = () => {
   )
   React.useEffect(() => {
     apiGet<JsonApiResponse>({
-      url: "/api/disruptions",
+      url: "/api/disruptions?only_published=true",
       parser: toModelObject,
       defaultResult: "error",
     }).then((result: JsonApiResponse) => {

--- a/lib/arrow/disruption.ex
+++ b/lib/arrow/disruption.ex
@@ -57,11 +57,6 @@ defmodule Arrow.Disruption do
 
     case Arrow.Repo.insert(disruption_revision_changeset) do
       {:ok, disruption_revision} ->
-        # For now, automatically "publish"
-        disruption
-        |> Ecto.Changeset.change(%{published_revision_id: disruption_revision.id})
-        |> Arrow.Repo.update!()
-
         {:ok, disruption_revision}
 
       {:error, err} ->
@@ -88,11 +83,6 @@ defmodule Arrow.Disruption do
 
     case Arrow.Repo.update(dr_changeset) do
       {:ok, disruption_revision} ->
-        # For now, automatically "publish"
-        Arrow.Repo.get!(Arrow.Disruption, disruption_revision.disruption_id)
-        |> Ecto.Changeset.change(%{published_revision_id: disruption_revision.id})
-        |> Arrow.Repo.update!()
-
         {:ok, disruption_revision}
 
       {:error, e} ->
@@ -109,11 +99,6 @@ defmodule Arrow.Disruption do
       Arrow.Repo.get(Arrow.DisruptionRevision, new_disruption_revision.id)
       |> change(%{is_active: false})
       |> Arrow.Repo.update!()
-
-    # For now, automatically "publish"
-    Arrow.Repo.get!(Arrow.Disruption, disruption_revision.disruption_id)
-    |> Ecto.Changeset.change(%{published_revision_id: disruption_revision.id})
-    |> Arrow.Repo.update!()
 
     {:ok, disruption_revision}
   end

--- a/lib/arrow/disruption.ex
+++ b/lib/arrow/disruption.ex
@@ -65,6 +65,7 @@ defmodule Arrow.Disruption do
     end
   end
 
+  @spec update(integer(), map()) :: {:ok, Arrow.DisruptionRevision.t()} | {:error, any()}
   def update(disruption_revision_id, attrs) do
     new_disruption_revision = Arrow.DisruptionRevision.clone!(disruption_revision_id)
 

--- a/lib/arrow/disruption_revision.ex
+++ b/lib/arrow/disruption_revision.ex
@@ -35,6 +35,7 @@ defmodule Arrow.DisruptionRevision do
     timestamps(type: :utc_datetime)
   end
 
+  @spec only_published(Ecto.Queryable.t()) :: Ecto.Query.t()
   def only_published(query) do
     published_ids =
       from(d in Disruption, select: d.published_revision_id) |> Repo.all() |> Enum.filter(& &1)
@@ -42,7 +43,8 @@ defmodule Arrow.DisruptionRevision do
     from(dr in query, where: dr.id in ^published_ids and dr.is_active)
   end
 
-  def only_draft(query) do
+  @spec latest_revision(Ecto.Queryable.t()) :: Ecto.Query.t()
+  def latest_revision(query) do
     draft_ids =
       from(dr in __MODULE__, select: max(dr.id), group_by: dr.disruption_id) |> Repo.all()
 

--- a/lib/arrow_web/controllers/temp_review_changes_controller.ex
+++ b/lib/arrow_web/controllers/temp_review_changes_controller.ex
@@ -1,0 +1,15 @@
+defmodule ArrowWeb.TempReviewChangesController do
+  use ArrowWeb, :controller
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, _params) do
+    render(conn, "index.html")
+  end
+
+  @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def create(conn, _params) do
+    :ok = Arrow.DisruptionRevision.publish_all!()
+
+    redirect(conn, to: ArrowWeb.Router.Helpers.page_path(conn, :index))
+  end
+end

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -51,6 +51,8 @@ defmodule ArrowWeb.Router do
     get "/disruptions/:id", PageController, :index
     get "/disruptions/:id/edit", PageController, :index
     get "/mytoken", MyTokenController, :show
+    get "/temp_review_changes", TempReviewChangesController, :index
+    post "/temp_review_changes", TempReviewChangesController, :create
   end
 
   scope "/", ArrowWeb do

--- a/lib/arrow_web/templates/temp_review_changes/index.html.eex
+++ b/lib/arrow_web/templates/temp_review_changes/index.html.eex
@@ -1,0 +1,3 @@
+<%= form_for @conn, Routes.temp_review_changes_path(@conn, :index), fn _f-> %>
+  <%=  submit "Publish all" %>
+<% end %>

--- a/lib/arrow_web/views/temp_review_changes_view.ex
+++ b/lib/arrow_web/views/temp_review_changes_view.ex
@@ -1,0 +1,3 @@
+defmodule ArrowWeb.TempReviewChangesView do
+  use ArrowWeb, :view
+end

--- a/test/arrow/disruption_revision_test.exs
+++ b/test/arrow/disruption_revision_test.exs
@@ -1,0 +1,26 @@
+defmodule Arrow.DisruptionRevisionTest do
+  @moduledoc false
+  use Arrow.DataCase
+  alias Arrow.DisruptionRevision
+
+  describe "publish_all!/0" do
+    test "publishes a brand new disruption, and then publishes an update to it" do
+      dr = insert(:disruption_revision)
+
+      :ok = DisruptionRevision.publish_all!()
+
+      new_dr = DisruptionRevision |> Arrow.Repo.get(dr.id) |> Arrow.Repo.preload([:disruption])
+
+      assert new_dr.disruption.published_revision_id == dr.id
+
+      {:ok, newer_dr} = Arrow.Disruption.update(new_dr.id, %{end_date: ~D[2020-01-31]})
+
+      :ok = DisruptionRevision.publish_all!()
+
+      newest_dr =
+        DisruptionRevision |> Arrow.Repo.get(newer_dr.id) |> Arrow.Repo.preload([:disruption])
+
+      assert newest_dr.disruption.published_revision_id == newer_dr.id
+    end
+  end
+end

--- a/test/arrow/disruption_test.exs
+++ b/test/arrow/disruption_test.exs
@@ -200,7 +200,7 @@ defmodule Arrow.DisruptionTest do
       d = Repo.get!(Arrow.Disruption, new_dr.disruption_id)
 
       assert new_dr.disruption_id == d.id
-      assert d.published_revision_id == new_dr.id
+      assert d.published_revision_id == dr_id
       assert new_dr.start_date == ~D[2021-01-01]
       assert new_dr.end_date == ~D[2021-11-30]
 
@@ -387,7 +387,7 @@ defmodule Arrow.DisruptionTest do
     test "creates a new revision which isn't active" do
       d = insert(:disruption)
 
-      dr =
+      dr1 =
         insert(:disruption_revision, %{
           disruption: d,
           start_date: ~D[2020-08-17],
@@ -395,15 +395,15 @@ defmodule Arrow.DisruptionTest do
           days_of_week: [build(:day_of_week, %{day_name: "tuesday"})]
         })
 
-      Repo.update!(Ecto.Changeset.change(d, %{published_revision_id: dr.id}))
+      Repo.update!(Ecto.Changeset.change(d, %{published_revision_id: dr1.id}))
 
-      assert {:ok, dr} = Arrow.Disruption.delete(dr.id)
+      assert {:ok, dr2} = Arrow.Disruption.delete(dr1.id)
 
       d = Repo.get(Arrow.Disruption, d.id)
 
       assert Repo.all(from(dr in Arrow.DisruptionRevision, select: count(dr.id))) == [2]
-      assert dr.is_active == false
-      assert d.published_revision_id == dr.id
+      assert dr2.is_active == false
+      assert d.published_revision_id == dr1.id
     end
   end
 end

--- a/test/arrow_web/controllers/temp_review_changes_controller_test.exs
+++ b/test/arrow_web/controllers/temp_review_changes_controller_test.exs
@@ -1,0 +1,25 @@
+defmodule ArrowWeb.TempReviewChangesControllerTest do
+  use ArrowWeb.ConnCase
+  import Arrow.Factory
+  import ArrowWeb.Router.Helpers
+
+  @tag :authenticated
+  test "GET /temp_review_changes", %{conn: conn} do
+    conn = get(conn, temp_review_changes_path(conn, :index))
+    assert html_response(conn, 200) =~ "Publish all"
+  end
+
+  @tag :authenticated
+  test "POST /temp_review_changes", %{conn: conn} do
+    dr = insert(:disruption_revision)
+
+    conn = post(conn, temp_review_changes_path(conn, :index))
+
+    assert html_response(conn, 302) =~ page_path(conn, :index)
+
+    new_dr =
+      Arrow.DisruptionRevision |> Arrow.Repo.get(dr.id) |> Arrow.Repo.preload([:disruption])
+
+    assert new_dr.disruption.published_revision_id == dr.id
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -19,7 +19,7 @@ defmodule Arrow.Factory do
     %Arrow.DisruptionRevision{
       start_date: ~D[2020-01-01],
       end_date: ~D[2020-01-15],
-      disruption: [build(:disruption)],
+      disruption: build(:disruption),
       days_of_week: [build(:day_of_week)],
       adjustments: [build(:adjustment)],
       trip_short_names: [build(:trip_short_name)]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Arrow distinguishes between published and draft versions](https://app.asana.com/0/584764604969369/1185700222235213/f)

This one is probably most easily-reviewed on a commit-by-commit basis, and the order of the commits should match the order of the acceptance criteria bullet points on the ticket.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
