### PR TITLE
feat: Detail page updates

### DIFF
--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -35,3 +35,8 @@ body {
 hr {
   border-top: 1px solid $black;
 }
+
+.btn-link:hover,
+a:hover {
+  text-decoration: none;
+}

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -29,4 +29,9 @@ fieldset {
 
 body {
   font-family: "Inter";
+  font-size: 18px;
+}
+
+hr {
+  border-top: 1px solid $black;
 }

--- a/assets/css/_disruption_details.scss
+++ b/assets/css/_disruption_details.scss
@@ -41,6 +41,7 @@
   padding: 1rem;
 
   &:hover {
+    background-color: $light-pink;
     color: $black;
   }
 

--- a/assets/css/_disruption_details.scss
+++ b/assets/css/_disruption_details.scss
@@ -1,0 +1,61 @@
+.m-disruption-details__adjustments {
+  margin-bottom: 1.5rem;
+}
+
+.m-disruption-details__header {
+  align-items: flex-end;
+  justify-content: space-between;
+  display: flex;
+  margin-bottom: 1.5rem;
+
+  h5 {
+    font-weight: 700;
+    line-height: 0.75;
+    margin-left: 2rem;
+  }
+}
+
+.m-disruption-details__adjustment-list {
+  padding-left: 0;
+}
+
+.m-disruption-details__adjustment-item {
+  display: flex;
+  align-items: center;
+  font-weight: 700;
+  list-style: none;
+}
+
+.m-disruption-details__view-toggle-group {
+  min-width: 350px;
+  max-width: 50%;
+}
+
+.m-disruption-details__view-toggle {
+  border: 1px solid $primary;
+  border-bottom: none;
+  color: $black;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+
+  &:hover {
+    color: $black;
+  }
+
+  &.active {
+    background-color: $light-pink;
+  }
+
+  &:first-child {
+    border-top-left-radius: 0.25rem;
+    border-top-right-radius: 0.25rem;
+  }
+
+  &:last-child {
+    border-bottom: 1px solid $primary;
+    border-bottom-left-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem;
+  }
+}

--- a/assets/css/_disruption_details.scss
+++ b/assets/css/_disruption_details.scss
@@ -59,3 +59,11 @@
     border-bottom-right-radius: 0.25rem;
   }
 }
+
+.m-disruption-details__deletion-indicator {
+  background-color: $light-grey;
+  border: 1px solid $blue-grey;
+  border-radius: 0.25rem;
+  padding: 1rem;
+  margin: 1rem 0;
+}

--- a/assets/css/_overrides.scss
+++ b/assets/css/_overrides.scss
@@ -1,7 +1,7 @@
 $black: #1e2127;
 $blue-grey: #9fa9c3;
 $grey: #aeaeae;
-$light-grey: #fbeaee;
+$light-grey: #f8f9fa;
 $light-pink: #fbeaee;
 $primary: #dd3159;
 $secondary: $blue-grey;
@@ -9,6 +9,8 @@ $dark: $black;
 
 $theme-colors: (
   "light-pink": $light-pink,
+  "blue-grey": $blue-grey,
+  "light-grey": $light-grey,
 );
 
 $text-muted: $grey;

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -11,6 +11,7 @@
 @import "header";
 @import "forms";
 @import "disruption_times";
+@import "disruption_details";
 @import "disruption_summary";
 @import "new_disruption_preview";
 @import "disruption_diffs";

