### PR TITLE
fix: pending deletions missing from "needs review"

### DIFF
--- a/assets/src/disruptions/disruptionIndex.tsx
+++ b/assets/src/disruptions/disruptionIndex.tsx
@@ -166,7 +166,7 @@ const revisionMatchesFilters = (
   pastThreshold: Date
 ) =>
   !!(
-    revision.isActive &&
+    (revision.isActive || revision.status !== DisruptionView.Published) &&
     (dateFilters.anyActive ||
       (revision.endDate && revision.endDate > pastThreshold)) &&
     (!routeFilters.anyActive ||

--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -1218,6 +1218,13 @@ describe("revisionMatchesFilters", () => {
     status: DisruptionView.Published,
   })
 
+  const publishedDeleted = new DisruptionRevision({
+    ...published,
+    isActive: false,
+  })
+  const readyDeleted = new DisruptionRevision({ ...ready, isActive: false })
+  const draftDeleted = new DisruptionRevision({ ...draft, isActive: false })
+
   const noRouteFilters = { state: {}, anyActive: false }
   const noStatusFilters = { state: {}, anyActive: false }
   const noDateFilters = { state: {}, anyActive: false }
@@ -1332,6 +1339,34 @@ describe("revisionMatchesFilters", () => {
       false,
     ],
     [past, "", noRouteFilters, noStatusFilters, includePast, oneWeekAgo, true],
+    // deleted revisions
+    [
+      publishedDeleted,
+      "",
+      noRouteFilters,
+      onlyPublished,
+      noDateFilters,
+      oneWeekAgo,
+      false,
+    ],
+    [
+      readyDeleted,
+      "",
+      noRouteFilters,
+      onlyReady,
+      noDateFilters,
+      oneWeekAgo,
+      true,
+    ],
+    [
+      draftDeleted,
+      "",
+      noRouteFilters,
+      onlyDraft,
+      noDateFilters,
+      oneWeekAgo,
+      true,
+    ],
   ])(
     "%o with filters (%p, %o, %o, %o, %p)",
     (


### PR DESCRIPTION
**Asana Ticket:** [🐛 Disruptions marked for deletion should appear in Needs Review filter](https://app.asana.com/0/584764604969369/1199550046000729)

The "needs review" filter only matches revisions that are in draft status. Separately, if a revision was deleted (`isActive === false`), it would not match any filters regardless of status. This meant disruptions with a drafted deletion didn't appear in "needs review" at all, since the draft revision was excluded by the `isActive` filter and the other revisions were excluded by the "needs review" filter.

This addresses the issue by having the universal `isActive` filter only exclude revisions that are published.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
