### PR TITLE
dev: add TypeScript watcher to dev server

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -22,7 +22,8 @@ config :arrow, ArrowWeb.Endpoint,
   check_origin: false,
   secret_key_base: "local_secret_key_base_at_least_64_bytes_________________________________",
   watchers: [
-    mix: ~w(esbuild default --sourcemap=inline --watch)
+    mix: ~w(esbuild default --sourcemap=inline --watch),
+    node: ~w(assets/node_modules/.bin/tsc --project assets --noEmit --watch --preserveWatchOutput)
   ]
 
 config :arrow, ArrowWeb.AuthManager, secret_key: "test key"


### PR DESCRIPTION
Lets you know about type errors while running the dev server, just like old times!