--- a/assets/src/disruptions/disruptionTable.tsx
+++ b/assets/src/disruptions/disruptionTable.tsx
@@ -230,7 +230,11 @@ const DisruptionTableRow = ({
       <td>
         <Link
           to={`/disruptions/${current.disruptionId}?v=${
-            current.status === DisruptionView.Draft ? "draft" : ""
+            current.status === DisruptionView.Draft
+              ? "draft"
+              : current.status === DisruptionView.Ready
+              ? "ready"
+              : "published"
           }`}
         >
           {current.disruptionId}

--- a/assets/src/disruptions/disruptionTable.tsx
+++ b/assets/src/disruptions/disruptionTable.tsx
@@ -117,6 +117,7 @@ interface DisruptionTableRow {
   daysAndTimes: string
   selectable: boolean
   selected: boolean
+  isActive: boolean
 }
 
 const DisruptionTableRow = ({
@@ -172,7 +173,7 @@ const DisruptionTableRow = ({
           ))}
         </td>
       )}
-      {!!current.startDate && !!current.endDate && (
+      {!!current.startDate && !!current.endDate && current.isActive ? (
         <td>
           <div
             className={
@@ -193,6 +194,8 @@ const DisruptionTableRow = ({
             {formatDisruptionDate(current.endDate)}
           </div>
         </td>
+      ) : (
+        <td>Marked for deletion</td>
       )}
       <td
         className={
@@ -204,16 +207,17 @@ const DisruptionTableRow = ({
             : "text-muted"
         }
       >
-        {current.exceptions.length}
+        {current.isActive && current.exceptions.length}
       </td>
       <td
         className={
           isDiff(base?.daysAndTimes, current.daysAndTimes) ? "" : "text-muted"
         }
       >
-        {current.daysAndTimes.split(", ").map((line, ix) => (
-          <div key={ix}>{line}</div>
-        ))}
+        {current.isActive &&
+          current.daysAndTimes
+            .split(", ")
+            .map((line, ix) => <div key={ix}>{line}</div>)}
       </td>
       <td>
         {
@@ -282,6 +286,7 @@ const DisruptionTable = ({
             return acc + curr.sourceLabel
           }, ""),
           adjustments: revision.adjustments,
+          isActive: revision.isActive,
           selected,
           selectable,
         }

--- a/assets/src/disruptions/editDisruption.tsx
+++ b/assets/src/disruptions/editDisruption.tsx
@@ -108,7 +108,7 @@ const EditDisruption = ({
   if (doRedirect) {
     return (
       <Redirect
-        to={"/disruptions/" + +encodeURIComponent(match.params.id) + "?v=draft"}
+        to={"/disruptions/" + encodeURIComponent(match.params.id) + "?v=draft"}
       />
     )
   }

--- a/assets/src/disruptions/editDisruption.tsx
+++ b/assets/src/disruptions/editDisruption.tsx
@@ -107,7 +107,9 @@ const EditDisruption = ({
 
   if (doRedirect) {
     return (
-      <Redirect to={"/disruptions/" + +encodeURIComponent(match.params.id)} />
+      <Redirect
+        to={"/disruptions/" + +encodeURIComponent(match.params.id) + "?v=draft"}
+      />
     )
   }
 

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -241,7 +241,7 @@ const dayOfWeekTimeRangesToDayOfWeeks = (
   return daysOfWeek
 }
 
-const timeOrEndOfService = (
+const timeOrStartOrEndOfService = (
   timeString?: string,
   end: "start" | "end" = "start"
 ): string => {
@@ -295,7 +295,7 @@ const timePeriodDescription = (
   startTime: string | undefined,
   endTime: string | undefined
 ) => {
-  return `${timeOrEndOfService(startTime)} - ${timeOrEndOfService(
+  return `${timeOrStartOrEndOfService(startTime)} - ${timeOrStartOrEndOfService(
     endTime,
     "end"
   )}`
@@ -340,14 +340,16 @@ const parseDaysAndTimes = (daysAndTimes: DayOfWeek[]): string => {
   } else if (timeType === "daily") {
     return `${dayToAbbr(first.dayName)} - ${dayToAbbr(
       last.dayName
-    )}, ${timeOrEndOfService(first.startTime)} - ${timeOrEndOfService(
-      first.endTime,
+    )}, ${timeOrStartOrEndOfService(
+      first.startTime
+    )} - ${timeOrStartOrEndOfService(first.endTime, "end")}`
+  } else {
+    return `${dayToAbbr(first.dayName)} ${timeOrStartOrEndOfService(
+      first.startTime
+    )} - ${dayToAbbr(last.dayName)} ${timeOrStartOrEndOfService(
+      last.endTime,
       "end"
     )}`
-  } else {
-    return `${dayToAbbr(first.dayName)} ${timeOrEndOfService(
-      first.startTime
-    )} - ${dayToAbbr(last.dayName)} ${timeOrEndOfService(last.endTime, "end")}`
   }
 }
 
@@ -365,6 +367,6 @@ export {
   dayOfWeekTimeRangesToDayOfWeeks,
   parseDaysAndTimes,
   dayToIx,
-  timeOrEndOfService,
+  timeOrStartOrEndOfService,
   timePeriodDescription,
 }

--- a/assets/src/disruptions/time.ts
+++ b/assets/src/disruptions/time.ts
@@ -291,14 +291,22 @@ const getDaysType = (days: DayName[]): DaysType => {
   return consecutive ? "consecutive" : "other"
 }
 
+const timePeriodDescription = (
+  startTime: string | undefined,
+  endTime: string | undefined
+) => {
+  return `${timeOrEndOfService(startTime)} - ${timeOrEndOfService(
+    endTime,
+    "end"
+  )}`
+}
+
 const describeSingleDay = ({
   dayName,
   startTime,
   endTime,
 }: DayOfWeek): string =>
-  `${dayToAbbr(dayName)}, ${timeOrEndOfService(
-    startTime
-  )} - ${timeOrEndOfService(endTime, "end")}`
+  `${dayToAbbr(dayName)}, ${timePeriodDescription(startTime, endTime)}`
 
 const parseDaysAndTimes = (daysAndTimes: DayOfWeek[]): string => {
   if (daysAndTimes.length === 1) {
@@ -357,4 +365,6 @@ export {
   dayOfWeekTimeRangesToDayOfWeeks,
   parseDaysAndTimes,
   dayToIx,
+  timeOrEndOfService,
+  timePeriodDescription,
 }

--- a/assets/src/disruptions/viewDisruption.tsx
+++ b/assets/src/disruptions/viewDisruption.tsx
@@ -124,6 +124,8 @@ const ViewDisruptionForm = ({
       disruptionRevision?.daysOfWeek || []
     )
 
+    const anyDeleted = [published, ready, draft].some((x) => !!x && !x.isActive)
+
     if (disruptionDaysOfWeek !== "error") {
       return (
         <Page>
@@ -148,22 +150,19 @@ const ViewDisruptionForm = ({
                     </span>
                   </h5>
                 </div>
-                {disruptionRevision?.disruptionId &&
-                  disruptionRevision.startDate &&
-                  disruptionRevision.startDate >=
-                    new Date(new Date().toDateString()) &&
-                  (view === DisruptionView.Draft ||
-                    (view === DisruptionView.Ready && !draft) ||
-                    (view === DisruptionView.Published && !draft && !ready)) &&
-                  (disruptionRevision.isActive ? (
+                {disruptionRevision &&
+                  (anyDeleted ? (
+                    <div>Marked for deletion</div>
+                  ) : disruptionRevision &&
+                    disruptionRevision.startDate &&
+                    disruptionRevision.startDate >=
+                      new Date(new Date().toDateString()) ? (
                     <DeleteDisruptionButton
                       disruptionId={disruption.id}
                       setDeletionErrors={setDeletionErrors}
                       setDoRedirect={setDoRedirect}
                     />
-                  ) : (
-                    <div>Marked for deletion</div>
-                  ))}
+                  ) : null)}
               </div>
               {disruptionRevision && (
                 <div className="m-disruption-details__adjustments">
@@ -235,21 +234,21 @@ const ViewDisruptionForm = ({
                         Created {formatDisruptionDate(draft.insertedAt || null)}
                       </span>
                     </NavLink>
-                  ) : (
+                  ) : !anyDeleted ? (
                     <Link
                       className="m-disruption-details__view-toggle text-primary"
                       to={`/disruptions/${disruption.id}/edit`}
                     >
                       <strong>create new draft</strong>
                     </Link>
-                  )}
+                  ) : null}
                 </div>
               </div>
               <hr className="my-3" />
               {disruptionRevision ? (
                 <div>
                   <Row>
-                    {!disruptionRevision.isActive && (
+                    {anyDeleted && (
                       <Col xs={12}>
                         <div className="m-disruption-details__deletion-indicator">
                           <span className="text-blue-grey mr-3">
@@ -261,11 +260,7 @@ const ViewDisruptionForm = ({
                       </Col>
                     )}
                     <Col md={10}>
-                      <div
-                        className={
-                          disruptionRevision.isActive ? "" : "text-muted"
-                        }
-                      >
+                      <div className={anyDeleted ? "text-muted" : ""}>
                         <div className="mb-3">
                           <h4>date range</h4>
                           <div className="pl-3">

--- a/assets/src/disruptions/viewDisruption.tsx
+++ b/assets/src/disruptions/viewDisruption.tsx
@@ -309,45 +309,6 @@ const ViewDisruptionForm = ({
                           </div>
                         </div>
                       )}
-                      {view === DisruptionView.Draft && (
-                        <SecondaryButton
-                          id="mark-ready"
-                          onClick={() => {
-                            if (
-                              window.confirm(
-                                "Are you sure you want to mark these revisions as ready?"
-                              )
-                            ) {
-                              apiSend({
-                                method: "POST",
-                                json: JSON.stringify({
-                                  revision_ids: disruptionRevision.id,
-                                }),
-                                url: "/api/ready_notice/",
-                              })
-                                .then(async () => {
-                                  await fetchDisruption()
-                                  history.replace(
-                                    "/disruptions/" +
-                                      encodeURIComponent(disruptionId) +
-                                      "?v=ready"
-                                  )
-                                })
-                                .catch(() => {
-                                  // eslint-disable-next-line no-console
-                                  console.log(
-                                    `failed to mark revision as ready: ${disruptionRevision.id}`
-                                  )
-                                })
-                            }
-                          }}
-                        >
-                          {"mark as ready" +
-                            (disruptionRevision.isActive
-                              ? ""
-                              : " for deletion")}
-                        </SecondaryButton>
-                      )}
                     </Col>
                     <Col md={2}>
                       {view === DisruptionView.Draft &&
@@ -362,6 +323,54 @@ const ViewDisruptionForm = ({
                             </PrimaryButton>
                           </Link>
                         )}
+                    </Col>
+                  </Row>
+                  <Row>
+                    <Col>
+                      {view === DisruptionView.Draft && (
+                        <div>
+                          <hr className="my-3" />
+                          <div className="d-flex justify-content-center">
+                            <SecondaryButton
+                              id="mark-ready"
+                              onClick={() => {
+                                if (
+                                  window.confirm(
+                                    "Are you sure you want to mark these revisions as ready?"
+                                  )
+                                ) {
+                                  apiSend({
+                                    method: "POST",
+                                    json: JSON.stringify({
+                                      revision_ids: disruptionRevision.id,
+                                    }),
+                                    url: "/api/ready_notice/",
+                                  })
+                                    .then(async () => {
+                                      await fetchDisruption()
+                                      history.replace(
+                                        "/disruptions/" +
+                                          encodeURIComponent(disruptionId) +
+                                          "?v=ready"
+                                      )
+                                    })
+                                    .catch(() => {
+                                      // eslint-disable-next-line no-console
+                                      console.log(
+                                        `failed to mark revision as ready: ${disruptionRevision.id}`
+                                      )
+                                    })
+                                }
+                              }}
+                            >
+                              {"mark as ready" +
+                                (disruptionRevision.isActive
+                                  ? ""
+                                  : " for deletion")}
+                            </SecondaryButton>
+                          </div>
+                        </div>
+                      )}
                     </Col>
                   </Row>
                 </div>

--- a/assets/src/disruptions/viewDisruption.tsx
+++ b/assets/src/disruptions/viewDisruption.tsx
@@ -130,7 +130,7 @@ const ViewDisruptionForm = ({
       return (
         <Page>
           <Row>
-            <Col>
+            <Col lg={7}>
               {deletionErrors.length > 0 && (
                 <Alert variant="danger">
                   <ul>

--- a/assets/src/disruptions/viewDisruption.tsx
+++ b/assets/src/disruptions/viewDisruption.tsx
@@ -162,7 +162,7 @@ const ViewDisruptionForm = ({
                       setDoRedirect={setDoRedirect}
                     />
                   ) : (
-                    <div>marked for deletion</div>
+                    <div>Marked for deletion</div>
                   ))}
               </div>
               {disruptionRevision && (
@@ -249,66 +249,83 @@ const ViewDisruptionForm = ({
               {disruptionRevision ? (
                 <div>
                   <Row>
+                    {!disruptionRevision.isActive && (
+                      <Col xs={12}>
+                        <div className="m-disruption-details__deletion-indicator">
+                          <span className="text-blue-grey mr-3">
+                            {"\uE14E"}
+                          </span>
+                          <strong>Note</strong> This disruption is marked for
+                          deletion
+                        </div>
+                      </Col>
+                    )}
                     <Col md={10}>
-                      <div className="mb-3">
-                        <h4>date range</h4>
-                        <div className="pl-3">
-                          {formatDisruptionDate(
-                            disruptionRevision.startDate || null
-                          )}{" "}
-                          &ndash;{" "}
-                          {formatDisruptionDate(
-                            disruptionRevision.endDate || null
-                          )}
-                        </div>
-                      </div>
-                      <div className="mb-3">
-                        <h4>time period</h4>
-                        <div className="pl-3">
-                          {disruptionRevision.daysOfWeek.map((d) => {
-                            return (
-                              <div key={d.id}>
-                                <div>
-                                  <strong>
-                                    {d.dayName.charAt(0).toUpperCase() +
-                                      d.dayName.slice(1)}
-                                  </strong>
-                                </div>
-                                <div>
-                                  {timePeriodDescription(
-                                    d.startTime,
-                                    d.endTime
-                                  )}
-                                </div>
-                              </div>
-                            )
-                          })}
-                        </div>
-                      </div>
-                      {disruptionRevision.tripShortNames.length > 0 && (
+                      <div
+                        className={
+                          disruptionRevision.isActive ? "" : "text-muted"
+                        }
+                      >
                         <div className="mb-3">
-                          <h4>trips</h4>
+                          <h4>date range</h4>
                           <div className="pl-3">
-                            {disruptionRevision.tripShortNames
-                              .map((x) => x.tripShortName)
-                              .join(", ")}
+                            {formatDisruptionDate(
+                              disruptionRevision.startDate || null
+                            )}{" "}
+                            &ndash;{" "}
+                            {formatDisruptionDate(
+                              disruptionRevision.endDate || null
+                            )}
                           </div>
                         </div>
-                      )}
-                      {exceptionDates.length > 0 && (
                         <div className="mb-3">
-                          <h4>exceptions</h4>
+                          <h4>time period</h4>
                           <div className="pl-3">
-                            {exceptionDates.map((exc) => {
+                            {disruptionRevision.daysOfWeek.map((d) => {
                               return (
-                                <div key={exc.toISOString()}>
-                                  {formatDisruptionDate(exc)}
+                                <div key={d.id}>
+                                  <div>
+                                    <strong>
+                                      {d.dayName.charAt(0).toUpperCase() +
+                                        d.dayName.slice(1)}
+                                    </strong>
+                                  </div>
+                                  <div>
+                                    {timePeriodDescription(
+                                      d.startTime,
+                                      d.endTime
+                                    )}
+                                  </div>
                                 </div>
                               )
                             })}
                           </div>
                         </div>
-                      )}
+                        {disruptionRevision.tripShortNames.length > 0 && (
+                          <div className="mb-3">
+                            <h4>trips</h4>
+                            <div className="pl-3">
+                              {disruptionRevision.tripShortNames
+                                .map((x) => x.tripShortName)
+                                .join(", ")}
+                            </div>
+                          </div>
+                        )}
+                        {exceptionDates.length > 0 && (
+                          <div className="mb-3">
+                            <h4>exceptions</h4>
+                            <div className="pl-3">
+                              {exceptionDates.map((exc) => {
+                                return (
+                                  <div key={exc.toISOString()}>
+                                    {formatDisruptionDate(exc)}
+                                  </div>
+                                )
+                              })}
+                            </div>
+                          </div>
+                        )}
+                      </div>
                     </Col>
                     <Col md={2}>
                       {view === DisruptionView.Draft &&

--- a/assets/src/disruptions/viewDisruption.tsx
+++ b/assets/src/disruptions/viewDisruption.tsx
@@ -162,7 +162,7 @@ const ViewDisruptionForm = ({
                       setDoRedirect={setDoRedirect}
                     />
                   ) : (
-                    <div className="text-primary">marked for deletion</div>
+                    <div>marked for deletion</div>
                   ))}
               </div>
               {disruptionRevision && (

--- a/assets/src/disruptions/viewDisruption.tsx
+++ b/assets/src/disruptions/viewDisruption.tsx
@@ -1,42 +1,28 @@
 import * as React from "react"
-import { RouteComponentProps, Link, Redirect } from "react-router-dom"
+import {
+  RouteComponentProps,
+  Link,
+  Redirect,
+  NavLink,
+  useHistory,
+} from "react-router-dom"
 import Alert from "react-bootstrap/Alert"
-import { Button } from "../button"
-
+import { LinkButton, PrimaryButton, SecondaryButton } from "../button"
 import { apiGet, apiSend } from "../api"
-
 import Loading from "../loading"
-import { DisruptionPreview } from "./disruptionPreview"
-import { fromDaysOfWeek } from "./time"
-
+import { fromDaysOfWeek, timePeriodDescription } from "./time"
 import { JsonApiResponse, toModelObject, parseErrors } from "../jsonApi"
 import { Page } from "../page"
 import Disruption, { DisruptionView } from "../models/disruption"
-import { DisruptionViewToggle, useDisruptionViewParam } from "./viewToggle"
+import { useDisruptionViewParam } from "./viewToggle"
 import Row from "react-bootstrap/Row"
 import Col from "react-bootstrap/Col"
-import DisruptionRevision from "../models/disruptionRevision"
+import Icon from "../icons"
+import { getRouteIcon } from "./disruptionIndex"
+import { formatDisruptionDate } from "./disruptions"
 
 interface TParams {
   id: string
-}
-
-interface EditDisruptionButtonProps {
-  disruptionId: string
-}
-
-const EditDisruptionButton = ({
-  disruptionId,
-}: EditDisruptionButtonProps): JSX.Element => {
-  return (
-    <Link
-      to={"/disruptions/" + encodeURIComponent(disruptionId) + "/edit"}
-      id="edit-disruption-link"
-      className="btn btn-primary"
-    >
-      edit disruption times
-    </Link>
-  )
 }
 
 interface DeleteDisruptionButtonProps {
@@ -51,8 +37,7 @@ const DeleteDisruptionButton = ({
   setDeletionErrors,
 }: DeleteDisruptionButtonProps): JSX.Element => {
   return (
-    <Button
-      variant="light"
+    <LinkButton
       onClick={async () => {
         if (window.confirm("Really delete this disruption?")) {
           const result = await apiSend({
@@ -74,8 +59,8 @@ const DeleteDisruptionButton = ({
       }}
       id="delete-disruption-button"
     >
-      delete disruption
-    </Button>
+      delete
+    </LinkButton>
   )
 }
 
@@ -92,51 +77,58 @@ interface ViewDisruptionFormProps {
 const ViewDisruptionForm = ({
   disruptionId,
 }: ViewDisruptionFormProps): JSX.Element => {
-  const [disruptionRevision, setDisruptionRevision] = React.useState<
-    DisruptionRevision | "error" | null
+  const [disruption, setDisruption] = React.useState<
+    Disruption | "error" | null
   >(null)
   const [doRedirect, setDoRedirect] = React.useState<boolean>(false)
   const [deletionErrors, setDeletionErrors] = React.useState<string[]>([])
-  const view = useDisruptionViewParam()
-  React.useEffect(() => {
-    apiGet<JsonApiResponse>({
+  const fetchDisruption = React.useCallback(() => {
+    return apiGet<JsonApiResponse>({
       url: "/api/disruptions/" + encodeURIComponent(disruptionId),
       parser: toModelObject,
       defaultResult: "error",
     }).then((result: JsonApiResponse) => {
       if (result instanceof Disruption) {
-        setDisruptionRevision(
-          Disruption.revisionFromDisruptionForView(result, view) || null
-        )
+        setDisruption(result)
       } else {
-        setDisruptionRevision("error")
+        setDisruption("error")
       }
     })
-  }, [disruptionId, view])
+  }, [disruptionId, setDisruption])
+  React.useEffect(() => {
+    fetchDisruption()
+  }, [disruptionId, fetchDisruption])
+
+  const view = useDisruptionViewParam()
+  const history = useHistory()
 
   if (doRedirect) {
     return <Redirect to={`/`} />
   }
 
-  if (
-    disruptionRevision &&
-    disruptionRevision !== "error" &&
-    disruptionRevision.id
-  ) {
-    const exceptionDates = disruptionRevision.exceptions
+  if (disruption && disruption !== "error" && disruption.id) {
+    const { published, ready, draft } = disruption.getUniqueRevisions()
+    const disruptionRevision = Disruption.uniqueRevisionFromDisruptionForView(
+      disruption,
+      view
+    )
+
+    const exceptionDates = (disruptionRevision?.exceptions || [])
       .map((exception) => exception.excludedDate)
       .filter(
         (maybeDate: Date | undefined): maybeDate is Date =>
           typeof maybeDate !== "undefined"
       )
 
-    const disruptionDaysOfWeek = fromDaysOfWeek(disruptionRevision.daysOfWeek)
+    const disruptionDaysOfWeek = fromDaysOfWeek(
+      disruptionRevision?.daysOfWeek || []
+    )
 
     if (disruptionDaysOfWeek !== "error") {
       return (
         <Page>
           <Row>
-            <Col xs={9}>
+            <Col>
               {deletionErrors.length > 0 && (
                 <Alert variant="danger">
                   <ul>
@@ -146,43 +138,244 @@ const ViewDisruptionForm = ({
                   </ul>
                 </Alert>
               )}
-              <DisruptionPreview
-                disruptionId={disruptionRevision.disruptionId}
-                adjustments={disruptionRevision.adjustments}
-                fromDate={disruptionRevision.startDate || null}
-                toDate={disruptionRevision.endDate || null}
-                exceptionDates={exceptionDates}
-                disruptionDaysOfWeek={disruptionDaysOfWeek}
-                tripShortNames={disruptionRevision.tripShortNames
-                  .map((tsn) => tsn.tripShortName)
-                  .join(", ")}
-              />
-              {view === DisruptionView.Draft && (
-                <>
-                  <div>
-                    {disruptionRevision.disruptionId && (
-                      <EditDisruptionButton
-                        disruptionId={disruptionRevision.disruptionId}
-                      />
-                    )}
-                  </div>
-                  {disruptionRevision.disruptionId &&
-                    disruptionRevision.startDate &&
-                    disruptionRevision.startDate >=
-                      new Date(new Date().toDateString()) && (
-                      <div>
-                        <DeleteDisruptionButton
-                          disruptionId={disruptionRevision.disruptionId}
-                          setDoRedirect={setDoRedirect}
-                          setDeletionErrors={setDeletionErrors}
+              <div className="m-disruption-details__header">
+                <div className="d-flex align-items-end">
+                  <h2 className="mb-0">adjustment</h2>
+                  <h5>
+                    ID
+                    <span className="ml-2 font-weight-normal">
+                      {disruptionId}
+                    </span>
+                  </h5>
+                </div>
+                {disruptionRevision?.disruptionId &&
+                  disruptionRevision.startDate &&
+                  disruptionRevision.startDate >=
+                    new Date(new Date().toDateString()) &&
+                  (view === DisruptionView.Draft ||
+                    (view === DisruptionView.Ready && !draft) ||
+                    (view === DisruptionView.Published && !draft && !ready)) &&
+                  (disruptionRevision.isActive ? (
+                    <DeleteDisruptionButton
+                      disruptionId={disruption.id}
+                      setDeletionErrors={setDeletionErrors}
+                      setDoRedirect={setDoRedirect}
+                    />
+                  ) : (
+                    <div className="text-primary">marked for deletion</div>
+                  ))}
+              </div>
+              {disruptionRevision && (
+                <div className="m-disruption-details__adjustments">
+                  <ul className="m-disruption-details__adjustment-list">
+                    {disruptionRevision.adjustments.map((adj) => (
+                      <li
+                        key={adj.id}
+                        className="m-disruption-details__adjustment-item"
+                      >
+                        <Icon
+                          className="mr-3"
+                          type={getRouteIcon(adj.routeId)}
+                          size="sm"
                         />
-                      </div>
-                    )}
-                </>
+                        {adj.sourceLabel}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               )}
-            </Col>
-            <Col>
-              <DisruptionViewToggle />
+              <div>
+                <div className="mb-2">
+                  <strong>select view</strong>
+                </div>
+                <div className="m-disruption-details__view-toggle-group d-flex flex-column">
+                  {published && (
+                    <NavLink
+                      id="published"
+                      to="?"
+                      className="m-disruption-details__view-toggle"
+                      activeClassName="active"
+                      isActive={() => view === DisruptionView.Published}
+                    >
+                      <strong className="mr-3">published</strong>
+                      <span className="text-muted">
+                        In GTFS{" "}
+                        {formatDisruptionDate(
+                          disruption.lastPublishedAt || null
+                        )}
+                      </span>
+                    </NavLink>
+                  )}
+                  {ready && (
+                    <NavLink
+                      id="ready"
+                      className="m-disruption-details__view-toggle"
+                      to="?v=ready"
+                      activeClassName="active"
+                      isActive={() => view === DisruptionView.Ready}
+                      replace
+                    >
+                      <strong className="mr-3">ready</strong>
+                      <span className="text-muted">
+                        Created {formatDisruptionDate(ready.insertedAt || null)}
+                      </span>
+                    </NavLink>
+                  )}
+                  {draft ? (
+                    <NavLink
+                      id="draft"
+                      className="m-disruption-details__view-toggle text-primary"
+                      to="?v=draft"
+                      activeClassName="active"
+                      isActive={() => view === DisruptionView.Draft}
+                      replace
+                    >
+                      <strong className="mr-3">needs review</strong>
+                      <span className="text-muted">
+                        Created {formatDisruptionDate(draft.insertedAt || null)}
+                      </span>
+                    </NavLink>
+                  ) : (
+                    <Link
+                      className="m-disruption-details__view-toggle text-primary"
+                      to={`/disruptions/${disruption.id}/edit`}
+                    >
+                      <strong>create new draft</strong>
+                    </Link>
+                  )}
+                </div>
+              </div>
+              <hr className="my-3" />
+              {disruptionRevision ? (
+                <div>
+                  <Row>
+                    <Col md={10}>
+                      <div className="mb-3">
+                        <h4>date range</h4>
+                        <div className="pl-3">
+                          {formatDisruptionDate(
+                            disruptionRevision.startDate || null
+                          )}{" "}
+                          &ndash;{" "}
+                          {formatDisruptionDate(
+                            disruptionRevision.endDate || null
+                          )}
+                        </div>
+                      </div>
+                      <div className="mb-3">
+                        <h4>time period</h4>
+                        <div className="pl-3">
+                          {disruptionRevision.daysOfWeek.map((d) => {
+                            return (
+                              <div key={d.id}>
+                                <div>
+                                  <strong>
+                                    {d.dayName.charAt(0).toUpperCase() +
+                                      d.dayName.slice(1)}
+                                  </strong>
+                                </div>
+                                <div>
+                                  {timePeriodDescription(
+                                    d.startTime,
+                                    d.endTime
+                                  )}
+                                </div>
+                              </div>
+                            )
+                          })}
+                        </div>
+                      </div>
+                      {disruptionRevision.tripShortNames.length > 0 && (
+                        <div className="mb-3">
+                          <h4>trips</h4>
+                          <div className="pl-3">
+                            {disruptionRevision.tripShortNames
+                              .map((x) => x.tripShortName)
+                              .join(", ")}
+                          </div>
+                        </div>
+                      )}
+                      {exceptionDates.length > 0 && (
+                        <div className="mb-3">
+                          <h4>exceptions</h4>
+                          <div className="pl-3">
+                            {exceptionDates.map((exc) => {
+                              return (
+                                <div key={exc.toISOString()}>
+                                  {formatDisruptionDate(exc)}
+                                </div>
+                              )
+                            })}
+                          </div>
+                        </div>
+                      )}
+                      {view === DisruptionView.Draft && (
+                        <SecondaryButton
+                          id="mark-ready"
+                          onClick={() => {
+                            if (
+                              window.confirm(
+                                "Are you sure you want to mark these revisions as ready?"
+                              )
+                            ) {
+                              apiSend({
+                                method: "POST",
+                                json: JSON.stringify({
+                                  revision_ids: disruptionRevision.id,
+                                }),
+                                url: "/api/ready_notice/",
+                              })
+                                .then(async () => {
+                                  await fetchDisruption()
+                                  history.replace(
+                                    "/disruptions/" +
+                                      encodeURIComponent(disruptionId) +
+                                      "?v=ready"
+                                  )
+                                })
+                                .catch(() => {
+                                  // eslint-disable-next-line no-console
+                                  console.log(
+                                    `failed to mark revision as ready: ${disruptionRevision.id}`
+                                  )
+                                })
+                            }
+                          }}
+                        >
+                          {"mark as ready" +
+                            (disruptionRevision.isActive
+                              ? ""
+                              : " for deletion")}
+                        </SecondaryButton>
+                      )}
+                    </Col>
+                    <Col md={2}>
+                      {view === DisruptionView.Draft &&
+                        disruptionRevision.isActive && (
+                          <Link to={`/disruptions/${disruption.id}/edit`}>
+                            <PrimaryButton
+                              id="edit-disruption-link"
+                              className="w-100"
+                              filled
+                            >
+                              edit
+                            </PrimaryButton>
+                          </Link>
+                        )}
+                    </Col>
+                  </Row>
+                </div>
+              ) : (
+                <div>
+                  Disruption {disruption.id} has no{" "}
+                  {view === DisruptionView.Draft
+                    ? "draft"
+                    : view === DisruptionView.Ready
+                    ? "ready"
+                    : "published"}{" "}
+                  revision
+                </div>
+              )}
             </Col>
           </Row>
         </Page>
@@ -190,7 +383,7 @@ const ViewDisruptionForm = ({
     } else {
       return <div>Error parsing day of week information.</div>
     }
-  } else if (disruptionRevision === "error") {
+  } else if (disruption === "error") {
     return <div>Error fetching or parsing disruption.</div>
   } else {
     return <Loading />

--- a/assets/src/disruptions/viewToggle.tsx
+++ b/assets/src/disruptions/viewToggle.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-import { NavLink, useHistory } from "react-router-dom"
+import { useHistory } from "react-router-dom"
 import queryString from "query-string"
 
 import { DisruptionView } from "../models/disruption"
@@ -10,39 +9,13 @@ const useDisruptionViewParam = (): DisruptionView => {
     case "draft": {
       return DisruptionView.Draft
     }
-    default: {
+    case "ready": {
       return DisruptionView.Ready
+    }
+    default: {
+      return DisruptionView.Published
     }
   }
 }
 
-const DisruptionViewToggle = () => {
-  const view = useDisruptionViewParam()
-  return (
-    <div className="d-flex flex-column">
-      <h5>Select View</h5>
-      <NavLink
-        id="draft"
-        className="btn m-disruption-view-toggle_button"
-        to="?v=draft"
-        activeClassName="active"
-        isActive={() => view === DisruptionView.Draft}
-        replace
-      >
-        create or edit
-      </NavLink>
-      <NavLink
-        id="ready"
-        className="btn m-disruption-view-toggle_button"
-        to="?"
-        activeClassName="active"
-        isActive={() => view === DisruptionView.Ready}
-        replace
-      >
-        ready
-      </NavLink>
-    </div>
-  )
-}
-
-export { DisruptionViewToggle, useDisruptionViewParam }
+export { useDisruptionViewParam }

--- a/assets/src/header.tsx
+++ b/assets/src/header.tsx
@@ -27,9 +27,11 @@ const Header = ({ includeHomeLink }: HeaderProps) => (
       </Navbar.Collapse>
     </Navbar>
     {includeHomeLink && (
-      <a id="header-home-link" href="/">
-        &lt; back to home
-      </a>
+      <div className="my-3">
+        <a id="header-home-link" href="/">
+          &lt; back to home
+        </a>
+      </div>
     )}
   </div>
 )

--- a/assets/tests/disruptions/disruptionTable.test.tsx
+++ b/assets/tests/disruptions/disruptionTable.test.tsx
@@ -24,7 +24,7 @@ const DisruptionTableWithRouter = ({
             disruptionId: "1",
             startDate: new Date("2019-10-31"),
             endDate: new Date("2019-11-15"),
-            isActive: false,
+            isActive: true,
             adjustments: [
               new Adjustment({
                 id: "1",
@@ -63,7 +63,7 @@ const DisruptionTableWithRouter = ({
             disruptionId: "1",
             startDate: new Date("2019-10-31"),
             endDate: new Date("2019-11-16"),
-            isActive: false,
+            isActive: true,
             adjustments: [
               new Adjustment({
                 id: "1",

--- a/assets/tests/disruptions/disruptionTable.test.tsx
+++ b/assets/tests/disruptions/disruptionTable.test.tsx
@@ -263,8 +263,9 @@ describe("DisruptionTable", () => {
     )
     expect(firstRowData.item(4).textContent).toEqual("published")
     expect(
-      firstRowData.item(5).querySelectorAll("a[href='/disruptions/2?v=']")
-        .length
+      firstRowData
+        .item(5)
+        .querySelectorAll("a[href='/disruptions/2?v=published']").length
     ).toEqual(1)
     let activeSortToggle = container.querySelector(
       ".m-disruption-table__sortable.active"

--- a/assets/tests/disruptions/viewDisruption.test.tsx
+++ b/assets/tests/disruptions/viewDisruption.test.tsx
@@ -1353,4 +1353,73 @@ describe("ViewDisruption", () => {
     })
     expect(spy).toBeCalledTimes(1)
   })
+
+  test("does not display 'create new disruption' button if any revision is deleted", async () => {
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
+      return Promise.resolve(
+        new Disruption({
+          id: "1",
+          readyRevision: new DisruptionRevision({
+            id: "1",
+            disruptionId: "1",
+            startDate: new Date("2020-01-15"),
+            endDate: new Date("2020-01-30"),
+            isActive: false,
+            adjustments: [],
+            daysOfWeek: [],
+            exceptions: [],
+            tripShortNames: [],
+          }),
+          revisions: [
+            new DisruptionRevision({
+              id: "1",
+              disruptionId: "1",
+              startDate: new Date("2020-01-15"),
+              endDate: new Date("2020-01-30"),
+              isActive: true,
+              adjustments: [],
+              daysOfWeek: [],
+              exceptions: [],
+              tripShortNames: [],
+            }),
+          ],
+        })
+      )
+    })
+
+    const history = createBrowserHistory()
+    history.push("/disruptions/1?v=ready")
+
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      ReactDOM.render(
+        <BrowserRouter>
+          <ViewDisruption
+            match={{
+              params: { id: "1" },
+              isExact: true,
+              path: "/disruptions/1?v=ready",
+              url: "https://localhost/disruptions/1?v=ready",
+            }}
+            history={history}
+            location={{
+              pathname: "/disruptions/1?v=ready",
+              search: "?v=ready",
+              state: {},
+              hash: "",
+            }}
+          />
+        </BrowserRouter>,
+        container
+      )
+    })
+
+    const editButton = container.querySelector(
+      "a[href='/disruptions/1/edit']"
+    ) as Element
+    expect(editButton).toBeNull()
+  })
 })

--- a/assets/tests/disruptions/viewDisruption.test.tsx
+++ b/assets/tests/disruptions/viewDisruption.test.tsx
@@ -95,6 +95,7 @@ describe("ViewDisruption", () => {
     })
 
     const history = createBrowserHistory()
+    history.push("/disruptions/1?v=ready")
 
     const container = document.createElement("div")
     document.body.appendChild(container)
@@ -107,13 +108,13 @@ describe("ViewDisruption", () => {
             match={{
               params: { id: "1" },
               isExact: true,
-              path: "/disruptions/1",
-              url: "https://localhost/disruptions/1",
+              path: "/disruptions/1?v=ready",
+              url: "https://localhost/disruptions/1?v=ready",
             }}
             history={history}
             location={{
-              pathname: "/disruptions/1",
-              search: "",
+              pathname: "/disruptions/1?v=ready",
+              search: "?v=ready",
               state: {},
               hash: "",
             }}
@@ -129,16 +130,16 @@ describe("ViewDisruption", () => {
     expect(document.body.textContent).toMatch("1/20/2020")
     expect(document.body.textContent).toMatch("Friday")
     expect(document.body.textContent).toMatch("8:45PM")
-    expect(document.body.textContent).toMatch("Trips: 123, 456")
+    expect(document.body.textContent).toMatch("123, 456")
     expect(document.body.textContent).toMatch("End of service")
   })
 
-  test("edit link redirects to edit page", async () => {
+  test("indicates if revision does not exist for ready view", async () => {
     jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
       return Promise.resolve(
         new Disruption({
           id: "1",
-          readyRevision: new DisruptionRevision({
+          publishedRevision: new DisruptionRevision({
             id: "1",
             disruptionId: "1",
             startDate: new Date("2020-01-15"),
@@ -180,13 +181,213 @@ describe("ViewDisruption", () => {
             match={{
               params: { id: "1" },
               isExact: true,
-              path: "/disruptions/1",
-              url: "https://localhost/disruptions/1",
+              path: "/disruptions/1?v=draft",
+              url: "https://localhost/disruptions/1?v=draft",
             }}
             history={history}
             location={{
-              pathname: "/disruptions/1",
-              search: "",
+              pathname: "/disruptions/1?v=draft",
+              search: "?v=draft",
+              state: {},
+              hash: "",
+            }}
+          />
+        </BrowserRouter>,
+        container
+      )
+    })
+
+    expect(container.textContent).toMatch("Disruption 1 has no draft revision")
+  })
+
+  test("indicates if revision does not exist for draft view", async () => {
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
+      return Promise.resolve(
+        new Disruption({
+          id: "1",
+          draftRevision: new DisruptionRevision({
+            id: "1",
+            disruptionId: "1",
+            startDate: new Date("2020-01-15"),
+            endDate: new Date("2020-01-30"),
+            isActive: true,
+            adjustments: [],
+            daysOfWeek: [],
+            exceptions: [],
+            tripShortNames: [],
+          }),
+          revisions: [
+            new DisruptionRevision({
+              id: "1",
+              disruptionId: "1",
+              startDate: new Date("2020-01-15"),
+              endDate: new Date("2020-01-30"),
+              isActive: true,
+              adjustments: [],
+              daysOfWeek: [],
+              exceptions: [],
+              tripShortNames: [],
+            }),
+          ],
+        })
+      )
+    })
+
+    const history = createBrowserHistory()
+    history.push("/disruptions/1?v=ready")
+
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      ReactDOM.render(
+        <BrowserRouter>
+          <ViewDisruption
+            match={{
+              params: { id: "1" },
+              isExact: true,
+              path: "/disruptions/1?v=ready",
+              url: "https://localhost/disruptions/1?v=ready",
+            }}
+            history={history}
+            location={{
+              pathname: "/disruptions/1?v=ready",
+              search: "?v=ready",
+              state: {},
+              hash: "",
+            }}
+          />
+        </BrowserRouter>,
+        container
+      )
+    })
+
+    expect(container.textContent).toMatch("Disruption 1 has no ready revision")
+  })
+
+  test("indicates if revision does not exist for published view", async () => {
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
+      return Promise.resolve(
+        new Disruption({
+          id: "1",
+          draftRevision: new DisruptionRevision({
+            id: "1",
+            disruptionId: "1",
+            startDate: new Date("2020-01-15"),
+            endDate: new Date("2020-01-30"),
+            isActive: true,
+            adjustments: [],
+            daysOfWeek: [],
+            exceptions: [],
+            tripShortNames: [],
+          }),
+          revisions: [
+            new DisruptionRevision({
+              id: "1",
+              disruptionId: "1",
+              startDate: new Date("2020-01-15"),
+              endDate: new Date("2020-01-30"),
+              isActive: true,
+              adjustments: [],
+              daysOfWeek: [],
+              exceptions: [],
+              tripShortNames: [],
+            }),
+          ],
+        })
+      )
+    })
+
+    const history = createBrowserHistory()
+    history.push("/disruptions/1?v=published")
+
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      ReactDOM.render(
+        <BrowserRouter>
+          <ViewDisruption
+            match={{
+              params: { id: "1" },
+              isExact: true,
+              path: "/disruptions/1?v=published",
+              url: "https://localhost/disruptions/1?v=published",
+            }}
+            history={history}
+            location={{
+              pathname: "/disruptions/1?v=published",
+              search: "?v=published",
+              state: {},
+              hash: "",
+            }}
+          />
+        </BrowserRouter>,
+        container
+      )
+    })
+
+    expect(container.textContent).toMatch(
+      "Disruption 1 has no published revision"
+    )
+  })
+
+  test("edit link redirects to edit page", async () => {
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
+      return Promise.resolve(
+        new Disruption({
+          id: "1",
+          draftRevision: new DisruptionRevision({
+            id: "1",
+            disruptionId: "1",
+            startDate: new Date("2020-01-15"),
+            endDate: new Date("2020-01-30"),
+            isActive: true,
+            adjustments: [],
+            daysOfWeek: [],
+            exceptions: [],
+            tripShortNames: [],
+          }),
+          revisions: [
+            new DisruptionRevision({
+              id: "1",
+              disruptionId: "1",
+              startDate: new Date("2020-01-15"),
+              endDate: new Date("2020-01-30"),
+              isActive: true,
+              adjustments: [],
+              daysOfWeek: [],
+              exceptions: [],
+              tripShortNames: [],
+            }),
+          ],
+        })
+      )
+    })
+
+    const history = createBrowserHistory()
+    history.push("/disruptions/1?v=draft")
+
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      ReactDOM.render(
+        <BrowserRouter>
+          <ViewDisruption
+            match={{
+              params: { id: "1" },
+              isExact: true,
+              path: "/disruptions/1?v=draft",
+              url: "https://localhost/disruptions/1?v=draft",
+            }}
+            history={history}
+            location={{
+              pathname: "/disruptions/1?v=draft",
+              search: "?v=draft",
               state: {},
               hash: "",
             }}
@@ -200,7 +401,7 @@ describe("ViewDisruption", () => {
       "#edit-disruption-link"
     ) as Element
     expect(editButton).toBeDefined()
-    expect(editButton.textContent).toEqual("edit disruption times")
+    // expect(editButton.textContent).toEqual("edit")
 
     act(() => {
       editButton.dispatchEvent(new MouseEvent("click", { bubbles: true }))
@@ -253,7 +454,7 @@ describe("ViewDisruption", () => {
       return Promise.resolve(
         new Disruption({
           id: "1",
-          readyRevision: new DisruptionRevision({
+          publishedRevision: new DisruptionRevision({
             id: "1",
             disruptionId: "1",
             startDate: new Date("2020-01-15"),
@@ -505,7 +706,7 @@ describe("ViewDisruption", () => {
     })
 
     const { container } = render(
-      <MemoryRouter initialEntries={["/disruptions/1?v=draft"]}>
+      <MemoryRouter initialEntries={["/disruptions/1?v=ready"]}>
         <Switch>
           <Route
             exact={true}
@@ -620,7 +821,7 @@ describe("ViewDisruption", () => {
     })
 
     const { container } = render(
-      <MemoryRouter initialEntries={["/disruptions/1?v=draft"]}>
+      <MemoryRouter initialEntries={["/disruptions/1?v=ready"]}>
         <Switch>
           <Route
             exact={true}
@@ -663,7 +864,7 @@ describe("ViewDisruption", () => {
     expect(screen.getByText("Test error")).not.toBeNull()
   })
 
-  test("can toggle between ready and draft view", async () => {
+  test("can toggle between views", async () => {
     let startDate = new Date()
     startDate.setTime(startDate.getTime() + 24 * 60 * 60 * 1000)
     startDate = new Date(startDate.toDateString())
@@ -676,7 +877,7 @@ describe("ViewDisruption", () => {
       return Promise.resolve(
         new Disruption({
           id: "1",
-          readyRevision: new DisruptionRevision({
+          publishedRevision: new DisruptionRevision({
             id: "1",
             disruptionId: "1",
             startDate,
@@ -693,7 +894,55 @@ describe("ViewDisruption", () => {
             daysOfWeek: [
               new DayOfWeek({
                 id: "1",
+                startTime: "21:45:00",
+                dayName: "friday",
+              }),
+            ],
+            exceptions: [],
+            tripShortNames: [],
+          }),
+          readyRevision: new DisruptionRevision({
+            id: "2",
+            disruptionId: "1",
+            startDate,
+            endDate,
+            isActive: true,
+            adjustments: [
+              new Adjustment({
+                id: "1",
+                routeId: "Green-D",
+                source: "gtfs_creator",
+                sourceLabel: "NewtonHighlandsKenmore",
+              }),
+            ],
+            daysOfWeek: [
+              new DayOfWeek({
+                id: "1",
                 startTime: "20:45:00",
+                dayName: "friday",
+              }),
+            ],
+            exceptions: [],
+            tripShortNames: [],
+          }),
+          draftRevision: new DisruptionRevision({
+            id: "3",
+            disruptionId: "1",
+            startDate,
+            endDate,
+            isActive: true,
+            adjustments: [
+              new Adjustment({
+                id: "1",
+                routeId: "Green-D",
+                source: "gtfs_creator",
+                sourceLabel: "NewtonHighlandsKenmore",
+              }),
+            ],
+            daysOfWeek: [
+              new DayOfWeek({
+                id: "1",
+                startTime: "19:45:00",
                 dayName: "friday",
               }),
             ],
@@ -725,13 +974,37 @@ describe("ViewDisruption", () => {
               exceptions: [],
               tripShortNames: [],
             }),
+            new DisruptionRevision({
+              id: "2",
+              disruptionId: "1",
+              startDate,
+              endDate,
+              isActive: true,
+              adjustments: [
+                new Adjustment({
+                  id: "1",
+                  routeId: "Green-D",
+                  source: "gtfs_creator",
+                  sourceLabel: "NewtonHighlandsKenmore",
+                }),
+              ],
+              daysOfWeek: [
+                new DayOfWeek({
+                  id: "1",
+                  startTime: "21:00:00",
+                  dayName: "friday",
+                }),
+              ],
+              exceptions: [],
+              tripShortNames: [],
+            }),
           ],
         })
       )
     })
 
     const { container } = render(
-      <MemoryRouter initialEntries={["/disruptions/1"]}>
+      <MemoryRouter initialEntries={["/disruptions/1?v=ready"]}>
         <Switch>
           <Route
             exact={true}
@@ -753,12 +1026,15 @@ describe("ViewDisruption", () => {
       defaultResult: "error",
     })
 
+    const publishedButton = container.querySelector("#published")
+    expect(publishedButton?.classList).not.toContain("active")
     const readyButton = container.querySelector("#ready")
     expect(readyButton?.classList).toContain("active")
     const draftButton = container.querySelector("#draft")
     expect(draftButton?.classList).not.toContain("active")
     expect(container.querySelector("#edit-disruption-link")).toBeNull()
     expect(container.querySelector("#delete-disruption-button")).toBeNull()
+    expect(container.textContent).toContain("8:45PM")
 
     if (draftButton) {
       // eslint-disable-next-line @typescript-eslint/require-await
@@ -769,14 +1045,312 @@ describe("ViewDisruption", () => {
       throw new Error("draft button not found")
     }
 
+    expect(publishedButton?.classList).not.toContain("active")
+    expect(readyButton?.classList).not.toContain("active")
+    expect(draftButton?.classList).toContain("active")
+    expect(container.querySelector("#edit-disruption-link")).not.toBeNull()
+    expect(container.querySelector("#delete-disruption-button")).not.toBeNull()
+    expect(container.textContent).toContain("7:45PM")
+
+    if (publishedButton) {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      await act(async () => {
+        fireEvent.click(publishedButton)
+      })
+    } else {
+      throw new Error("draft button not found")
+    }
+
+    expect(publishedButton?.classList).toContain("active")
+    expect(readyButton?.classList).not.toContain("active")
+    expect(draftButton?.classList).not.toContain("active")
+    expect(container.querySelector("#edit-disruption-link")).toBeNull()
+    expect(container.querySelector("#delete-disruption-button")).toBeNull()
+    expect(container.textContent).toContain("9:45PM")
+  })
+
+  test("can mark active draft revision as ready", async () => {
+    const mockHistoryReplace = jest.fn()
+
+    jest.mock("react-router-dom", () => ({
+      useHistory: () => ({
+        replace: mockHistoryReplace,
+      }),
+    }))
+    let startDate = new Date()
+    startDate.setTime(startDate.getTime() + 24 * 60 * 60 * 1000)
+    startDate = new Date(startDate.toDateString())
+
+    let endDate = new Date()
+    startDate.setTime(startDate.getTime() + 2 * 24 * 60 * 60 * 1000)
+    endDate = new Date(endDate.toDateString())
+
+    const spy = jest.spyOn(api, "apiGet").mockImplementation(() => {
+      return Promise.resolve(
+        new Disruption({
+          id: "1",
+          draftRevision: new DisruptionRevision({
+            id: "3",
+            disruptionId: "1",
+            startDate,
+            endDate,
+            isActive: true,
+            adjustments: [
+              new Adjustment({
+                id: "1",
+                routeId: "Green-D",
+                source: "gtfs_creator",
+                sourceLabel: "NewtonHighlandsKenmore",
+              }),
+            ],
+            daysOfWeek: [
+              new DayOfWeek({
+                id: "1",
+                startTime: "19:45:00",
+                dayName: "friday",
+              }),
+            ],
+            exceptions: [],
+            tripShortNames: [],
+          }),
+          revisions: [],
+        })
+      )
+    })
+
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/1?v=draft"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/"
+            component={ViewDisruption}
+          />
+          <Route exact={true} path="/" render={() => <div>Success!!!</div>} />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
     expect(spy).toHaveBeenCalledWith({
       url: "/api/disruptions/1",
       parser: toModelObject,
       defaultResult: "error",
     })
-    expect(readyButton?.classList).not.toContain("active")
-    expect(draftButton?.classList).toContain("active")
-    expect(container.querySelector("#edit-disruption-link")).not.toBeNull()
-    expect(container.querySelector("#delete-disruption-button")).not.toBeNull()
+
+    const apiSendSpy = jest.spyOn(api, "apiSend").mockImplementationOnce(() => {
+      return Promise.resolve({
+        ok: null,
+      })
+    })
+
+    jest.spyOn(window, "confirm").mockImplementationOnce(() => {
+      return true
+    })
+
+    const readyButton = container.querySelector("#mark-ready")
+    if (!readyButton) {
+      throw new Error("mark as ready button not found")
+    }
+    expect(readyButton.textContent).toEqual("mark as ready")
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      fireEvent.click(readyButton)
+    })
+    expect(apiSendSpy).toBeCalledWith({
+      url: "/api/ready_notice/",
+      method: "POST",
+      json: JSON.stringify({ revision_ids: "3" }),
+    })
+    expect(spy).toBeCalledTimes(2)
+  })
+
+  test("can mark deleted draft revision as ready", async () => {
+    let startDate = new Date()
+    startDate.setTime(startDate.getTime() + 24 * 60 * 60 * 1000)
+    startDate = new Date(startDate.toDateString())
+
+    let endDate = new Date()
+    startDate.setTime(startDate.getTime() + 2 * 24 * 60 * 60 * 1000)
+    endDate = new Date(endDate.toDateString())
+
+    const spy = jest.spyOn(api, "apiGet").mockImplementation(() => {
+      return Promise.resolve(
+        new Disruption({
+          id: "1",
+          draftRevision: new DisruptionRevision({
+            id: "3",
+            disruptionId: "1",
+            startDate,
+            endDate,
+            isActive: false,
+            adjustments: [
+              new Adjustment({
+                id: "1",
+                routeId: "Green-D",
+                source: "gtfs_creator",
+                sourceLabel: "NewtonHighlandsKenmore",
+              }),
+            ],
+            daysOfWeek: [
+              new DayOfWeek({
+                id: "1",
+                startTime: "19:45:00",
+                dayName: "friday",
+              }),
+            ],
+            exceptions: [],
+            tripShortNames: [],
+          }),
+          revisions: [],
+        })
+      )
+    })
+
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/1?v=draft"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/"
+            component={ViewDisruption}
+          />
+          <Route exact={true} path="/" render={() => <div>Success!!!</div>} />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    expect(spy).toHaveBeenCalledWith({
+      url: "/api/disruptions/1",
+      parser: toModelObject,
+      defaultResult: "error",
+    })
+
+    const apiSendSpy = jest.spyOn(api, "apiSend").mockImplementationOnce(() => {
+      return Promise.resolve({
+        ok: null,
+      })
+    })
+
+    jest.spyOn(window, "confirm").mockImplementationOnce(() => {
+      return true
+    })
+
+    const readyButton = container.querySelector("#mark-ready")
+    if (!readyButton) {
+      throw new Error("mark as ready button not found")
+    }
+    expect(readyButton.textContent).toEqual("mark as ready for deletion")
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      fireEvent.click(readyButton)
+    })
+    expect(apiSendSpy).toBeCalledWith({
+      url: "/api/ready_notice/",
+      method: "POST",
+      json: JSON.stringify({ revision_ids: "3" }),
+    })
+
+    expect(spy).toBeCalledTimes(2)
+  })
+
+  test("handles error marking draft revision as ready", async () => {
+    let startDate = new Date()
+    startDate.setTime(startDate.getTime() + 24 * 60 * 60 * 1000)
+    startDate = new Date(startDate.toDateString())
+
+    let endDate = new Date()
+    startDate.setTime(startDate.getTime() + 2 * 24 * 60 * 60 * 1000)
+    endDate = new Date(endDate.toDateString())
+
+    const spy = jest.spyOn(api, "apiGet").mockImplementation(() => {
+      return Promise.resolve(
+        new Disruption({
+          id: "1",
+          draftRevision: new DisruptionRevision({
+            id: "3",
+            disruptionId: "1",
+            startDate,
+            endDate,
+            isActive: false,
+            adjustments: [
+              new Adjustment({
+                id: "1",
+                routeId: "Green-D",
+                source: "gtfs_creator",
+                sourceLabel: "NewtonHighlandsKenmore",
+              }),
+            ],
+            daysOfWeek: [
+              new DayOfWeek({
+                id: "1",
+                startTime: "19:45:00",
+                dayName: "friday",
+              }),
+            ],
+            exceptions: [],
+            tripShortNames: [],
+          }),
+          revisions: [],
+        })
+      )
+    })
+
+    const { container } = render(
+      <MemoryRouter initialEntries={["/disruptions/1?v=draft"]}>
+        <Switch>
+          <Route
+            exact={true}
+            path="/disruptions/:id/"
+            component={ViewDisruption}
+          />
+          <Route exact={true} path="/" render={() => <div>Success!!!</div>} />
+        </Switch>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(
+      document.querySelector("#loading-indicator")
+    )
+
+    expect(spy).toHaveBeenCalledWith({
+      url: "/api/disruptions/1",
+      parser: toModelObject,
+      defaultResult: "error",
+    })
+
+    const apiSendSpy = jest.spyOn(api, "apiSend").mockImplementationOnce(() => {
+      return Promise.reject()
+    })
+
+    jest.spyOn(window, "confirm").mockImplementationOnce(() => {
+      return true
+    })
+
+    const readyButton = container.querySelector("#mark-ready")
+    if (!readyButton) {
+      throw new Error("mark as ready button not found")
+    }
+    expect(readyButton.textContent).toEqual("mark as ready for deletion")
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      fireEvent.click(readyButton)
+    })
+    expect(apiSendSpy).toBeCalledWith({
+      url: "/api/ready_notice/",
+      method: "POST",
+      json: JSON.stringify({ revision_ids: "3" }),
+    })
+    expect(spy).toBeCalledTimes(1)
   })
 })

--- a/assets/tests/disruptions/viewDisruption.test.tsx
+++ b/assets/tests/disruptions/viewDisruption.test.tsx
@@ -1058,7 +1058,7 @@ describe("ViewDisruption", () => {
         fireEvent.click(publishedButton)
       })
     } else {
-      throw new Error("draft button not found")
+      throw new Error("published button not found")
     }
 
     expect(publishedButton?.classList).toContain("active")

--- a/assets/tests/disruptions/viewDisruption.test.tsx
+++ b/assets/tests/disruptions/viewDisruption.test.tsx
@@ -1033,7 +1033,7 @@ describe("ViewDisruption", () => {
     const draftButton = container.querySelector("#draft")
     expect(draftButton?.classList).not.toContain("active")
     expect(container.querySelector("#edit-disruption-link")).toBeNull()
-    expect(container.querySelector("#delete-disruption-button")).toBeNull()
+    expect(container.querySelector("#delete-disruption-button")).not.toBeNull()
     expect(container.textContent).toContain("8:45PM")
 
     if (draftButton) {
@@ -1065,7 +1065,7 @@ describe("ViewDisruption", () => {
     expect(readyButton?.classList).not.toContain("active")
     expect(draftButton?.classList).not.toContain("active")
     expect(container.querySelector("#edit-disruption-link")).toBeNull()
-    expect(container.querySelector("#delete-disruption-button")).toBeNull()
+    expect(container.querySelector("#delete-disruption-button")).not.toBeNull()
     expect(container.textContent).toContain("9:45PM")
   })
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Detail page updates](https://app.asana.com/0/584764604969369/1195117716558252/f)

Changes: mostly cosmetic changes and a few new features and changes to logic:
* added `draftRevision` as an optional attribute, set while parsing in `fromJsonObject` (like `draftRevision` and `readyRevision`
* added `getUniqueRevisions` function that returns `{published: DisruptionRevision | null, ready: ...}`, to make it more convenient to do the "rolling up" of revisions
* added `uniqueRevisionFromDisruptionForView` function, which takes unique revisions and returns one matching the supplied view
* added a button to "mark as ready" from details page
* added proper view params `?v=draft | ready | published` on homepage links and redirects from create/edit pages

![details](https://user-images.githubusercontent.com/18427346/94733388-addca280-0335-11eb-9ac5-5d368ccdf1e9.gif)


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
