### PR TITLE
Direnv support and refactor using aliases/imports

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,2 @@
+DATABASE_USERNAME=postgres
+DATABASE_PASSWORD=postgres

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,8 @@ npm-debug.log
 # this depending on your deployment strategy.
 /priv/static/
 
+# Code coverage from React tests
 /assets/coverage/
+
+# Private environment variables
+.envrc

--- a/README.md
+++ b/README.md
@@ -1,20 +1,39 @@
 # Arrow
 
-To start your Phoenix server:
+🏹 Adjustments to the Regular Right of Way
 
-  * Install tools with `asdf install`
-  * Install dependencies with `mix deps.get`
-  * Create and migrate your database with `mix ecto.setup`
-  * Install Node.js dependencies with `cd assets && npm install`
-  * Start Phoenix endpoint with `mix phx.server`
+## Setup
 
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+### Requirements
 
-Useful when developing:
+- [`asdf`](https://github.com/asdf-vm/asdf)
+  - Add `erlang`, `elixir`, and `nodejs` plugins
+  - Install [additional requirements][nodejs-reqs] for `nodejs` plugin
+- [`direnv`](https://github.com/direnv/direnv)
+- PostgreSQL 11 (using Homebrew: `brew install postgresql@11`)
 
-  * Test elixir code with `mix test`
-  * Format elixir code with `mix format`
-  * Lint elixir code with `mix dialyzer` and `mix credo`
-  * Test frontend code with `npm run test`
-  * Format frontend code with `npm run format`
-  * Lint frontend code with `npm run lint`
+[nodejs-reqs]: https://github.com/asdf-vm/asdf-nodejs#requirements
+
+### Instructions
+
+- `asdf install`
+- `mix deps.get`
+- `npm install --prefix assets`
+- `cp .envrc.example .envrc`
+- Update `.envrc` with your local Postgres username and password
+- `direnv allow`
+- `mix ecto.setup`
+
+### Useful commands
+
+- Run the app: `mix phx.server` (visit <http://localhost:4000/>)
+- Elixir:
+  - `mix test` — run tests
+  - `mix dialyzer` — check typespecs
+  - `mix format` — format code
+  - `mix credo` — lint code
+- JavaScript: `cd assets` and...
+  - `npm run test` — run tests
+  - `npm run test -- --watch` — run tests continuously for changed code
+  - `npm run format` — format code
+  - `npm run lint` — lint code (and fix automatically if possible)

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,8 +2,8 @@ use Mix.Config
 
 # Configure your database
 config :arrow, Arrow.Repo,
-  username: System.get_env("DATABASE_POSTGRESQL_USERNAME") || "postgres",
-  password: System.get_env("DATABASE_POSTGRESQL_PASSWORD") || "postgres",
+  username: System.get_env("DATABASE_USERNAME") || "postgres",
+  password: System.get_env("DATABASE_PASSWORD") || "postgres",
   database: "arrow_dev",
   hostname: "localhost",
   show_sensitive_data_on_connection_error: true,

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,8 +2,8 @@ use Mix.Config
 
 # Configure your database
 config :arrow, Arrow.Repo,
-  username: System.get_env("DATABASE_POSTGRESQL_USERNAME") || "postgres",
-  password: System.get_env("DATABASE_POSTGRESQL_PASSWORD") || "postgres",
+  username: System.get_env("DATABASE_USERNAME") || "postgres",
+  password: System.get_env("DATABASE_PASSWORD") || "postgres",
   database: "arrow_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox

--- a/lib/arrow_web/auth_manager/error_handler.ex
+++ b/lib/arrow_web/auth_manager/error_handler.ex
@@ -3,13 +3,13 @@ defmodule ArrowWeb.AuthManager.ErrorHandler do
   Plug to handle if user is not authenticated.
   """
 
+  alias ArrowWeb.Router.Helpers, as: Routes
+  alias Phoenix.Controller
+
   @behaviour Guardian.Plug.ErrorHandler
 
   @impl Guardian.Plug.ErrorHandler
   def auth_error(conn, {_type, _reason}, _opts) do
-    Phoenix.Controller.redirect(
-      conn,
-      to: ArrowWeb.Router.Helpers.auth_path(conn, :request, "cognito")
-    )
+    Controller.redirect(conn, to: Routes.auth_path(conn, :request, "cognito"))
   end
 end

--- a/lib/arrow_web/controllers/api/db_dump_controller.ex
+++ b/lib/arrow_web/controllers/api/db_dump_controller.ex
@@ -2,7 +2,7 @@ defmodule ArrowWeb.API.DBDumpController do
   use ArrowWeb, :controller
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def show(conn, _pamas) do
+  def show(conn, _params) do
     json(conn, Arrow.DBStructure.dump_data())
   end
 end

--- a/lib/arrow_web/controllers/auth_controller.ex
+++ b/lib/arrow_web/controllers/auth_controller.ex
@@ -17,8 +17,8 @@ defmodule ArrowWeb.AuthController do
       %{groups: credentials.other[:groups]},
       ttl: {expiration - current_time, :seconds}
     )
-    |> Plug.Conn.put_session(:arrow_username, username)
-    |> redirect(to: ArrowWeb.Router.Helpers.disruption_path(conn, :index))
+    |> put_session(:arrow_username, username)
+    |> redirect(to: Routes.disruption_path(conn, :index))
   end
 
   def callback(

--- a/lib/arrow_web/controllers/my_token_controller.ex
+++ b/lib/arrow_web/controllers/my_token_controller.ex
@@ -4,8 +4,7 @@ defmodule ArrowWeb.MyTokenController do
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, _params) do
-    token =
-      conn |> Plug.Conn.get_session(:arrow_username) |> AuthToken.get_or_create_token_for_user()
+    token = conn |> get_session(:arrow_username) |> AuthToken.get_or_create_token_for_user()
 
     render(conn, "index.html", token: token)
   end

--- a/lib/arrow_web/controllers/temp_review_changes_controller.ex
+++ b/lib/arrow_web/controllers/temp_review_changes_controller.ex
@@ -10,6 +10,6 @@ defmodule ArrowWeb.TempReviewChangesController do
   def create(conn, _params) do
     :ok = Arrow.DisruptionRevision.ready_all!()
 
-    redirect(conn, to: ArrowWeb.Router.Helpers.disruption_path(conn, :index))
+    redirect(conn, to: Routes.disruption_path(conn, :index))
   end
 end

--- a/lib/arrow_web/ensure_arrow_group.ex
+++ b/lib/arrow_web/ensure_arrow_group.ex
@@ -3,6 +3,8 @@ defmodule ArrowWeb.EnsureArrowGroup do
   Plug to ensure that an authenticated user is authorized
   """
 
+  alias ArrowWeb.Router.Helpers, as: Routes
+  alias Phoenix.Controller
   import Plug.Conn
 
   def init(options), do: options
@@ -15,11 +17,7 @@ defmodule ArrowWeb.EnsureArrowGroup do
       conn
     else
       _ ->
-        conn
-        |> Phoenix.Controller.redirect(
-          to: ArrowWeb.Router.Helpers.unauthorized_path(conn, :index)
-        )
-        |> halt()
+        conn |> Controller.redirect(to: Routes.unauthorized_path(conn, :index)) |> halt()
     end
   end
 end

--- a/lib/arrow_web/try_api_token_auth.ex
+++ b/lib/arrow_web/try_api_token_auth.ex
@@ -60,7 +60,7 @@ defmodule ArrowWeb.TryApiTokenAuth do
           auth_token.username,
           %{groups: group_names}
         )
-        |> Plug.Conn.put_session(:arrow_username, auth_token.username)
+        |> put_session(:arrow_username, auth_token.username)
       end
     end
   end

--- a/test/arrow_web/controllers/api/db_dump_controller_test.exs
+++ b/test/arrow_web/controllers/api/db_dump_controller_test.exs
@@ -4,7 +4,7 @@ defmodule ArrowWeb.API.DBDumpControllerTest do
   describe "show/2" do
     @tag :authenticated
     test "returns JSON with database contents", %{conn: conn} do
-      conn = get(conn, ArrowWeb.Router.Helpers.db_dump_path(conn, :show))
+      conn = get(conn, Routes.db_dump_path(conn, :show))
 
       assert resp = json_response(conn, 200)
 

--- a/test/arrow_web/controllers/api/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/api/disruption_controller_test.exs
@@ -698,7 +698,7 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
       |> Ecto.Changeset.change(%{ready_revision_id: disruption_revision.id})
       |> Arrow.Repo.update!()
 
-      conn = delete(conn, ArrowWeb.Router.Helpers.disruption_path(conn, :delete, disruption.id))
+      conn = delete(conn, Routes.disruption_path(conn, :delete, disruption.id))
 
       response = response(conn, 204)
 
@@ -716,7 +716,7 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
 
     @tag :authenticated
     test "returns 404 when no disruption by given ID exists", %{conn: conn} do
-      conn = delete(conn, ArrowWeb.Router.Helpers.disruption_path(conn, :delete, 1))
+      conn = delete(conn, Routes.disruption_path(conn, :delete, 1))
 
       response = json_response(conn, 404)
 

--- a/test/arrow_web/controllers/api/notice_controller_test.exs
+++ b/test/arrow_web/controllers/api/notice_controller_test.exs
@@ -19,19 +19,11 @@ defmodule ArrowWeb.API.PublishNoticeControllerTest do
       log =
         capture_log([level: :info], fn ->
           conn =
-            post(
-              conn,
-              ArrowWeb.Router.Helpers.notice_path(conn, :publish,
-                revision_ids: Integer.to_string(dr.id)
-              )
-            )
+            post(conn, Routes.notice_path(conn, :publish, revision_ids: Integer.to_string(dr.id)))
 
           assert resp = response(conn, 200)
-
           assert resp == ""
-
           new_d = Arrow.Repo.get(Arrow.Disruption, d.id)
-
           assert new_d.published_revision_id == dr.id
         end)
 
@@ -46,32 +38,19 @@ defmodule ArrowWeb.API.PublishNoticeControllerTest do
       dr = insert(:disruption_revision, %{disruption: d})
 
       conn =
-        post(
-          conn,
-          ArrowWeb.Router.Helpers.notice_path(conn, :publish,
-            revision_ids: Integer.to_string(dr.id)
-          )
-        )
+        post(conn, Routes.notice_path(conn, :publish, revision_ids: Integer.to_string(dr.id)))
 
       assert resp = response(conn, 400)
-
       assert resp == "can't publish revision more recent than ready revision"
-
       new_d = Arrow.Repo.get(Arrow.Disruption, d.id)
-
       assert is_nil(new_d.published_revision_id)
     end
 
     @tag :authenticated
     test "returns 400 error when non-integer argument is given", %{conn: conn} do
-      conn =
-        post(
-          conn,
-          ArrowWeb.Router.Helpers.notice_path(conn, :publish, revision_ids: "foo")
-        )
+      conn = post(conn, Routes.notice_path(conn, :publish, revision_ids: "foo"))
 
       assert resp = response(conn, 400)
-
       assert resp == "bad argument"
     end
   end
@@ -91,19 +70,11 @@ defmodule ArrowWeb.API.PublishNoticeControllerTest do
       log =
         capture_log([level: :info], fn ->
           conn =
-            post(
-              conn,
-              ArrowWeb.Router.Helpers.notice_path(conn, :ready,
-                revision_ids: Integer.to_string(dr.id)
-              )
-            )
+            post(conn, Routes.notice_path(conn, :ready, revision_ids: Integer.to_string(dr.id)))
 
           assert resp = response(conn, 204)
-
           assert resp == ""
-
           new_d = Arrow.Repo.get(Arrow.Disruption, d.id)
-
           assert new_d.ready_revision_id == dr.id
         end)
 
@@ -119,32 +90,19 @@ defmodule ArrowWeb.API.PublishNoticeControllerTest do
       _dr_2 = insert(:disruption_revision, %{disruption: d})
 
       conn =
-        post(
-          conn,
-          ArrowWeb.Router.Helpers.notice_path(conn, :ready,
-            revision_ids: Integer.to_string(dr_1.id)
-          )
-        )
+        post(conn, Routes.notice_path(conn, :ready, revision_ids: Integer.to_string(dr_1.id)))
 
       assert resp = response(conn, 400)
-
       assert resp == "can't ready revision more recent than latest revision"
-
       new_d = Arrow.Repo.get(Arrow.Disruption, d.id)
-
       assert is_nil(new_d.ready_revision_id)
     end
 
     @tag :authenticated
     test "returns 400 error when non-integer argument is given", %{conn: conn} do
-      conn =
-        post(
-          conn,
-          ArrowWeb.Router.Helpers.notice_path(conn, :ready, revision_ids: "foo")
-        )
+      conn = post(conn, Routes.notice_path(conn, :ready, revision_ids: "foo"))
 
       assert resp = response(conn, 400)
-
       assert resp == "bad argument"
     end
   end

--- a/test/arrow_web/controllers/auth_controller_test.exs
+++ b/test/arrow_web/controllers/auth_controller_test.exs
@@ -16,20 +16,20 @@ defmodule ArrowWeb.Controllers.AuthControllerTest do
       conn =
         conn
         |> assign(:ueberauth_auth, auth)
-        |> get(ArrowWeb.Router.Helpers.auth_path(conn, :callback, "cognito"))
+        |> get(Routes.auth_path(conn, :callback, "cognito"))
 
       response = html_response(conn, 302)
 
-      assert response =~ ArrowWeb.Router.Helpers.disruption_path(conn, :index)
+      assert response =~ Routes.disruption_path(conn, :index)
       assert Guardian.Plug.current_claims(conn)["groups"] == ["test1"]
-      assert Plug.Conn.get_session(conn, :arrow_username) == "foo@mbta.com"
+      assert get_session(conn, :arrow_username) == "foo@mbta.com"
     end
 
     test "handles generic failure", %{conn: conn} do
       conn =
         conn
         |> assign(:ueberauth_failure, %Ueberauth.Failure{})
-        |> get(ArrowWeb.Router.Helpers.auth_path(conn, :callback, "cognito"))
+        |> get(Routes.auth_path(conn, :callback, "cognito"))
 
       response = response(conn, 401)
 
@@ -39,11 +39,11 @@ defmodule ArrowWeb.Controllers.AuthControllerTest do
 
   describe "request" do
     test "redirects to auth callback", %{conn: conn} do
-      conn = get(conn, ArrowWeb.Router.Helpers.auth_path(conn, :request, "cognito"))
+      conn = get(conn, Routes.auth_path(conn, :request, "cognito"))
 
       response = response(conn, 302)
 
-      assert response =~ ArrowWeb.Router.Helpers.auth_path(conn, :callback, "cognito")
+      assert response =~ Routes.auth_path(conn, :callback, "cognito")
     end
   end
 end

--- a/test/arrow_web/controllers/my_token_controller_test.exs
+++ b/test/arrow_web/controllers/my_token_controller_test.exs
@@ -1,10 +1,9 @@
 defmodule ArrowWeb.MyTokenControllerTest do
   use ArrowWeb.ConnCase
-  import ArrowWeb.Router.Helpers
 
   @tag :authenticated
   test "GET /mytoken", %{conn: conn} do
-    conn = get(conn, my_token_path(conn, :show))
+    conn = get(conn, Routes.my_token_path(conn, :show))
     assert html_response(conn, 200) =~ "Your token is"
   end
 end

--- a/test/arrow_web/controllers/page_controller_test.exs
+++ b/test/arrow_web/controllers/page_controller_test.exs
@@ -27,7 +27,7 @@ defmodule ArrowWeb.PageControllerTest do
 
   @tag :authenticated
   test "GET / with HTTP redirects to HTTPS", %{conn: conn} do
-    conn = conn |> Plug.Conn.put_req_header("x-forwarded-proto", "http") |> get("/")
+    conn = conn |> put_req_header("x-forwarded-proto", "http") |> get("/")
 
     location_header = Enum.find(conn.resp_headers, fn {key, _value} -> key == "location" end)
     {"location", url} = location_header

--- a/test/arrow_web/controllers/temp_review_changes_controller_test.exs
+++ b/test/arrow_web/controllers/temp_review_changes_controller_test.exs
@@ -1,11 +1,10 @@
 defmodule ArrowWeb.TempReviewChangesControllerTest do
   use ArrowWeb.ConnCase
   import Arrow.Factory
-  import ArrowWeb.Router.Helpers
 
   @tag :authenticated
   test "GET /temp_review_changes", %{conn: conn} do
-    conn = get(conn, temp_review_changes_path(conn, :index))
+    conn = get(conn, Routes.temp_review_changes_path(conn, :index))
     assert html_response(conn, 200) =~ "Publish all"
   end
 
@@ -13,9 +12,9 @@ defmodule ArrowWeb.TempReviewChangesControllerTest do
   test "POST /temp_review_changes", %{conn: conn} do
     dr = insert(:disruption_revision)
 
-    conn = post(conn, temp_review_changes_path(conn, :index))
+    conn = post(conn, Routes.temp_review_changes_path(conn, :index))
 
-    assert html_response(conn, 302) =~ disruption_path(conn, :index)
+    assert html_response(conn, 302) =~ Routes.disruption_path(conn, :index)
 
     new_dr =
       Arrow.DisruptionRevision |> Arrow.Repo.get(dr.id) |> Arrow.Repo.preload([:disruption])

--- a/test/arrow_web/controllers/unauthorized_controller_test.exs
+++ b/test/arrow_web/controllers/unauthorized_controller_test.exs
@@ -1,11 +1,10 @@
 defmodule ArrowWeb.UnauthorizedControllerTest do
   use ArrowWeb.ConnCase
-  import ArrowWeb.Router.Helpers
 
   describe "index/2" do
     @tag :authenticated_not_in_group
     test "renders response", %{conn: conn} do
-      conn = get(conn, unauthorized_path(conn, :index))
+      conn = get(conn, Routes.unauthorized_path(conn, :index))
 
       assert html_response(conn, 403) =~ "not authorized"
     end

--- a/test/arrow_web/try_api_token_auth_test.exs
+++ b/test/arrow_web/try_api_token_auth_test.exs
@@ -53,7 +53,7 @@ defmodule ArrowWeb.TryApiTokenAuthTest do
       assert claims["sub"] == "foo@mbta.com"
       assert claims["typ"] == "access"
       assert claims["groups"] == ["arrow-admin"]
-      assert Plug.Conn.get_session(conn, :arrow_username) == "foo@mbta.com"
+      assert get_session(conn, :arrow_username) == "foo@mbta.com"
     end
 
     test "handles unexpected response from Cognito API", %{conn: conn} do


### PR DESCRIPTION
A couple of miscellaneous things that caught my attention on the way to the (de-)SPA:

* Add `direnv` for greater convenience of specifying your own database username (with Homebrew the default Postgres username is your system username, not `postgres`)
* We were doing a lot of extra typing in some instances where we could take advantage of the default Phoenix aliases and imports