### PR TITLE
chore: Disable object-literal-sort-keys lint

### DIFF
--- a/assets/.eslintrc.js
+++ b/assets/.eslintrc.js
@@ -129,7 +129,7 @@ module.exports = {
         rules: {
           "jsdoc-format": true,
           "no-reference-import": true,
-          "object-literal-sort-keys": [true, "match-declaration-order-only"],
+          "object-literal-sort-keys": false,
         },
       },
     ],


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

I find this rule kind of annoying. To me, objects (even object literals) don't conceptually have an ordering to their keys.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
