### PR TITLE
Space out adjustment names in select box

### DIFF
--- a/assets/src/components/DisruptionForm.tsx
+++ b/assets/src/components/DisruptionForm.tsx
@@ -9,7 +9,7 @@ enum TransitMode {
 }
 
 type TimeRange = { start: string | null; end: string | null }
-type Adjustment = { id: number; routeId: string; sourceLabel: string }
+type Adjustment = { id: number; label: string; routeId: string }
 type DaysOfWeek = { [dayName: string]: TimeRange }
 type DisruptionRevision = {
   startDate: string | null
@@ -42,7 +42,7 @@ const whichTripsLabels: ["all" | "some", string][] = [
 
 const adjustmentSelectOption = (adjustment: Adjustment) => {
   return {
-    label: adjustment.sourceLabel,
+    label: adjustment.label,
     value: adjustment.id,
     data: adjustment,
   }

--- a/assets/tests/components/DisruptionForm.test.tsx
+++ b/assets/tests/components/DisruptionForm.test.tsx
@@ -6,10 +6,10 @@ import { pickDate } from "../testHelpers"
 
 describe("DisruptionForm", () => {
   const adjustments = [
-    { id: 1, routeId: "Red", sourceLabel: "Alewife" },
-    { id: 2, routeId: "Blue", sourceLabel: "Bowdoin" },
-    { id: 3, routeId: "CR-Lowell", sourceLabel: "Lowell" },
-    { id: 4, routeId: "CR-Worcester", sourceLabel: "Worcester" },
+    { id: 1, label: "Alewife", routeId: "Red" },
+    { id: 2, label: "Bowdoin", routeId: "Blue" },
+    { id: 3, label: "Lowell", routeId: "CR-Lowell" },
+    { id: 4, label: "Worcester", routeId: "CR-Worcester" },
   ]
 
   const blankRevision = {
@@ -33,9 +33,7 @@ describe("DisruptionForm", () => {
             ...blankRevision,
             startDate: "2021-01-01",
             endDate: "2021-01-31",
-            adjustments: [
-              { id: 3, routeId: "CR-Lowell", sourceLabel: "Lowell" },
-            ],
+            adjustments: [{ id: 3, label: "Lowell", routeId: "CR-Lowell" }],
             daysOfWeek: {
               monday: { start: null, end: null },
               tuesday: { start: "20:00:00", end: null },

--- a/lib/arrow/adjustment.ex
+++ b/lib/arrow/adjustment.ex
@@ -38,6 +38,10 @@ defmodule Arrow.Adjustment do
     timestamps(type: :utc_datetime)
   end
 
+  @doc "Returns all adjustments, sorted by label."
+  @spec all() :: [t()]
+  def all, do: Repo.all(from a in __MODULE__, order_by: :source_label)
+
   @doc false
   @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(adjustment, attrs) do

--- a/lib/arrow/adjustment.ex
+++ b/lib/arrow/adjustment.ex
@@ -52,6 +52,17 @@ defmodule Arrow.Adjustment do
   end
 
   @doc """
+  Returns a version of the adjustment's `source_label` with spaces between words. Attempts to
+  correctly handle uppercased acronyms such as "JFK" or "SL2".
+  """
+  @spec display_label(t()) :: String.t()
+  def display_label(%__MODULE__{source_label: source_label}) do
+    source_label
+    |> String.replace(~r/([[:lower:]])([[:upper:]\d])/, "\\1 \\2")
+    |> String.replace(~r/([[:upper:]\d])([[:upper:]\d])(?=[[:lower:]])/, "\\1 \\2")
+  end
+
+  @doc """
   Fetches the adjustments corresponding to the given `DisruptionRevision` changeset parameters.
   Allows us to `put_assoc` adjustments when building a revision changeset, since `many_to_many`
   associations don't support updating values in the join table using `cast_assoc`.

--- a/lib/arrow_web/controllers/disruption_controller.ex
+++ b/lib/arrow_web/controllers/disruption_controller.ex
@@ -2,7 +2,7 @@ defmodule ArrowWeb.DisruptionController do
   use ArrowWeb, :controller
 
   alias __MODULE__.{Filters, Index}
-  alias Arrow.{Adjustment, Disruption, DisruptionRevision, Repo}
+  alias Arrow.{Adjustment, Disruption, DisruptionRevision}
   alias ArrowWeb.ErrorHelpers
   alias Ecto.Changeset
 
@@ -18,7 +18,7 @@ defmodule ArrowWeb.DisruptionController do
 
   def new(conn, _params) do
     changeset = DisruptionRevision.new() |> Changeset.change()
-    render(conn, "new.html", adjustments: adjustments(), changeset: changeset)
+    render(conn, "new.html", adjustments: Adjustment.all(), changeset: changeset)
   end
 
   def edit(conn, %{"id" => id}) do
@@ -26,7 +26,7 @@ defmodule ArrowWeb.DisruptionController do
 
     render(conn, "edit.html",
       id: id,
-      adjustments: adjustments(),
+      adjustments: Adjustment.all(),
       changeset: Changeset.change(revision)
     )
   end
@@ -41,7 +41,7 @@ defmodule ArrowWeb.DisruptionController do
       {:error, changeset} ->
         conn
         |> put_flash(:errors, {"Disruption could not be created:", errors(changeset)})
-        |> render("new.html", adjustments: adjustments(), changeset: changeset)
+        |> render("new.html", adjustments: Adjustment.all(), changeset: changeset)
     end
   end
 
@@ -55,7 +55,7 @@ defmodule ArrowWeb.DisruptionController do
       {:error, changeset} ->
         conn
         |> put_flash(:errors, {"Disruption could not be updated:", errors(changeset)})
-        |> render("edit.html", adjustments: adjustments(), changeset: changeset, id: id)
+        |> render("edit.html", adjustments: Adjustment.all(), changeset: changeset, id: id)
     end
   end
 
@@ -63,8 +63,6 @@ defmodule ArrowWeb.DisruptionController do
     _revision = Disruption.delete!(id)
     redirect(conn, to: Routes.disruption_path(conn, :show, id))
   end
-
-  defp adjustments, do: Repo.all(Adjustment)
 
   defp errors(changeset) do
     changeset

--- a/lib/arrow_web/controllers/disruption_controller/index.ex
+++ b/lib/arrow_web/controllers/disruption_controller/index.ex
@@ -62,9 +62,7 @@ defmodule ArrowWeb.DisruptionController.Index do
            [
              {:adjustments, ^from(a in Adjustment, order_by: :source_label)},
              :days_of_week,
-             :exceptions,
-             # Required (but unused) for JSON:API serialization for the calendar
-             :trip_short_names
+             :exceptions
            ]}
       ]
   end

--- a/lib/arrow_web/views/disruption_view/form.ex
+++ b/lib/arrow_web/views/disruption_view/form.ex
@@ -30,8 +30,8 @@ defmodule ArrowWeb.DisruptionView.Form do
     }
   end
 
-  defp encode_adjustment(%Adjustment{id: id, route_id: route_id, source_label: source_label}) do
-    %{"id" => id, "routeId" => route_id, "sourceLabel" => source_label}
+  defp encode_adjustment(%Adjustment{id: id, route_id: route_id} = adjustment) do
+    %{"id" => id, "label" => Adjustment.display_label(adjustment), "routeId" => route_id}
   end
 
   defp encode_day_of_week(%DayOfWeek{

--- a/test/arrow/adjustment_test.exs
+++ b/test/arrow/adjustment_test.exs
@@ -38,6 +38,17 @@ defmodule Arrow.AdjustmentTest do
     end
   end
 
+  describe "display_label/1" do
+    defp display_label(label), do: Adjustment.display_label(%Adjustment{source_label: label})
+
+    test "returns a friendlier label for the adjustment" do
+      assert display_label("AirportBowdoinExpress") == "Airport Bowdoin Express"
+      assert display_label("GreenEStopAtBrighamCircle") == "Green E Stop At Brigham Circle"
+      assert display_label("AshmontJFK") == "Ashmont JFK"
+      assert display_label("SL2NoTransitwayAM") == "SL2 No Transitway AM"
+    end
+  end
+
   describe "from_revision_attrs/1" do
     test "fetches adjustments for DisruptionRevision changeset params" do
       [%{id: id1}, _, %{id: id2}] = insert_list(3, :adjustment)

--- a/test/arrow_web/views/disruption_view/form_test.exs
+++ b/test/arrow_web/views/disruption_view/form_test.exs
@@ -29,13 +29,13 @@ defmodule ArrowWeb.DisruptionView.FormTest do
 
       expected = %{
         "allAdjustments" => [
-          %{"id" => 1, "routeId" => "Red", "sourceLabel" => "Kendall"},
-          %{"id" => 2, "routeId" => "Orange", "sourceLabel" => "Wellington"}
+          %{"id" => 1, "label" => "Kendall", "routeId" => "Red"},
+          %{"id" => 2, "label" => "Wellington", "routeId" => "Orange"}
         ],
         "disruptionRevision" => %{
           "startDate" => ~D[2021-01-01],
           "endDate" => ~D[2021-02-28],
-          "adjustments" => [%{"id" => 1, "routeId" => "Red", "sourceLabel" => "Kendall"}],
+          "adjustments" => [%{"id" => 1, "label" => "Kendall", "routeId" => "Red"}],
           "daysOfWeek" => %{"monday" => %{"start" => ~T[21:15:00], "end" => nil}},
           "exceptions" => [~D[2021-01-11]],
           "tripShortNames" => "one,two"


### PR DESCRIPTION
**Asana:** [🏹 Adjustments shown with spaces aka "pretty name" ](https://app.asana.com/0/584764604969369/1200681721075711)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
