### PR TITLE
fix: "unbound variable" error in build script

### DIFF
--- a/semaphore/build_push.sh
+++ b/semaphore/build_push.sh
@@ -7,6 +7,9 @@ set -e -u
 # * DOCKER_REPO
 awsenv=$1
 
+DOCKER_USERNAME=$(printenv DOCKER_USERNAME || echo "")
+DOCKER_PASSWORD=$(printenv DOCKER_PASSWORD || echo "")
+
 # log into docker hub if credentials are in the environment
 if [ -n "$DOCKER_USERNAME" ]; then
   echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin


### PR DESCRIPTION
I really should have test-deployed the last branch to dev _before_ merging it 😑 This would also go away once the Docker Hub variables are set up for this project, but in any case the script should work if they're not present.