### PR TITLE
test: fix calendar test failing on Mondays

### DIFF
--- a/assets/tests/disruptions/disruptionIndex.test.tsx
+++ b/assets/tests/disruptions/disruptionIndex.test.tsx
@@ -1060,11 +1060,11 @@ describe("DisruptionIndexConnected", () => {
   test("displays only published revisions on the calendar view", async () => {
     const today = new Date()
     today.setUTCHours(0, 0, 0, 0)
-    const nextWeek = new Date(
+    const endDate = new Date(
       Date.UTC(
         today.getUTCFullYear(),
         today.getUTCMonth(),
-        today.getUTCDate() + 7
+        today.getUTCDate() + 6
       )
     )
 
@@ -1072,7 +1072,7 @@ describe("DisruptionIndexConnected", () => {
       id: "1",
       disruptionId: "1",
       startDate: today,
-      endDate: nextWeek,
+      endDate,
       isActive: true,
       adjustments: [
         new Adjustment({


### PR DESCRIPTION
This test meant to create a 7-day date span, but used "today + 7 days" rather than "today + 6 days", so the end date fell on the same day of the week as the start date. Since the test disruption was active on Monday, when the current day was Monday this caused the disruption to appear in the calendar twice, failing the test.
