### PR TITLE
fix: exception datepicker

### DIFF
--- a/assets/src/disruptions/disruptionDateRange.tsx
+++ b/assets/src/disruptions/disruptionDateRange.tsx
@@ -27,6 +27,7 @@ const DisruptionDateRange = ({
           </div>
           <DatePicker
             id="disruption-date-range-start"
+            autoComplete="off"
             selected={fromDate}
             onChange={(date) => {
               if (!Array.isArray(date)) {
@@ -41,6 +42,7 @@ const DisruptionDateRange = ({
           </div>
           <DatePicker
             id="disruption-date-range-end"
+            autoComplete="off"
             selected={toDate}
             onChange={(date) => {
               if (!Array.isArray(date)) {

--- a/assets/src/disruptions/disruptionExceptionDates.tsx
+++ b/assets/src/disruptions/disruptionExceptionDates.tsx
@@ -18,15 +18,18 @@ const DisruptionExceptionDateList = ({
   isAddingDate,
   setIsAddingDate,
 }: DisruptionExceptionDateListProps): JSX.Element => {
+  const dates = isAddingDate ? [...exceptionDates, null] : exceptionDates
   return (
     <Form.Group>
-      {exceptionDates.map((date, index) => (
+      {dates.map((date, index) => (
         <div
           id={"date-exception-row-" + index}
           key={"date-exception-row-" + index}
+          data-date-exception-new={!date}
         >
           <Row className="mb-2 ml-0">
             <DatePicker
+              autoComplete="off"
               selected={date}
               onChange={(newDate) => {
                 if (newDate !== null && !Array.isArray(newDate)) {
@@ -43,17 +46,22 @@ const DisruptionExceptionDateList = ({
                       .concat(exceptionDates.slice(index + 1))
                   )
                 }
+                setIsAddingDate(false)
               }}
             />
             <button
               className="btn btn-link"
               data-testid="remove-exception-date"
               onClick={() => {
-                const newExceptionDates = exceptionDates
-                  .slice(0, index)
-                  .concat(exceptionDates.slice(index + 1))
+                if (date) {
+                  const newExceptionDates = exceptionDates
+                    .slice(0, index)
+                    .concat(exceptionDates.slice(index + 1))
 
-                setExceptionDates(newExceptionDates)
+                  setExceptionDates(newExceptionDates)
+                } else {
+                  setIsAddingDate(false)
+                }
               }}
             >
               &#xe161;
@@ -62,27 +70,7 @@ const DisruptionExceptionDateList = ({
         </div>
       ))}
 
-      {isAddingDate ? (
-        <div id="date-exception-new" key="date-exception-new">
-          <Row className="ml-0">
-            <DatePicker
-              selected={null}
-              onChange={(newDate) => {
-                if (newDate !== null && !Array.isArray(newDate)) {
-                  setExceptionDates(exceptionDates.concat([newDate]))
-                  setIsAddingDate(false)
-                }
-              }}
-            />
-            <button
-              className="btn btn-link"
-              onClick={() => setIsAddingDate(false)}
-            >
-              &#xe161;
-            </button>
-          </Row>
-        </div>
-      ) : (
+      {!isAddingDate && (
         <Row key="date-exception-add-link">
           <button
             className="btn btn-link"

--- a/assets/tests/disruptions/disruptionExceptionDates.test.tsx
+++ b/assets/tests/disruptions/disruptionExceptionDates.test.tsx
@@ -24,7 +24,9 @@ describe("DisruptionExceptionDates", () => {
     }
     fireEvent.click(dateExceptionsCheck)
 
-    expect(container.querySelector("#date-exception-new")).not.toBeNull()
+    expect(
+      container.querySelector("[data-date-exception-new=true]")
+    ).not.toBeNull()
     expect(container.querySelector("#date-exception-add-link")).toBeNull()
   })
 
@@ -38,7 +40,7 @@ describe("DisruptionExceptionDates", () => {
     fireEvent.click(dateExceptionsCheck)
 
     const newDateExceptionInput = container.querySelector(
-      "#date-exception-new input"
+      "[data-date-exception-new=true] input"
     )
     if (!newDateExceptionInput) {
       throw new Error("new date exception input not found")
@@ -53,7 +55,9 @@ describe("DisruptionExceptionDates", () => {
     }
     fireEvent.click(addExceptionLink)
 
-    expect(container.querySelector("#date-exception-new")).not.toBeNull()
+    expect(
+      container.querySelector("[data-date-exception-new=true]")
+    ).not.toBeNull()
   })
 
   test("can delete a not-yet-added exception date field", () => {
@@ -66,14 +70,14 @@ describe("DisruptionExceptionDates", () => {
     fireEvent.click(dateExceptionsCheck)
 
     const deleteExceptionButton = container.querySelector(
-      "#date-exception-new button"
+      "[data-date-exception-new=true] button"
     )
     if (!deleteExceptionButton) {
       throw new Error("delete exception button not found")
     }
     fireEvent.click(deleteExceptionButton)
 
-    expect(container.querySelector("#date-exception-new")).toBeNull()
+    expect(container.querySelector("[data-date-exception-new=true]")).toBeNull()
     expect(
       (container.querySelector("#exception-add") as HTMLInputElement).checked
     ).toBe(false)
@@ -89,7 +93,7 @@ describe("DisruptionExceptionDates", () => {
     fireEvent.click(dateExceptionsCheck)
 
     const newDateExceptionInput = container.querySelector(
-      "#date-exception-new input"
+      "[data-date-exception-new=true] input"
     )
     if (!newDateExceptionInput) {
       throw new Error("new date exception input not found")
@@ -107,7 +111,7 @@ describe("DisruptionExceptionDates", () => {
     fireEvent.click(dateExceptionsCheck)
 
     const newDateExceptionInput = container.querySelector(
-      "#date-exception-new input"
+      "[data-date-exception-new=true] input"
     )
     if (!newDateExceptionInput) {
       throw new Error("new date exception input not found")
@@ -138,7 +142,7 @@ describe("DisruptionExceptionDates", () => {
     fireEvent.click(dateExceptionsCheck)
 
     let newDateExceptionInput = container.querySelector(
-      "#date-exception-new input"
+      "[data-date-exception-new=true] input"
     )
     if (!newDateExceptionInput) {
       throw new Error("new date exception input not found")
@@ -173,7 +177,9 @@ describe("DisruptionExceptionDates", () => {
     }
     fireEvent.click(addDateExceptionLink)
 
-    newDateExceptionInput = container.querySelector("#date-exception-new input")
+    newDateExceptionInput = container.querySelector(
+      "[data-date-exception-new=true] input"
+    )
     if (!newDateExceptionInput) {
       throw new Error("new date exception input not found")
     }
@@ -204,7 +210,7 @@ describe("DisruptionExceptionDates", () => {
     fireEvent.click(dateExceptionsCheck)
 
     const newDateExceptionInput = container.querySelector(
-      "#date-exception-new input"
+      "[data-date-exception-new=true] input"
     )
     if (!newDateExceptionInput) {
       throw new Error("new date exception input not found")
@@ -238,7 +244,7 @@ describe("DisruptionExceptionDates", () => {
     fireEvent.click(dateExceptionsYesCheck)
 
     const newDateExceptionInput = container.querySelector(
-      "#date-exception-new input"
+      "[data-date-exception-new=true] input"
     )
     if (!newDateExceptionInput) {
       throw new Error("new date exception input not found")

--- a/assets/tests/disruptions/editDisruption.test.tsx
+++ b/assets/tests/disruptions/editDisruption.test.tsx
@@ -366,7 +366,7 @@ describe("EditDisruption", () => {
     }
 
     const exceptionDateInput = container.querySelector(
-      "#date-exception-new input"
+      "[data-date-exception-new=true] input"
     )
 
     if (exceptionDateInput) {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 date fields are more user friendly](https://app.asana.com/0/584764604969369/1199117764695509/f)

## Changes
* set `autoComplete="off"` prop to disable the browser's autocomplete
* treat the "new" exception date input the same as the existing exception dates, only conditionally showing/hiding the "add new exception" button based on `isAddingException`, so that we don't unmount the "new" exception date input when the user types a number (which `react-datepicker` treats as selecting a date). 

## Before
![before](https://user-images.githubusercontent.com/18427346/101050040-1290c500-3552-11eb-8790-883795abc109.gif)

## After
![after](https://user-images.githubusercontent.com/18427346/101050064-1886a600-3552-11eb-92cf-6c5e420a2c89.gif)


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
