### PR TITLE
fix: exclude deleted disruptions in latest_revision

### DIFF
--- a/lib/arrow/disruption_revision.ex
+++ b/lib/arrow/disruption_revision.ex
@@ -48,7 +48,7 @@ defmodule Arrow.DisruptionRevision do
     draft_ids =
       from(dr in __MODULE__, select: max(dr.id), group_by: dr.disruption_id) |> Repo.all()
 
-    from(dr in query, where: dr.id in ^draft_ids)
+    from(dr in query, where: dr.id in ^draft_ids and dr.is_active)
   end
 
   @spec clone!(integer()) :: __MODULE__.t()

--- a/test/arrow/disruption_revision_test.exs
+++ b/test/arrow/disruption_revision_test.exs
@@ -3,6 +3,42 @@ defmodule Arrow.DisruptionRevisionTest do
   use Arrow.DataCase
   alias Arrow.DisruptionRevision
 
+  describe "only_published/1" do
+    test "returns nothing when published revision of a disruption is deleted" do
+      dr1 = insert(:disruption_revision) |> Arrow.Repo.preload([:disruption])
+
+      :ok = DisruptionRevision.publish_all!()
+
+      {:ok, _dr2} = Arrow.Disruption.delete(dr1.id)
+
+      :ok = DisruptionRevision.publish_all!()
+
+      published_dr =
+        DisruptionRevision
+        |> DisruptionRevision.only_published()
+        |> Repo.get_by(disruption_id: dr1.disruption.id)
+
+      assert is_nil(published_dr)
+    end
+  end
+
+  describe "latest_revision/1" do
+    test "returns nothing when latest revision of a disruption is deleted" do
+      dr1 = insert(:disruption_revision) |> Arrow.Repo.preload([:disruption])
+
+      :ok = DisruptionRevision.publish_all!()
+
+      {:ok, _dr2} = Arrow.Disruption.delete(dr1.id)
+
+      published_dr =
+        DisruptionRevision
+        |> DisruptionRevision.latest_revision()
+        |> Repo.get_by(disruption_id: dr1.disruption.id)
+
+      assert is_nil(published_dr)
+    end
+  end
+
   describe "publish_all!/0" do
     test "publishes a brand new disruption, and then publishes an update to it" do
       dr = insert(:disruption_revision)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Fix deletion of disruptions not being reflected in pending changes](https://app.asana.com/0/584764604969369/1191193425257601/f)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
