### PR TITLE
chore: remove "published/ready" status filter

### DIFF
--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -319,23 +319,6 @@ const DisruptionIndexView = ({ disruptions }: DisruptionIndexProps) => {
             />
             <div>
               <SecondaryButton
-                id="status-filter-toggle-published-ready"
-                disabled={view === "calendar"}
-                className={classnames("mx-2", {
-                  active:
-                    statusFilters.state.published && statusFilters.state.ready,
-                })}
-                onClick={() =>
-                  statusFilters.updateFiltersState({
-                    ...statusFilters.state,
-                    published: !statusFilters.state.published,
-                    ready: !statusFilters.state.ready,
-                  })
-                }
-              >
-                published/ready
-              </SecondaryButton>
-              <SecondaryButton
                 disabled={view === "calendar"}
                 id="status-filter-toggle-needs-review"
                 className={classnames("mx-2", {

--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -296,25 +296,6 @@ describe("DisruptionIndexView", () => {
 
     expect(container.querySelectorAll("tbody tr").length).toEqual(2)
 
-    const publishedReadyStatusToggle = container.querySelector(
-      "#status-filter-toggle-published-ready"
-    )
-
-    if (!publishedReadyStatusToggle) {
-      throw new Error("search input not found")
-    }
-
-    fireEvent.click(publishedReadyStatusToggle)
-
-    expect(container.querySelectorAll("tbody tr").length).toEqual(1)
-    expect(container.querySelectorAll("tbody tr").item(0).innerHTML).toMatch(
-      "AlewifeHarvard"
-    )
-
-    fireEvent.click(publishedReadyStatusToggle)
-
-    expect(container.querySelectorAll("tbody tr").length).toEqual(2)
-
     const draftStatusToggle = container.querySelector(
       "#status-filter-toggle-needs-review"
     )


### PR DESCRIPTION
This just deletes the published/ready filter. The "needs review" and other filters will continue work as before. 


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
