### PR TITLE
ci: fix deploy failing on new Debian release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM hexpm/elixir:1.11.4-erlang-23.3-debian-buster-20210208 as builder
 ENV LANG=C.UTF-8 \
   MIX_ENV=prod
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  ca-certificates curl git
+RUN apt-get update --allow-releaseinfo-change && \
+  apt-get install -y --no-install-recommends ca-certificates curl git
 
 # Instructions from:
 # https://github.com/nodesource/distributions/blob/master/README.md
@@ -25,9 +25,9 @@ RUN mix local.hex --force && \
 
 FROM debian:buster
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  libssl1.1 libsctp1 curl \
-  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update --allow-releaseinfo-change && \
+  apt-get install -y --no-install-recommends libssl1.1 libsctp1 curl && \
+  rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root
 EXPOSE 4000


### PR DESCRIPTION
Buster is no longer the current stable release of Debian, causing an error when running `apt-get update` in an image built when Buster _was_ the stable release:

```
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
```

The `--allow-releaseinfo-change` option allows the update to continue.

* [Failed deployment of `master`](https://github.com/mbta/arrow/actions/runs/1139595707)
* [Successful deployment of this branch](https://github.com/mbta/arrow/actions/runs/1139760603)