### PR TITLE
fix: conditionally add v=draft query param to detail page links on homepage

### DIFF
--- a/assets/src/disruptions/disruptionCalendar.tsx
+++ b/assets/src/disruptions/disruptionCalendar.tsx
@@ -5,6 +5,7 @@ import { RRule, RRuleSet } from "rrule"
 import { getRouteColor } from "./disruptionIndex"
 import Disruption from "../models/disruption"
 import DayOfWeek from "../models/dayOfWeek"
+import { useDisruptionViewParam, DisruptionView } from "./viewToggle"
 
 interface DisruptionCalendarProps {
   disruptions: Disruption[]
@@ -42,7 +43,10 @@ const addDay = (date: Date): Date => {
   return new Date(date.setTime(date.getTime() + 60 * 60 * 24 * 1000))
 }
 
-export const disruptionsToCalendarEvents = (disruptions: Disruption[]) => {
+export const disruptionsToCalendarEvents = (
+  disruptions: Disruption[],
+  view: DisruptionView
+) => {
   return disruptions.reduce(
     (
       disruptionsAcc: {
@@ -101,7 +105,9 @@ export const disruptionsToCalendarEvents = (disruptions: Disruption[]) => {
             backgroundColor: getRouteColor(adj.routeId),
             start: group[0],
             end: group.length > 1 ? addDay(group.slice(-1)[0]) : group[0],
-            url: `/disruptions/${disruption.id}`,
+            url:
+              `/disruptions/${disruption.id}` +
+              (view === DisruptionView.Draft ? "?v=draft" : ""),
             eventDisplay: "block",
             allDay: true,
           })
@@ -117,9 +123,10 @@ export const DisruptionCalendar = ({
   disruptions,
   initialDate,
 }: DisruptionCalendarProps) => {
+  const view = useDisruptionViewParam()
   const calendarEvents = React.useMemo(() => {
-    return disruptionsToCalendarEvents(disruptions)
-  }, [disruptions])
+    return disruptionsToCalendarEvents(disruptions, view)
+  }, [disruptions, view])
   return (
     <div id="calendar" className="my-3">
       <FullCalendar

--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -288,7 +288,7 @@ const DisruptionIndex = () => {
   React.useEffect(() => {
     apiGet<JsonApiResponse>({
       url:
-        "/api/disruptions?published_only=" +
+        "/api/disruptions?only_published=" +
         (view === DisruptionView.Published ? "true" : "false"),
       parser: toModelObject,
       defaultResult: "error",

--- a/assets/src/disruptions/disruptionTable.tsx
+++ b/assets/src/disruptions/disruptionTable.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom"
 import { formatDisruptionDate } from "./disruptions"
 import Disruption from "../models/disruption"
 import { parseDaysAndTimes } from "./time"
+import { useDisruptionViewParam, DisruptionView } from "./viewToggle"
 
 interface DisruptionTableHeaderProps {
   active?: boolean
@@ -92,6 +93,8 @@ const DisruptionTable = ({ disruptions }: DisruptionTableProps) => {
     },
     [sortState]
   )
+
+  const view = useDisruptionViewParam()
   return (
     <Table className="m-disruption-table" striped>
       <thead>
@@ -125,7 +128,14 @@ const DisruptionTable = ({ disruptions }: DisruptionTableProps) => {
             )}
             <td>{x.daysAndTimes}</td>
             <td>
-              <Link to={`/disruptions/${x.id}`}>See details</Link>
+              <Link
+                to={
+                  `/disruptions/${x.id}` +
+                  (view === DisruptionView.Draft ? "?v=draft" : "")
+                }
+              >
+                See details
+              </Link>
             </td>
           </tr>
         ))}

--- a/assets/src/disruptions/viewDisruption.tsx
+++ b/assets/src/disruptions/viewDisruption.tsx
@@ -106,7 +106,7 @@ const ViewDisruptionForm = ({
       url:
         "/api/disruptions/" +
         encodeURIComponent(disruptionId) +
-        `?published_only=${
+        `?only_published=${
           view === DisruptionView.Published ? "true" : "false"
         }`,
       parser: toModelObject,

--- a/assets/tests/disruptions/disruptionCalendar.test.tsx
+++ b/assets/tests/disruptions/disruptionCalendar.test.tsx
@@ -10,6 +10,8 @@ import Adjustment from "../../src/models/adjustment"
 import DayOfWeek from "../../src/models/dayOfWeek"
 import Exception from "../../src/models/exception"
 import { toUTCDate } from "../../src/jsonApi"
+import { BrowserRouter } from "react-router-dom"
+import { DisruptionView } from "../../src/disruptions/viewToggle"
 
 const SAMPLE_DISRUPTIONS = [
   new Disruption({
@@ -104,7 +106,12 @@ describe("DisruptionCalendar", () => {
 
   describe("disruptionsToCalendarEvents", () => {
     it("parses disruptions", () => {
-      expect(disruptionsToCalendarEvents(SAMPLE_DISRUPTIONS)).toEqual([
+      expect(
+        disruptionsToCalendarEvents(
+          SAMPLE_DISRUPTIONS,
+          DisruptionView.Published
+        )
+      ).toEqual([
         {
           id: "1",
           title: "AlewifeHarvard",
@@ -168,73 +175,94 @@ describe("DisruptionCalendar", () => {
       ])
     })
 
+    it("correctly adds view query param to detail page links", () => {
+      expect(
+        disruptionsToCalendarEvents(
+          SAMPLE_DISRUPTIONS,
+          DisruptionView.Published
+        ).every((x) => !x.url.includes("?v=draft"))
+      ).toEqual(true)
+
+      expect(
+        disruptionsToCalendarEvents(
+          SAMPLE_DISRUPTIONS,
+          DisruptionView.Draft
+        ).every((x) => x.url.includes("?v=draft"))
+      ).toEqual(true)
+    })
+
     it("handles invalid days of week gracefully", () => {
       expect(
-        disruptionsToCalendarEvents([
-          new Disruption({
-            id: "1",
-            startDate: toUTCDate("2020-07-01"),
-            endDate: toUTCDate("2020-07-02"),
-            adjustments: [
-              new Adjustment({
-                id: "1",
-                routeId: "Red",
-                sourceLabel: "AlewifeHarvard",
-              }),
-            ],
-            daysOfWeek: [
-              new DayOfWeek({
-                id: "1",
-                startTime: "20:45:00",
-                dayName: "friday",
-              }),
-            ],
-            exceptions: [],
-            tripShortNames: [],
-          }),
-        ])
+        disruptionsToCalendarEvents(
+          [
+            new Disruption({
+              id: "1",
+              startDate: toUTCDate("2020-07-01"),
+              endDate: toUTCDate("2020-07-02"),
+              adjustments: [
+                new Adjustment({
+                  id: "1",
+                  routeId: "Red",
+                  sourceLabel: "AlewifeHarvard",
+                }),
+              ],
+              daysOfWeek: [
+                new DayOfWeek({
+                  id: "1",
+                  startTime: "20:45:00",
+                  dayName: "friday",
+                }),
+              ],
+              exceptions: [],
+              tripShortNames: [],
+            }),
+          ],
+          DisruptionView.Published
+        )
       ).toEqual([])
     })
   })
 
   test("handles daylight savings correctly", () => {
     const { container } = render(
-      <DisruptionCalendar
-        initialDate={toUTCDate("2020-11-15")}
-        disruptions={[
-          new Disruption({
-            id: "1",
-            startDate: toUTCDate("2020-10-30"),
-            endDate: toUTCDate("2020-11-22"),
-            adjustments: [
-              new Adjustment({
-                id: "1",
-                routeId: "Red",
-                sourceLabel: "AlewifeHarvard",
-              }),
-            ],
-            daysOfWeek: [
-              new DayOfWeek({
-                id: "1",
-                startTime: "20:45:00",
-                dayName: "friday",
-              }),
-              new DayOfWeek({
-                id: "2",
-                dayName: "saturday",
-              }),
-              new DayOfWeek({
-                id: "3",
-                dayName: "sunday",
-              }),
-            ],
-            exceptions: [
-              new Exception({ excludedDate: toUTCDate("2020-11-15") }),
-            ],
-            tripShortNames: [],
-          }),
-        ]}
-      />
+      <BrowserRouter>
+        <DisruptionCalendar
+          initialDate={toUTCDate("2020-11-15")}
+          disruptions={[
+            new Disruption({
+              id: "1",
+              startDate: toUTCDate("2020-10-30"),
+              endDate: toUTCDate("2020-11-22"),
+              adjustments: [
+                new Adjustment({
+                  id: "1",
+                  routeId: "Red",
+                  sourceLabel: "AlewifeHarvard",
+                }),
+              ],
+              daysOfWeek: [
+                new DayOfWeek({
+                  id: "1",
+                  startTime: "20:45:00",
+                  dayName: "friday",
+                }),
+                new DayOfWeek({
+                  id: "2",
+                  dayName: "saturday",
+                }),
+                new DayOfWeek({
+                  id: "3",
+                  dayName: "sunday",
+                }),
+              ],
+              exceptions: [
+                new Exception({ excludedDate: toUTCDate("2020-11-15") }),
+              ],
+              tripShortNames: [],
+            }),
+          ]}
+        />
+      </BrowserRouter>
     )
 
     const activeDays = ["01", "06", "08", "13", "20", "22"]
@@ -254,10 +282,12 @@ describe("DisruptionCalendar", () => {
 
   test("renders correctly", () => {
     const tree = render(
-      <DisruptionCalendar
-        initialDate={toUTCDate("2019-11-15")}
-        disruptions={SAMPLE_DISRUPTIONS}
-      />
+      <BrowserRouter>
+        <DisruptionCalendar
+          initialDate={toUTCDate("2019-11-15")}
+          disruptions={SAMPLE_DISRUPTIONS}
+        />
+      </BrowserRouter>
     )
     expect(tree).toMatchSnapshot()
   })

--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -402,7 +402,7 @@ describe("DisruptionIndexConnected", () => {
     )
 
     expect(spy).toHaveBeenCalledWith({
-      url: "/api/disruptions?published_only=true",
+      url: "/api/disruptions?only_published=true",
       parser: toModelObject,
       defaultResult: "error",
     })
@@ -423,7 +423,7 @@ describe("DisruptionIndexConnected", () => {
     }
 
     expect(spy).toHaveBeenCalledWith({
-      url: "/api/disruptions?published_only=false",
+      url: "/api/disruptions?only_published=false",
       parser: toModelObject,
       defaultResult: "error",
     })

--- a/assets/tests/disruptions/disruptionTable.test.tsx
+++ b/assets/tests/disruptions/disruptionTable.test.tsx
@@ -1,14 +1,18 @@
 import * as React from "react"
-import { BrowserRouter } from "react-router-dom"
+import { MemoryRouter } from "react-router-dom"
 import { render, fireEvent, screen } from "@testing-library/react"
 import { DisruptionTable } from "../../src/disruptions/disruptionTable"
 import Adjustment from "../../src/models/adjustment"
 import DayOfWeek from "../../src/models/dayOfWeek"
 import Disruption from "../../src/models/disruption"
 
-const DisruptionTableWithRouter = () => {
+const DisruptionTableWithRouter = ({
+  initialEntries,
+}: {
+  initialEntries?: string[]
+}) => {
   return (
-    <BrowserRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <DisruptionTable
         disruptions={[
           new Disruption({
@@ -100,7 +104,7 @@ const DisruptionTableWithRouter = () => {
           }),
         ]}
       />
-    </BrowserRouter>
+    </MemoryRouter>
   )
 }
 
@@ -158,5 +162,27 @@ describe("DisruptionTable", () => {
     expect(activeSortToggle.className).toMatch("asc")
     expect(firstRowData.item(0).textContent).toEqual("Kenmore-Newton Highlands")
     expect(firstRowData.item(1).textContent).toEqual("9/22/2019 - 10/22/2019")
+  })
+
+  test("correctly adds view query param to detail page links", () => {
+    const { container: publishedContainer } = render(
+      <DisruptionTableWithRouter initialEntries={["/"]} />
+    )
+    let tableRows = publishedContainer.querySelectorAll("tbody tr")
+    expect(tableRows.length).toEqual(3)
+    tableRows.forEach((r) => {
+      expect(r.querySelector("a")?.getAttribute("href")).not.toContain(
+        "?v=draft"
+      )
+    })
+
+    const { container: draftContainer } = render(
+      <DisruptionTableWithRouter initialEntries={["/?v=draft"]} />
+    )
+    tableRows = draftContainer.querySelectorAll("tbody tr")
+    expect(tableRows.length).toEqual(3)
+    tableRows.forEach((r) => {
+      expect(r.querySelector("a")?.getAttribute("href")).toContain("?v=draft")
+    })
   })
 })

--- a/assets/tests/disruptions/viewDisruption.test.tsx
+++ b/assets/tests/disruptions/viewDisruption.test.tsx
@@ -529,7 +529,7 @@ describe("ViewDisruption", () => {
     )
 
     expect(spy).toHaveBeenCalledWith({
-      url: "/api/disruptions/1?published_only=true",
+      url: "/api/disruptions/1?only_published=true",
       parser: toModelObject,
       defaultResult: "error",
     })
@@ -551,7 +551,7 @@ describe("ViewDisruption", () => {
     }
 
     expect(spy).toHaveBeenCalledWith({
-      url: "/api/disruptions/1?published_only=false",
+      url: "/api/disruptions/1?only_published=false",
       parser: toModelObject,
       defaultResult: "error",
     })


### PR DESCRIPTION
Follow up to https://github.com/mbta/arrow/commit/643af75851bab92029aa57aadb3fc45c966cf747, adding the correct query param on detail page links so the user arrives on the page with the correct view enabled.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
