### PR TITLE
chore: pin Erlang version in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ ENV LANG=C.UTF-8 \
   MIX_ENV=prod
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  curl git
+  ca-certificates curl git 
 
 # Instructions from:
 # https://github.com/nodesource/distributions/blob/master/README.md
 RUN  curl -sL https://deb.nodesource.com/setup_14.x | bash - \
-  && apt-get install -y nodejs npm \
+  && apt-get install -y nodejs \
   && npm install -g npm@latest
 
 WORKDIR /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM hexpm/elixir:1.9.4-erlang-22.2.1-debian-buster-20200224 as builder
 ENV LANG=C.UTF-8 \
   MIX_ENV=prod
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  curl git
+
 # Instructions from:
 # https://github.com/nodesource/distributions/blob/master/README.md
 RUN  curl -sL https://deb.nodesource.com/setup_14.x | bash - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Instructions from:
 # https://github.com/nodesource/distributions/blob/master/README.md
 RUN  curl -sL https://deb.nodesource.com/setup_14.x | bash - \
-  && apt-get install -y nodejs
+  && apt-get install -y nodejs npm \
+  && npm install -g npm@latest
 
 WORKDIR /root
 ADD . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.9.4 as builder
+FROM hexpm/elixir:1.9.4-erlang-22.2.1-debian-buster-20200224 as builder
 
 ENV LANG=C.UTF-8 \
   MIX_ENV=prod


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [💳 update arrow to use hexpm/elixir container](https://app.asana.com/0/0/1200075745309243/f)

Similar to mbta/prediction_analyzer#432, this pins the Erlang version used when building the application in the Docker container using a hexpm/elixir image. `curl`, `git`, and `ca-certificates` had to be installed as well. This branch is currently deployed to dev.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
