### PR TITLE
feat: custom confirmation modal

### DIFF
--- a/assets/src/confirmationModal.tsx
+++ b/assets/src/confirmationModal.tsx
@@ -1,0 +1,61 @@
+import React from "react"
+import Modal from "react-bootstrap/Modal"
+import { PrimaryButton, SecondaryButton } from "./button"
+
+interface ConfirmationModalProps {
+  onClickConfirm: () => void
+  confirmationText: string
+  confirmationButtonText: string
+  buttonIdentifier?: string
+  Component: JSX.Element
+}
+
+const ConfirmationModal = ({
+  confirmationText,
+  confirmationButtonText,
+  buttonIdentifier,
+  onClickConfirm,
+  Component,
+}: ConfirmationModalProps) => {
+  const [modalOpen, setModalOpen] = React.useState(false)
+  return (
+    <>
+      <Modal show={modalOpen} className="m-confirmation-modal">
+        <Modal.Body>
+          <div className="my-3">
+            <strong>Are you sure?</strong>
+          </div>
+          <div>{confirmationText}</div>
+          <div className="d-flex my-3 w-100">
+            <div className="w-50 mr-3">
+              <SecondaryButton
+                id={buttonIdentifier ? `${buttonIdentifier}-cancel` : "cancel"}
+                className="w-100"
+                onClick={() => setModalOpen(false)}
+              >
+                cancel
+              </SecondaryButton>
+            </div>
+            <div className="w-50 ml-3">
+              <PrimaryButton
+                id={
+                  buttonIdentifier ? `${buttonIdentifier}-confirm` : "confirm"
+                }
+                className="w-100"
+                onClick={() => {
+                  onClickConfirm()
+                  setModalOpen(false)
+                }}
+              >
+                {confirmationButtonText}
+              </PrimaryButton>
+            </div>
+          </div>
+        </Modal.Body>
+      </Modal>
+      {React.cloneElement(Component, { onClick: () => setModalOpen(true) })}
+    </>
+  )
+}
+
+export { ConfirmationModal }

--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -14,6 +14,7 @@ import { JsonApiResponse, toModelObject } from "../jsonApi"
 import { Page } from "../page"
 import Disruption, { DisruptionView } from "../models/disruption"
 import Checkbox from "../checkbox"
+import { ConfirmationModal } from "../confirmationModal"
 
 type Routes =
   | "Red"
