### PR TITLE
fix: Update disruptions that aren't ready

### DIFF
--- a/lib/arrow_web/controllers/api/disruption_controller.ex
+++ b/lib/arrow_web/controllers/api/disruption_controller.ex
@@ -81,7 +81,7 @@ defmodule ArrowWeb.API.DisruptionController do
 
     disruption_revision =
       DisruptionRevision
-      |> DisruptionRevision.only_ready()
+      |> DisruptionRevision.latest_revision()
       |> Repo.get_by!(disruption_id: params["id"])
 
     case Disruption.update(disruption_revision.id, attrs) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐛 Unable to edit disruption in Arrow](https://app.asana.com/0/281253957434160/1198920748926221)

The fix is pretty small. Basically, the `update` controller action used `DisruptionRevision.only_ready()` to select the latest "ready" revision to clone when updating. However, I think actually we should be cloning the latest revision. The frontend flow lets you edit only based off the latest draft. And the current flow causes a crash if a given disruption doesn't have a ready revision yet, but is updated (i.e.: two drafts in a row before any approvals).

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
