### PR TITLE
fix: sort adjustments for equality comparison

### DIFF
--- a/assets/src/disruptions/disruptionTable.tsx
+++ b/assets/src/disruptions/disruptionTable.tsx
@@ -114,6 +114,9 @@ const DisruptionTable = ({ disruptionRevisions }: DisruptionTableProps) => {
   const disruptionRows = React.useMemo(() => {
     return disruptionRevisions.map(
       (x): DisruptionTableRow => {
+        const adjustments = x.adjustments.sort(
+          (a, b) => parseInt(a.id, 10) - parseInt(b.id, 10)
+        )
         return {
           id: x.id,
           status: x.status,
@@ -121,11 +124,13 @@ const DisruptionTable = ({ disruptionRevisions }: DisruptionTableProps) => {
           startDate: x.startDate,
           endDate: x.endDate,
           exceptions: x.exceptions.length,
-          adjustments: x.adjustments,
-          label: x.adjustments.map((adj) => adj.sourceLabel).join(", "),
           daysOfWeek: x.daysOfWeek,
           daysAndTimes:
             x.daysOfWeek.length > 0 ? parseDaysAndTimes(x.daysOfWeek) : "",
+          label: adjustments.reduce((acc, curr) => {
+            return acc + curr.sourceLabel
+          }, ""),
+          adjustments,
         }
       }
     )

--- a/assets/tests/disruptions/disruptionTable.test.tsx
+++ b/assets/tests/disruptions/disruptionTable.test.tsx
@@ -24,6 +24,11 @@ const DisruptionTableWithRouter = ({
             isActive: false,
             adjustments: [
               new Adjustment({
+                id: "2",
+                routeId: "Green-D",
+                sourceLabel: "Kenmore-Newton Highlands",
+              }),
+              new Adjustment({
                 id: "1",
                 routeId: "Red",
                 sourceLabel: "NorthQuincyQuincyCenter",
@@ -59,6 +64,11 @@ const DisruptionTableWithRouter = ({
                 id: "1",
                 routeId: "Red",
                 sourceLabel: "NorthQuincyQuincyCenter",
+              }),
+              new Adjustment({
+                id: "2",
+                routeId: "Green-D",
+                sourceLabel: "Kenmore-Newton Highlands",
               }),
             ],
             daysOfWeek: [
@@ -156,7 +166,7 @@ describe("DisruptionTable", () => {
     const tableRows = container.querySelectorAll("tbody tr")
     expect(
       tableRows.item(2).querySelectorAll("td").item(0).textContent
-    ).toEqual("NorthQuincyQuincyCenter")
+    ).toEqual("NorthQuincyQuincyCenterKenmore-Newton Highlands")
     expect(
       tableRows.item(3).querySelectorAll("td").item(0).textContent
     ).toEqual("↘")
@@ -200,7 +210,9 @@ describe("DisruptionTable", () => {
       throw new Error("active sort toggle not found")
     }
     expect(activeSortToggle.textContent).toEqual("adjustments↓")
-    expect(firstRowData.item(0).textContent).toEqual("NorthQuincyQuincyCenter")
+    expect(firstRowData.item(0).textContent).toEqual(
+      "NorthQuincyQuincyCenterKenmore-Newton Highlands"
+    )
 
     const dateSort = screen.getByText("date range")
     fireEvent.click(dateSort)
@@ -230,7 +242,9 @@ describe("DisruptionTable", () => {
     firstRow = tableRows.item(0)
     firstRowData = firstRow.querySelectorAll("td")
     expect(activeSortToggle.textContent).toEqual("time period↑")
-    expect(firstRowData.item(0).textContent).toEqual("NorthQuincyQuincyCenter")
+    expect(firstRowData.item(0).textContent).toEqual(
+      "NorthQuincyQuincyCenterKenmore-Newton Highlands"
+    )
     expect(firstRowData.item(1).textContent).toContain("10/31/2019")
     expect(firstRowData.item(1).textContent).toContain("11/15/2019")
 
@@ -261,7 +275,9 @@ describe("DisruptionTable", () => {
     firstRow = tableRows.item(0)
     firstRowData = firstRow.querySelectorAll("td")
     expect(activeSortToggle.textContent).toEqual("ID↑")
-    expect(firstRowData.item(0).textContent).toEqual("NorthQuincyQuincyCenter")
+    expect(firstRowData.item(0).textContent).toEqual(
+      "NorthQuincyQuincyCenterKenmore-Newton Highlands"
+    )
     expect(firstRowData.item(1).textContent).toContain("10/31/2019")
     expect(firstRowData.item(1).textContent).toContain("11/15/2019")
 
@@ -292,7 +308,9 @@ describe("DisruptionTable", () => {
     firstRow = tableRows.item(0)
     firstRowData = firstRow.querySelectorAll("td")
     expect(activeSortToggle.textContent).toEqual("status↑")
-    expect(firstRowData.item(0).textContent).toEqual("NorthQuincyQuincyCenter")
+    expect(firstRowData.item(0).textContent).toEqual(
+      "NorthQuincyQuincyCenterKenmore-Newton Highlands"
+    )
     expect(firstRowData.item(1).textContent).toContain("10/31/2019")
     expect(firstRowData.item(1).textContent).toContain("11/15/2019")
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] sort Arrow adjustment labels in table view](https://app.asana.com/0/584764604969369/1194957087550849)

In the attached screenshot, you'll see two separate rows where there should be a rowlette. This is because the adjustments were saved in different orders for each revision, for whatever reason. This just fixes the logic to sort the adjustments before [comparing whether labels are equal](https://github.com/mbta/arrow/blob/fl/fix-adjustments-sorting/assets/src/disruptions/disruptionTable.tsx#L222), and thus whether we should show a rowlette or new labels.

<img width="1021" alt="Screen Shot 2020-09-21 at 2 22 25 PM" src="https://user-images.githubusercontent.com/18427346/93810272-627f1180-fc1c-11ea-8f4f-037ea59ba113.png">


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