@@ -316,25 +317,21 @@ const DisruptionIndexView = ({
   }, [selectedFilteredRevisions])
 
   const markReady = React.useCallback(() => {
-    if (
-      window.confirm("Are you sure you want to mark these revisions as ready?")
-    ) {
-      const revisionIds = selectedFilteredRevisions.map((x) => x.id).join()
-      apiSend({
-        method: "POST",
-        json: JSON.stringify({
-          revision_ids: revisionIds,
-        }),
-        url: "/api/ready_notice/",
+    const revisionIds = selectedFilteredRevisions.map((x) => x.id).join()
+    apiSend({
+      method: "POST",
+      json: JSON.stringify({
+        revision_ids: revisionIds,
+      }),
+      url: "/api/ready_notice/",
+    })
+      .then(() => {
+        fetchDisruptions()
       })
-        .then(() => {
-          fetchDisruptions()
-        })
-        .catch(() => {
-          // eslint-disable-next-line no-console
-          console.log(`failed to mark revisions as ready: ${revisionIds}`)
-        })
-    }
+      .catch(() => {
+        // eslint-disable-next-line no-console
+        console.log(`failed to mark revisions as ready: ${revisionIds}`)
+      })
   }, [selectedFilteredRevisions, fetchDisruptions])
 
   const toggleRevisionSelection = React.useCallback(
@@ -480,13 +477,19 @@ const DisruptionIndexView = ({
                 <strong className="mx-3">select</strong>
               </div>
               <div className="d-flex">
-                <SecondaryButton
-                  id="mark-ready"
-                  onClick={markReady}
-                  disabled={!availableActions.includes("mark_ready")}
-                >
-                  mark as ready
-                </SecondaryButton>
+                <ConfirmationModal
+                  confirmationButtonText="yes, mark as ready"
+                  confirmationText="Are you sure you want to mark these revisions as ready?"
+                  onClickConfirm={markReady}
+                  Component={
+                    <SecondaryButton
+                      id="mark-ready"
+                      disabled={!availableActions.includes("mark_ready")}
+                    >
+                      mark as ready
+                    </SecondaryButton>
+                  }
+                />
               </div>
             </div>
           </Col>

--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -183,7 +183,7 @@ const anyMatchesFilter = (
         (adj) =>
           adj.sourceLabel && adj.sourceLabel.toLowerCase().includes(query)
       ) &&
-      (revision.isActive || revision.status !== DisruptionView.Published)
+      revision.isActive
     )
   })
 }
@@ -268,16 +268,10 @@ const DisruptionIndexView = ({
   const filteredDisruptionRevisions = React.useMemo(() => {
     const query = searchQuery.toLowerCase()
     return disruptions.reduce((acc, curr) => {
-      const uniqueRevisions = [
-        Disruption.revisionFromDisruptionForView(
-          curr,
-          DisruptionView.Published
-        ),
-        Disruption.revisionFromDisruptionForView(curr, DisruptionView.Ready),
-        Disruption.revisionFromDisruptionForView(curr, DisruptionView.Draft),
-      ].filter((x, i, self) => {
-        return !!x && self.findIndex((y) => y?.id === x.id) === i
-      }) as DisruptionRevision[]
+      const { published, ready, draft } = curr.getUniqueRevisions()
+      const uniqueRevisions = [published, ready, draft].filter(
+        (x) => !!x
+      ) as DisruptionRevision[]
 
       if (
         anyMatchesFilter(uniqueRevisions, query, routeFilters, statusFilters)

--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -3,8 +3,8 @@ import { BrowserRouter } from "react-router-dom"
 import {
   render,
   fireEvent,
-  screen,
   queryByAttribute,
+  queryByText,
 } from "@testing-library/react"
 
 import {
@@ -28,10 +28,12 @@ import { DisruptionView } from "../../src/models/disruption"
 
 const DisruptionIndexWithRouter = ({
   connected = false,
-  fetchDisruptions = jest.fn(),
+  fetchDisruption = jest.fn(),
+  disruptions,
 }: {
   connected?: boolean
-  fetchDisruptions?: () => void
+  fetchDisruption?: () => void
+  disruptions?: Disruption[]
 }) => {
   return (
     <BrowserRouter>
@@ -39,44 +41,11 @@ const DisruptionIndexWithRouter = ({
         <DisruptionIndex />
       ) : (
         <DisruptionIndexView
-          fetchDisruptions={fetchDisruptions}
-          disruptions={[
-            new Disruption({
-              publishedRevision: new DisruptionRevision({
-                id: "1",
-                disruptionId: "1",
-                startDate: new Date("2019-10-31"),
-                endDate: new Date("2019-11-15"),
-                isActive: true,
-                adjustments: [
-                  new Adjustment({
-                    id: "1",
-                    routeId: "Red",
-                    sourceLabel: "AlewifeHarvard",
-                  }),
-                ],
-                daysOfWeek: [
-                  new DayOfWeek({
-                    id: "1",
-                    startTime: "20:45:00",
-                    dayName: "friday",
-                  }),
-                  new DayOfWeek({
-                    id: "2",
-                    dayName: "saturday",
-                  }),
-                  new DayOfWeek({
-                    id: "3",
-                    dayName: "sunday",
-                  }),
-                ],
-                exceptions: [],
-                tripShortNames: [],
-                status: DisruptionView.Published,
-              }),
-
-              revisions: [
-                new DisruptionRevision({
+          fetchDisruptions={fetchDisruption}
+          disruptions={
+            disruptions || [
+              new Disruption({
+                publishedRevision: new DisruptionRevision({
                   id: "1",
                   disruptionId: "1",
                   startDate: new Date("2019-10-31"),
@@ -108,43 +77,45 @@ const DisruptionIndexWithRouter = ({
                   tripShortNames: [],
                   status: DisruptionView.Published,
                 }),
-              ],
-            }),
-            new Disruption({
-              id: "3",
-              readyRevision: new DisruptionRevision({
-                id: "3",
-                disruptionId: "3",
-                startDate: new Date("2019-09-22"),
-                endDate: new Date("2019-10-22"),
-                isActive: true,
-                adjustments: [
-                  new Adjustment({
-                    id: "2",
-                    routeId: "Green-D",
-                    sourceLabel: "Kenmore-Newton Highlands",
-                  }),
-                ],
-                daysOfWeek: [
-                  new DayOfWeek({
+
+                revisions: [
+                  new DisruptionRevision({
                     id: "1",
-                    startTime: "20:45:00",
-                    dayName: "friday",
-                  }),
-                  new DayOfWeek({
-                    id: "2",
-                    dayName: "saturday",
-                  }),
-                  new DayOfWeek({
-                    id: "3",
-                    dayName: "sunday",
+                    disruptionId: "1",
+                    startDate: new Date("2019-10-31"),
+                    endDate: new Date("2019-11-15"),
+                    isActive: true,
+                    adjustments: [
+                      new Adjustment({
+                        id: "1",
+                        routeId: "Red",
+                        sourceLabel: "AlewifeHarvard",
+                      }),
+                    ],
+                    daysOfWeek: [
+                      new DayOfWeek({
+                        id: "1",
+                        startTime: "20:45:00",
+                        dayName: "friday",
+                      }),
+                      new DayOfWeek({
+                        id: "2",
+                        dayName: "saturday",
+                      }),
+                      new DayOfWeek({
+                        id: "3",
+                        dayName: "sunday",
+                      }),
+                    ],
+                    exceptions: [],
+                    tripShortNames: [],
+                    status: DisruptionView.Published,
                   }),
                 ],
-                exceptions: [],
-                tripShortNames: [],
               }),
-              revisions: [
-                new DisruptionRevision({
+              new Disruption({
+                id: "3",
+                readyRevision: new DisruptionRevision({
                   id: "3",
                   disruptionId: "3",
                   startDate: new Date("2019-09-22"),
@@ -175,9 +146,42 @@ const DisruptionIndexWithRouter = ({
                   exceptions: [],
                   tripShortNames: [],
                 }),
-              ],
-            }),
-          ]}
+                revisions: [
+                  new DisruptionRevision({
+                    id: "3",
+                    disruptionId: "3",
+                    startDate: new Date("2019-09-22"),
+                    endDate: new Date("2019-10-22"),
+                    isActive: true,
+                    adjustments: [
+                      new Adjustment({
+                        id: "2",
+                        routeId: "Green-D",
+                        sourceLabel: "Kenmore-Newton Highlands",
+                      }),
+                    ],
+                    daysOfWeek: [
+                      new DayOfWeek({
+                        id: "1",
+                        startTime: "20:45:00",
+                        dayName: "friday",
+                      }),
+                      new DayOfWeek({
+                        id: "2",
+                        dayName: "saturday",
+                      }),
+                      new DayOfWeek({
+                        id: "3",
+                        dayName: "sunday",
+                      }),
+                    ],
+                    exceptions: [],
+                    tripShortNames: [],
+                  }),
+                ],
+              }),
+            ]
+          }
         />
       )}
     </BrowserRouter>
@@ -315,9 +319,89 @@ describe("DisruptionIndexView", () => {
     )
   })
 
-  test("can toggle between table and calendar view", () => {
-    const { container } = render(<DisruptionIndexWithRouter />)
-    expect(screen.queryByText("time period")).not.toBeNull()
+  test("can toggle between table and calendar view", async () => {
+    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
+      return Promise.resolve([
+        new Disruption({
+          id: "1",
+          draftRevision: new DisruptionRevision({
+            id: "1",
+            disruptionId: "1",
+            startDate: new Date("2019-10-31"),
+            endDate: new Date("2019-11-15"),
+            isActive: true,
+            adjustments: [
+              new Adjustment({
+                id: "1",
+                routeId: "Red",
+                sourceLabel: "AlewifeHarvard",
+              }),
+            ],
+            daysOfWeek: [
+              new DayOfWeek({
+                id: "1",
+                startTime: "20:45:00",
+                dayName: "friday",
+              }),
+              new DayOfWeek({
+                id: "2",
+                dayName: "saturday",
+              }),
+              new DayOfWeek({
+                id: "3",
+                dayName: "sunday",
+              }),
+            ],
+            exceptions: [],
+            tripShortNames: [],
+            status: DisruptionView.Draft,
+          }),
+          revisions: [
+            new DisruptionRevision({
+              id: "1",
+              disruptionId: "1",
+              startDate: new Date("2019-10-31"),
+              endDate: new Date("2019-11-15"),
+              isActive: true,
+              adjustments: [
+                new Adjustment({
+                  id: "1",
+                  routeId: "Red",
+                  sourceLabel: "AlewifeHarvard",
+                }),
+              ],
+              daysOfWeek: [
+                new DayOfWeek({
+                  id: "1",
+                  startTime: "20:45:00",
+                  dayName: "friday",
+                }),
+                new DayOfWeek({
+                  id: "2",
+                  dayName: "saturday",
+                }),
+                new DayOfWeek({
+                  id: "3",
+                  dayName: "sunday",
+                }),
+              ],
+              exceptions: [],
+              tripShortNames: [],
+              status: DisruptionView.Draft,
+            }),
+          ],
+        }),
+      ])
+    })
+    // eslint-disable-next-line @typescript-eslint/require-await
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      ReactDOM.render(<DisruptionIndexWithRouter connected />, container)
+    })
+    expect(queryByText(container, "time period")).not.toBeNull()
     expect(queryByAttribute("id", container, "calendar")).toBeNull()
 
     const toggleButton = container.querySelector("#view-toggle")
@@ -327,14 +411,20 @@ describe("DisruptionIndexView", () => {
     expect(toggleButton.textContent).toEqual("⬒ calendar view")
 
     fireEvent.click(toggleButton)
-    expect(screen.queryByText("time period")).toBeNull()
+    expect(queryByText(container, "time period")).toBeNull()
     expect(queryByAttribute("id", container, "calendar")).not.toBeNull()
     expect(toggleButton.textContent).toEqual("⬒ list view")
+    expect(
+      container.querySelector("#actions")?.hasAttribute("disabled")
+    ).toEqual(true)
 
     fireEvent.click(toggleButton)
-    expect(screen.queryByText("time period")).not.toBeNull()
+    expect(queryByText(container, "time period")).not.toBeNull()
     expect(queryByAttribute("id", container, "calendar")).toBeNull()
     expect(toggleButton.textContent).toEqual("⬒ calendar view")
+    expect(
+      container.querySelector("#actions")?.hasAttribute("disabled")
+    ).toEqual(false)
   })
 })
 
@@ -602,6 +692,238 @@ describe("DisruptionIndexConnected", () => {
     })
   })
 
+  test("can mark multiple revisions as ready", async () => {
+    const disruptions = [
+      new Disruption({
+        id: "1",
+        publishedRevision: new DisruptionRevision({
+          id: "1",
+          disruptionId: "1",
+          startDate: new Date("2020-01-15"),
+          endDate: new Date("2020-01-30"),
+          isActive: false,
+          adjustments: [
+            new Adjustment({
+              id: "1",
+              routeId: "Green-D",
+              source: "gtfs_creator",
+              sourceLabel: "NewtonHighlandsKenmore",
+            }),
+          ],
+          daysOfWeek: [],
+          exceptions: [],
+          tripShortNames: [],
+          status: DisruptionView.Published,
+        }),
+        revisions: [
+          new DisruptionRevision({
+            id: "1",
+            disruptionId: "1",
+            startDate: new Date("2020-01-15"),
+            endDate: new Date("2020-01-30"),
+            isActive: false,
+            adjustments: [
+              new Adjustment({
+                id: "1",
+                routeId: "Green-D",
+                source: "gtfs_creator",
+                sourceLabel: "NewtonHighlandsKenmore",
+              }),
+            ],
+            daysOfWeek: [],
+            exceptions: [],
+            tripShortNames: [],
+          }),
+        ],
+      }),
+      new Disruption({
+        id: "2",
+        readyRevision: new DisruptionRevision({
+          id: "2",
+          disruptionId: "2",
+          startDate: new Date("2020-01-20"),
+          endDate: new Date("2020-01-25"),
+          isActive: false,
+          adjustments: [
+            new Adjustment({
+              id: "1",
+              routeId: "Red",
+              source: "gtfs_creator",
+              sourceLabel: "AlewifeHarvard",
+            }),
+          ],
+          daysOfWeek: [],
+          exceptions: [],
+          tripShortNames: [],
+          status: DisruptionView.Published,
+        }),
+        draftRevision: new DisruptionRevision({
+          id: "3",
+          disruptionId: "2",
+          startDate: new Date("2020-01-20"),
+          endDate: new Date("2020-01-28"),
+          isActive: true,
+          adjustments: [
+            new Adjustment({
+              id: "1",
+              routeId: "Red",
+              source: "gtfs_creator",
+              sourceLabel: "AlewifeHarvard",
+            }),
+          ],
+          daysOfWeek: [],
+          exceptions: [],
+          tripShortNames: [],
+        }),
+        revisions: [],
+      }),
+      new Disruption({
+        id: "3",
+        readyRevision: new DisruptionRevision({
+          id: "4",
+          disruptionId: "3",
+          startDate: new Date("2020-02-20"),
+          endDate: new Date("2020-02-25"),
+          isActive: false,
+          adjustments: [
+            new Adjustment({
+              id: "1",
+              routeId: "Orange",
+              source: "gtfs_creator",
+              sourceLabel: "Wellington",
+            }),
+          ],
+          daysOfWeek: [],
+          exceptions: [],
+          tripShortNames: [],
+          status: DisruptionView.Ready,
+        }),
+        draftRevision: new DisruptionRevision({
+          id: "5",
+          disruptionId: "3",
+          startDate: new Date("2020-02-21"),
+          endDate: new Date("2020-02-225"),
+          isActive: true,
+          adjustments: [
+            new Adjustment({
+              id: "1",
+              routeId: "Orange",
+              source: "gtfs_creator",
+              sourceLabel: "Wellington",
+            }),
+          ],
+          daysOfWeek: [],
+          exceptions: [],
+          tripShortNames: [],
+        }),
+        revisions: [],
+      }),
+    ]
+    const getSpy = jest.fn()
+    const sendSpy = jest.spyOn(api, "apiSend").mockImplementation(() => {
+      return Promise.resolve({
+        ok: {},
+      })
+    })
+    const { container, findByText } = render(
+      <DisruptionIndexWithRouter
+        disruptions={disruptions}
+        fetchDisruption={getSpy}
+      />
+    )
+    const actionsButton = container.querySelector("#actions")
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    fireEvent.click(actionsButton!)
+    let checkboxes: NodeListOf<HTMLInputElement> = container.querySelectorAll(
+      "tr input[type=checkbox]"
+    )
+    expect(checkboxes.length).toEqual(2)
+    checkboxes.forEach((x: HTMLInputElement) => {
+      expect(x.checked).toEqual(false)
+    })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    fireEvent.click(container.querySelector('tr[data-revision-id="5"] input')!)
+    expect(
+      (container.querySelector(
+        'tr[data-revision-id="5"] input[type=checkbox]'
+      ) as HTMLInputElement).checked
+    ).toEqual(true)
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    fireEvent.click(container.querySelector("#toggle-all")!)
+    checkboxes.forEach((x: HTMLInputElement) => {
+      expect(x.checked).toEqual(false)
+    })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    fireEvent.click(container.querySelector("#toggle-all")!)
+    expect(container.querySelectorAll("tr input:checked").length).toEqual(2)
+    checkboxes.forEach((x: HTMLInputElement) => {
+      expect(x.checked).toEqual(true)
+    })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    fireEvent.click(container.querySelector("#actions")!)
+    expect(container.querySelectorAll("tr input").length).toEqual(0)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    fireEvent.click(container.querySelector("#actions")!)
+    checkboxes = container.querySelectorAll("tr input")
+    expect(checkboxes.length).toEqual(2)
+    checkboxes.forEach((x: HTMLInputElement) => {
+      expect(x.checked).toEqual(false)
+    })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    fireEvent.click(container.querySelector("#toggle-all")!)
+    expect(container.querySelectorAll("tr input:checked").length).toEqual(2)
+    checkboxes.forEach((x: HTMLInputElement) => {
+      expect(x.checked).toEqual(true)
+    })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    fireEvent.click(container.querySelector("#route-filter-toggle-Orange")!)
+    expect(container.querySelectorAll("tr input:checked").length).toEqual(1)
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      fireEvent.click(container.querySelector("#mark-ready")!)
+    })
+    let confirmButton = await findByText("yes, mark as ready")
+    if (confirmButton) {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      await act(async () => {
+        fireEvent.click(confirmButton)
+      })
+    } else {
+      throw new Error("confirm button not found")
+    }
+    expect(sendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/api/ready_notice/",
+        json: JSON.stringify({ revision_ids: "5" }),
+        method: "POST",
+      })
+    )
+
+    expect(getSpy).toHaveBeenCalledTimes(1)
+    sendSpy.mockClear()
+    const sendSpyFail = jest.spyOn(api, "apiSend").mockImplementation(() => {
+      return Promise.reject()
+    })
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      fireEvent.click(container.querySelector("#mark-ready")!)
+    })
+    confirmButton = await findByText("yes, mark as ready")
+    if (confirmButton) {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      await act(async () => {
+        fireEvent.click(confirmButton)
+      })
+    } else {
+      throw new Error("confirm button not found")
+    }
+    expect(sendSpyFail).toBeCalledTimes(1)
+    expect(getSpy).toHaveBeenCalledTimes(1)
+  })
+
   test("doesn't render deleted published disruption", async () => {
     jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
       return Promise.resolve([
@@ -658,104 +980,6 @@ describe("DisruptionIndexConnected", () => {
     })
     const rows = container.querySelectorAll("tbody tr")
     expect(rows.length).toEqual(0)
-  })
-
-  test("renders deleted ready disruption", async () => {
-    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
-      return Promise.resolve([
-        new Disruption({
-          id: "1",
-          publishedRevision: new DisruptionRevision({
-            id: "2",
-            disruptionId: "1",
-            startDate: new Date("2020-01-15"),
-            endDate: new Date("2020-01-30"),
-            isActive: false,
-            adjustments: [
-              new Adjustment({
-                id: "1",
-                routeId: "Green-D",
-                source: "gtfs_creator",
-                sourceLabel: "NewtonHighlandsKenmore",
-              }),
-            ],
-            daysOfWeek: [],
-            exceptions: [],
-            tripShortNames: [],
-          }),
-          revisions: [
-            new DisruptionRevision({
-              id: "2",
-              disruptionId: "1",
-              startDate: new Date("2020-01-15"),
-              endDate: new Date("2020-01-30"),
-              isActive: false,
-              adjustments: [
-                new Adjustment({
-                  id: "1",
-                  routeId: "Green-D",
-                  source: "gtfs_creator",
-                  sourceLabel: "NewtonHighlandsKenmore",
-                }),
-              ],
-              daysOfWeek: [],
-              exceptions: [],
-              tripShortNames: [],
-            }),
-          ],
-        }),
-      ])
-    })
-
-    const container = document.createElement("div")
-    document.body.appendChild(container)
-
-    // eslint-disable-next-line @typescript-eslint/require-await
-    await act(async () => {
-      ReactDOM.render(<DisruptionIndexWithRouter connected />, container)
-    })
-    const rows = container.querySelectorAll("tbody tr")
-    expect(rows.length).toEqual(1)
-  })
-
-  test("renders deleted draft disruption", async () => {
-    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
-      return Promise.resolve([
-        new Disruption({
-          id: "1",
-          revisions: [
-            new DisruptionRevision({
-              id: "2",
-              disruptionId: "1",
-              startDate: new Date("2020-01-15"),
-              endDate: new Date("2020-01-30"),
-              isActive: false,
-              adjustments: [
-                new Adjustment({
-                  id: "1",
-                  routeId: "Green-D",
-                  source: "gtfs_creator",
-                  sourceLabel: "NewtonHighlandsKenmore",
-                }),
-              ],
-              daysOfWeek: [],
-              exceptions: [],
-              tripShortNames: [],
-            }),
-          ],
-        }),
-      ])
-    })
-
-    const container = document.createElement("div")
-    document.body.appendChild(container)
-
-    // eslint-disable-next-line @typescript-eslint/require-await
-    await act(async () => {
-      ReactDOM.render(<DisruptionIndexWithRouter connected />, container)
-    })
-    const rows = container.querySelectorAll("tbody tr")
-    expect(rows.length).toEqual(1)
   })
 
   test("renders error", async () => {

--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -3,8 +3,8 @@ import { BrowserRouter } from "react-router-dom"
 import {
   render,
   fireEvent,
+  screen,
   queryByAttribute,
-  queryByText,
 } from "@testing-library/react"
 
 import {
@@ -28,8 +28,10 @@ import { DisruptionView } from "../../src/models/disruption"
 
 const DisruptionIndexWithRouter = ({
   connected = false,
+  fetchDisruptions = jest.fn(),
 }: {
   connected?: boolean
+  fetchDisruptions?: () => void
 }) => {
   return (
     <BrowserRouter>
@@ -37,7 +39,7 @@ const DisruptionIndexWithRouter = ({
         <DisruptionIndex />
       ) : (
         <DisruptionIndexView
-          fetchDisruptions={() => true}
+          fetchDisruptions={fetchDisruptions}
           disruptions={[
             new Disruption({
               publishedRevision: new DisruptionRevision({
@@ -313,57 +315,9 @@ describe("DisruptionIndexView", () => {
     )
   })
 
-  test("can toggle between table and calendar view", async () => {
-    jest.spyOn(api, "apiGet").mockImplementationOnce(() => {
-      return Promise.resolve([
-        new Disruption({
-          id: "1",
-          revisions: [
-            new DisruptionRevision({
-              id: "1",
-              disruptionId: "1",
-              startDate: new Date("2019-10-31"),
-              endDate: new Date("2019-11-15"),
-              isActive: true,
-              adjustments: [
-                new Adjustment({
-                  id: "1",
-                  routeId: "Red",
-                  sourceLabel: "AlewifeHarvard",
-                }),
-              ],
-              daysOfWeek: [
-                new DayOfWeek({
-                  id: "1",
-                  startTime: "20:45:00",
-                  dayName: "friday",
-                }),
-                new DayOfWeek({
-                  id: "2",
-                  dayName: "saturday",
-                }),
-                new DayOfWeek({
-                  id: "3",
-                  dayName: "sunday",
-                }),
-              ],
-              exceptions: [],
-              tripShortNames: [],
-              status: DisruptionView.Draft,
-            }),
-          ],
-        }),
-      ])
-    })
-    // eslint-disable-next-line @typescript-eslint/require-await
-    const container = document.createElement("div")
-    document.body.appendChild(container)
-
-    // eslint-disable-next-line @typescript-eslint/require-await
-    await act(async () => {
-      ReactDOM.render(<DisruptionIndexWithRouter connected />, container)
-    })
-    expect(queryByText(container, "time period")).not.toBeNull()
+  test("can toggle between table and calendar view", () => {
+    const { container } = render(<DisruptionIndexWithRouter />)
+    expect(screen.queryByText("time period")).not.toBeNull()
     expect(queryByAttribute("id", container, "calendar")).toBeNull()
 
     const toggleButton = container.querySelector("#view-toggle")
@@ -373,20 +327,14 @@ describe("DisruptionIndexView", () => {
     expect(toggleButton.textContent).toEqual("⬒ calendar view")
 
     fireEvent.click(toggleButton)
-    expect(queryByText(container, "time period")).toBeNull()
+    expect(screen.queryByText("time period")).toBeNull()
     expect(queryByAttribute("id", container, "calendar")).not.toBeNull()
     expect(toggleButton.textContent).toEqual("⬒ list view")
-    expect(
-      container.querySelector("#actions")?.hasAttribute("disabled")
-    ).toEqual(true)
 
     fireEvent.click(toggleButton)
-    expect(queryByText(container, "time period")).not.toBeNull()
+    expect(screen.queryByText("time period")).not.toBeNull()
     expect(queryByAttribute("id", container, "calendar")).toBeNull()
     expect(toggleButton.textContent).toEqual("⬒ calendar view")
-    expect(
-      container.querySelector("#actions")?.hasAttribute("disabled")
-    ).toEqual(false)
   })
 })
 
@@ -652,226 +600,6 @@ describe("DisruptionIndexConnected", () => {
       expect(dataColumns[0].textContent).toEqual(expected[index][0])
       expect(dataColumns[1].textContent).toEqual(expected[index][1])
     })
-  })
-
-  test("can mark multiple revisions as ready", async () => {
-    window.confirm = jest.fn(() => true)
-    const disruptions = [
-      new Disruption({
-        id: "1",
-        publishedRevision: new DisruptionRevision({
-          id: "1",
-          disruptionId: "1",
-          startDate: new Date("2020-01-15"),
-          endDate: new Date("2020-01-30"),
-          isActive: false,
-          adjustments: [
-            new Adjustment({
-              id: "1",
-              routeId: "Green-D",
-              source: "gtfs_creator",
-              sourceLabel: "NewtonHighlandsKenmore",
-            }),
-          ],
-          daysOfWeek: [],
-          exceptions: [],
-          tripShortNames: [],
-          status: DisruptionView.Published,
-        }),
-        revisions: [
-          new DisruptionRevision({
-            id: "1",
-            disruptionId: "1",
-            startDate: new Date("2020-01-15"),
-            endDate: new Date("2020-01-30"),
-            isActive: false,
-            adjustments: [
-              new Adjustment({
-                id: "1",
-                routeId: "Green-D",
-                source: "gtfs_creator",
-                sourceLabel: "NewtonHighlandsKenmore",
-              }),
-            ],
-            daysOfWeek: [],
-            exceptions: [],
-            tripShortNames: [],
-          }),
-        ],
-      }),
-      new Disruption({
-        id: "2",
-        readyRevision: new DisruptionRevision({
-          id: "2",
-          disruptionId: "2",
-          startDate: new Date("2020-01-20"),
-          endDate: new Date("2020-01-25"),
-          isActive: false,
-          adjustments: [
-            new Adjustment({
-              id: "1",
-              routeId: "Red",
-              source: "gtfs_creator",
-              sourceLabel: "AlewifeHarvard",
-            }),
-          ],
-          daysOfWeek: [],
-          exceptions: [],
-          tripShortNames: [],
-          status: DisruptionView.Published,
-        }),
-        revisions: [
-          new DisruptionRevision({
-            id: "3",
-            disruptionId: "2",
-            startDate: new Date("2020-01-20"),
-            endDate: new Date("2020-01-28"),
-            isActive: false,
-            adjustments: [
-              new Adjustment({
-                id: "1",
-                routeId: "Red",
-                source: "gtfs_creator",
-                sourceLabel: "AlewifeHarvard",
-              }),
-            ],
-            daysOfWeek: [],
-            exceptions: [],
-            tripShortNames: [],
-          }),
-        ],
-      }),
-      new Disruption({
-        id: "3",
-        readyRevision: new DisruptionRevision({
-          id: "4",
-          disruptionId: "3",
-          startDate: new Date("2020-02-20"),
-          endDate: new Date("2020-02-25"),
-          isActive: false,
-          adjustments: [
-            new Adjustment({
-              id: "1",
-              routeId: "Orange",
-              source: "gtfs_creator",
-              sourceLabel: "Wellington",
-            }),
-          ],
-          daysOfWeek: [],
-          exceptions: [],
-          tripShortNames: [],
-          status: DisruptionView.Ready,
-        }),
-        revisions: [
-          new DisruptionRevision({
-            id: "5",
-            disruptionId: "3",
-            startDate: new Date("2020-02-21"),
-            endDate: new Date("2020-02-225"),
-            isActive: false,
-            adjustments: [
-              new Adjustment({
-                id: "1",
-                routeId: "Orange",
-                source: "gtfs_creator",
-                sourceLabel: "Wellington",
-              }),
-            ],
-            daysOfWeek: [],
-            exceptions: [],
-            tripShortNames: [],
-          }),
-        ],
-      }),
-    ]
-    const getSpy = jest.spyOn(api, "apiGet").mockImplementation(() => {
-      return Promise.resolve(disruptions)
-    })
-    const sendSpy = jest.spyOn(api, "apiSend").mockImplementation(() => {
-      return Promise.resolve({
-        ok: {},
-      })
-    })
-    const container = document.createElement("div")
-    document.body.appendChild(container)
-
-    // eslint-disable-next-line @typescript-eslint/require-await
-    await act(async () => {
-      ReactDOM.render(<DisruptionIndexWithRouter connected />, container)
-    })
-    expect(getSpy).toHaveBeenCalledTimes(1)
-    const actionsButton = container.querySelector("#actions")
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    fireEvent.click(actionsButton!)
-    let checkboxes: NodeListOf<HTMLInputElement> = container.querySelectorAll(
-      "tr input[type=checkbox]"
-    )
-    expect(checkboxes.length).toEqual(2)
-    checkboxes.forEach((x: HTMLInputElement) => {
-      expect(x.checked).toEqual(false)
-    })
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    fireEvent.click(container.querySelector('tr[data-revision-id="5"] input')!)
-    expect(
-      (container.querySelector(
-        'tr[data-revision-id="5"] input[type=checkbox]'
-      ) as HTMLInputElement).checked
-    ).toEqual(true)
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    fireEvent.click(container.querySelector("#toggle-all")!)
-    checkboxes.forEach((x: HTMLInputElement) => {
-      expect(x.checked).toEqual(false)
-    })
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    fireEvent.click(container.querySelector("#toggle-all")!)
-    expect(container.querySelectorAll("tr input:checked").length).toEqual(2)
-    checkboxes.forEach((x: HTMLInputElement) => {
-      expect(x.checked).toEqual(true)
-    })
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    fireEvent.click(container.querySelector("#actions")!)
-    expect(container.querySelectorAll("tr input").length).toEqual(0)
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    fireEvent.click(container.querySelector("#actions")!)
-    checkboxes = container.querySelectorAll("tr input")
-    expect(checkboxes.length).toEqual(2)
-    checkboxes.forEach((x: HTMLInputElement) => {
-      expect(x.checked).toEqual(false)
-    })
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    fireEvent.click(container.querySelector("#toggle-all")!)
-    expect(container.querySelectorAll("tr input:checked").length).toEqual(2)
-    checkboxes.forEach((x: HTMLInputElement) => {
-      expect(x.checked).toEqual(true)
-    })
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    fireEvent.click(container.querySelector("#route-filter-toggle-Orange")!)
-    expect(container.querySelectorAll("tr input:checked").length).toEqual(1)
-    // eslint-disable-next-line @typescript-eslint/require-await
-    await act(async () => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      fireEvent.click(container.querySelector("#mark-ready")!)
-    })
-    expect(sendSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        url: "/api/ready_notice/",
-        json: JSON.stringify({ revision_ids: "5" }),
-        method: "POST",
-      })
-    )
-    expect(getSpy).toHaveBeenCalledTimes(2)
-    sendSpy.mockClear()
-    const sendSpyFail = jest.spyOn(api, "apiSend").mockImplementation(() => {
-      return Promise.reject()
-    })
-    // eslint-disable-next-line @typescript-eslint/require-await
-    await act(async () => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      fireEvent.click(container.querySelector("#mark-ready")!)
-    })
-    expect(sendSpyFail).toBeCalledTimes(1)
-    expect(getSpy).toHaveBeenCalledTimes(2)
   })
 
   test("doesn't render deleted published disruption", async () => {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Detail page updates](https://app.asana.com/0/584764604969369/1195117716558252/f)

Follow up to https://github.com/mbta/arrow/pull/443, adding custom confirmation modal. Added this to:
* Index page (when marking revisions as ready)
* Details page (when marking revision as ready and when deleting)

Additionally, a couple of small refactors:
* in `DisruptionIndexView` component, use `Disruption.getUniqueRevisions` introduced in [#443](https://github.com/mbta/arrow/pull/443/files#diff-5214aebede4a1c4d16005ce49bd4ead5R120)
* Change logic in `anyMatchesFilter` to filter out disruptions with no active revision. Short term fix to clean up the table view. Still would have the problem where a deleted "ready" revision is not marked as "published", so the "published" revision would remain active and in the table.

<img width="1050" alt="Screen Shot 2020-10-05 at 10 00 05 AM" src="https://user-images.githubusercontent.com/18427346/95089741-79306880-06f2-11eb-89e0-bed0af072a56.png">


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
