### PR TITLE
fix: accept empty string for only_published query param

### DIFF
--- a/lib/arrow_web/controllers/api/disruption_controller.ex
+++ b/lib/arrow_web/controllers/api/disruption_controller.ex
@@ -180,8 +180,7 @@ defmodule ArrowWeb.API.DisruptionController do
   defp do_only_published_query(q, params) do
     case Map.get(params, "only_published") do
       "true" -> {:ok, DisruptionRevision.only_published(q)}
-      "false" -> {:ok, DisruptionRevision.latest_revision(q)}
-      nil -> {:ok, DisruptionRevision.latest_revision(q)}
+      val when val in [nil, "", "false"] -> {:ok, DisruptionRevision.latest_revision(q)}
       _ -> :error
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Followup to [🏹 Arrow distinguishes between published and draft versions](https://app.asana.com/0/584764604969369/1185700222235213/f)

After some discussion, realized we should be treating an empty query param as falsy. Also broke out the `?only_published=false` case into its own test to match what I did for `index/2`.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
