### PR TITLE
feat: add ability to toggle between draft and published versions on disruption details page

### DIFF
--- a/assets/css/_disruption_view_toggle.scss
+++ b/assets/css/_disruption_view_toggle.scss
@@ -1,0 +1,21 @@
+.m-disruption-view-toggle {
+  display: flex;
+  flex-direction: column;
+}
+
+.m-disruption-view-toggle_button {
+  background-color: #f8f9fa;
+  border-color: #f8f9fa;
+
+  &:first-child {
+    border-radius: 0.25rem 0.25rem 0 0;
+  }
+
+  &:last-child {
+    border-radius: 0 0 0.25rem 0.25rem;
+  }
+
+  &.active {
+    background-color: #cfe3f4;
+  }
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -12,4 +12,5 @@
 @import "disruption_list_container";
 @import "disruption_table";
 @import "disruption_index";
+@import "disruption_view_toggle";
 @import "datepicker";

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -3754,8 +3754,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-equal": {
       "version": "1.1.1",
@@ -7971,6 +7970,24 @@
         "prepend-http": "^1.0.0",
         "query-string": "^4.1.0",
         "sort-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+          "dev": true
+        }
       }
     },
     "npm-run-path": {
@@ -9245,13 +9262,13 @@
       "dev": true
     },
     "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true,
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz",
+      "integrity": "sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==",
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       }
     },
     "querystring": {
@@ -10687,6 +10704,11 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -10816,10 +10838,9 @@
       "dev": true
     },
     "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "3.1.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -22,6 +22,7 @@
     "lodash": "^4.17.19",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
+    "query-string": "^6.13.1",
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",
     "react-datepicker": "^3.1.3",

--- a/assets/src/disruptions/viewToggle.tsx
+++ b/assets/src/disruptions/viewToggle.tsx
@@ -1,0 +1,51 @@
+import * as React from "react"
+import { NavLink, useHistory } from "react-router-dom"
+import queryString from "query-string"
+
+enum DisruptionView {
+  Draft,
+  Published,
+}
+
+const useDisruptionViewParam = (): DisruptionView => {
+  const { v } = queryString.parse(useHistory().location.search)
+  switch (v) {
+    case "draft": {
+      return DisruptionView.Draft
+    }
+    default: {
+      return DisruptionView.Published
+    }
+  }
+}
+
+const DisruptionViewToggle = () => {
+  const view = useDisruptionViewParam()
+  return (
+    <div className="d-flex flex-column">
+      <h5>Select View</h5>
+      <NavLink
+        id="draft"
+        className="btn m-disruption-view-toggle_button"
+        to="?v=draft"
+        activeClassName="active"
+        isActive={() => view === DisruptionView.Draft}
+        replace
+      >
+        create or edit
+      </NavLink>
+      <NavLink
+        id="published"
+        className="btn m-disruption-view-toggle_button"
+        to="?"
+        activeClassName="active"
+        isActive={() => view === DisruptionView.Published}
+        replace
+      >
+        published
+      </NavLink>
+    </div>
+  )
+}
+
+export { DisruptionViewToggle, DisruptionView, useDisruptionViewParam }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Disruption detail page has draft and published versions](https://app.asana.com/0/584764604969369/1186492610975121/f)

* added reusable `useDisruptionViewParam` custom hook to extract the active view from a query param
* added reusable `DisruptionViewToggle` component that sets the appropriate query param
* added `DisruptionViewToggle` to `ViewDisruption` component, and used `useDisruptionViewParam` to conditionally add `published_only=true/false` to GET request

![toggle](https://user-images.githubusercontent.com/18427346/91080232-3ec3ae00-e613-11ea-8594-d6e75faae3a5.gif)


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
