### PR TITLE
mix copy_db fixes

### DIFF
--- a/lib/arrow/db_structure.ex
+++ b/lib/arrow/db_structure.ex
@@ -14,7 +14,8 @@ defmodule Arrow.DBStructure do
          {:ready_revision_id, :optional_fkey},
          {:published_revision_id, :optional_fkey},
          :inserted_at,
-         :updated_at
+         :updated_at,
+         :last_published_at
        ]},
       {"disruption_revisions",
        [

--- a/lib/arrow/db_structure.ex
+++ b/lib/arrow/db_structure.ex
@@ -1,79 +1,96 @@
+defmodule Arrow.DBStructure.Table do
+  @type t :: %__MODULE__{
+          name: String.t(),
+          columns: [atom()],
+          optional_fkeys: [atom()]
+        }
+  defstruct [:name, columns: [], optional_fkeys: []]
+end
+
 defmodule Arrow.DBStructure do
   import Ecto.Query
+  alias Arrow.DBStructure.Table
 
   @temp_table "temp_join_table"
-  @type db_structure :: [{String.t(), [atom() | {atom(), atom()}]}]
+  @type db_structure :: [Table.t()]
 
   @spec structure :: db_structure
   def structure do
     [
-      {"adjustments", [:id, :route_id, :source, :source_label, :inserted_at, :updated_at]},
-      {"disruptions",
-       [
-         :id,
-         {:ready_revision_id, :optional_fkey},
-         {:published_revision_id, :optional_fkey},
-         :inserted_at,
-         :updated_at,
-         :last_published_at
-       ]},
-      {"disruption_revisions",
-       [
-         :id,
-         :start_date,
-         :end_date,
-         :is_active,
-         :disruption_id,
-         :inserted_at,
-         :updated_at
-       ]},
-      {"disruption_adjustments",
-       [
-         :id,
-         :disruption_revision_id,
-         :adjustment_id
-       ]},
-      {"disruption_day_of_weeks",
-       [
-         :id,
-         :disruption_revision_id,
-         :day_name,
-         :start_time,
-         :end_time,
-         :inserted_at,
-         :updated_at
-       ]},
-      {"disruption_exceptions",
-       [
-         :id,
-         :disruption_revision_id,
-         :excluded_date,
-         :inserted_at,
-         :updated_at
-       ]},
-      {"disruption_trip_short_names",
-       [
-         :id,
-         :disruption_revision_id,
-         :trip_short_name,
-         :inserted_at,
-         :updated_at
-       ]}
+      %Table{
+        name: "adjustments",
+        columns: [:id, :route_id, :source, :source_label, :inserted_at, :updated_at]
+      },
+      %Table{
+        name: "disruptions",
+        columns: [
+          :id,
+          :inserted_at,
+          :updated_at,
+          :last_published_at
+        ],
+        optional_fkeys: [:ready_revision_id, :published_revision_id]
+      },
+      %Table{
+        name: "disruption_revisions",
+        columns: [
+          :id,
+          :start_date,
+          :end_date,
+          :is_active,
+          :disruption_id,
+          :inserted_at,
+          :updated_at
+        ]
+      },
+      %Table{
+        name: "disruption_adjustments",
+        columns: [
+          :id,
+          :disruption_revision_id,
+          :adjustment_id
+        ]
+      },
+      %Table{
+        name: "disruption_day_of_weeks",
+        columns: [
+          :id,
+          :disruption_revision_id,
+          :day_name,
+          :start_time,
+          :end_time,
+          :inserted_at,
+          :updated_at
+        ]
+      },
+      %Table{
+        name: "disruption_exceptions",
+        columns: [
+          :id,
+          :disruption_revision_id,
+          :excluded_date,
+          :inserted_at,
+          :updated_at
+        ]
+      },
+      %Table{
+        name: "disruption_trip_short_names",
+        columns: [
+          :id,
+          :disruption_revision_id,
+          :trip_short_name,
+          :inserted_at,
+          :updated_at
+        ]
+      }
     ]
   end
 
   @spec dump_data(db_structure) :: %{}
   def dump_data(structure \\ structure()) do
-    Map.new(structure, fn {table, columns} ->
-      columns_to_select =
-        Enum.map(columns, fn c ->
-          case c do
-            {column_name, _} -> column_name
-            column_name -> column_name
-          end
-        end)
-
-      {table, table |> from(select: ^columns_to_select) |> Arrow.Repo.all()}
+    Map.new(structure, fn table ->
+      columns_to_select = table.columns ++ table.optional_fkeys
+      {table.name, table.name |> from(select: ^columns_to_select) |> Arrow.Repo.all()}
     end)
   end
 
@@ -82,34 +99,28 @@ defmodule Arrow.DBStructure do
     repo.transaction(fn ->
       # null out optional fkeys
       structure
-      |> Enum.each(fn {table, columns} ->
-        Enum.each(columns, fn column ->
-          case column do
-            {name, :optional_fkey} ->
-              set = Keyword.new([{name, nil}])
-              table |> from(update: [set: ^set]) |> repo.update_all([])
-
-            _ ->
-              nil
-          end
+      |> Enum.each(fn table ->
+        Enum.each(table.optional_fkeys, fn column ->
+          set = Keyword.new([{column, nil}])
+          table.name |> from(update: [set: ^set]) |> repo.update_all([])
         end)
       end)
 
       # delete all rows
       structure
       |> Enum.reverse()
-      |> Enum.each(fn {table, _columns} ->
-        {_num_deleted, _return} = table |> from() |> repo.delete_all()
+      |> Enum.each(fn table ->
+        {_num_deleted, _return} = table.name |> from() |> repo.delete_all()
       end)
 
       # add back in rows, exclude optional fkeys
 
-      Enum.each(structure, fn {table, columns} ->
-        columns_to_include = Enum.filter(columns, &(!match?({_, :optional_fkey}, &1)))
+      Enum.each(structure, fn table ->
+        columns_to_include = table.columns
 
         repo.insert_all(
-          table,
-          data |> Map.get(table) |> Enum.map(&Map.take(&1, columns_to_include))
+          table.name,
+          data |> Map.get(table.name) |> Enum.map(&Map.take(&1, columns_to_include))
         )
       end)
 
@@ -121,29 +132,23 @@ defmodule Arrow.DBStructure do
           []
         )
 
-      Enum.each(data, fn {table, rows} ->
-        columns_to_include =
-          structure
-          |> Map.new()
-          |> Map.get(table)
-          |> Enum.filter(&match?({_, :optional_fkey}, &1))
-          |> Enum.map(&elem(&1, 0))
+      Enum.each(structure, fn table ->
+        Enum.each(table.optional_fkeys, fn fkey_column ->
+          @temp_table |> from() |> repo.delete_all()
 
-        @temp_table |> from() |> repo.delete_all()
-
-        Enum.each(columns_to_include, fn column ->
           temp_rows =
-            rows
-            |> Enum.map(&%{table_id: Map.get(&1, :id), fkey_value: Map.get(&1, column)})
+            data
+            |> Map.get(table.name)
+            |> Enum.map(&%{table_id: Map.get(&1, :id), fkey_value: Map.get(&1, fkey_column)})
             |> Enum.filter(&(!is_nil(&1[:fkey_value])))
 
           {_num_inserted, _return} = repo.insert_all(@temp_table, temp_rows)
 
-          from(t in table,
+          from(t in table.name,
             join: j in @temp_table,
             on: t.id == j.table_id,
             update: [
-              set: [{^column, field(j, :fkey_value)}]
+              set: [{^fkey_column, field(j, :fkey_value)}]
             ]
           )
           |> repo.update_all([])

--- a/test/arrow/db_structure_test.exs
+++ b/test/arrow/db_structure_test.exs
@@ -110,7 +110,8 @@ defmodule Arrow.DBStructureTest do
             inserted_at: ~U[2020-09-29 15:17:42.000000Z],
             published_revision_id: nil,
             ready_revision_id: 11206,
-            updated_at: ~U[2020-09-29 15:17:42.000000Z]
+            updated_at: ~U[2020-09-29 15:17:42.000000Z],
+            last_published_at: nil
           }
         ]
       }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Unrelated, but to help debug [🐛 Unable to edit disruption in Arrow](https://app.asana.com/0/281253957434160/1198920748926221)

A few tweaks to the `mix copy_db` task.

* The first commit adds `last_published_at` to the list of columns to copy over.
* The second commit is a refactor of the table structure. It switches the table definition from a list of tuples to a new struct `Arrow.DbStructure.Table`, to prepare for adding a new configuration option of columns that use sequences and the names of the sequences.
* The third commit adds a step to the import to query the columns that use auto-generated sequence values to get their current max value and then to reset their sequence generator to start higher than that.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
