### PR TITLE
fix: vertical alignment of route filter links

### DIFF
--- a/lib/arrow_web/templates/disruption/index.html.eex
+++ b/lib/arrow_web/templates/disruption/index.html.eex
@@ -41,7 +41,7 @@
 
         <%= link(
               route_icon(@conn, route, "lg"),
-              class: "mr-1 m-disruption-index__route_filter #{active_class}",
+              class: "d-flex mr-1 m-disruption-index__route_filter #{active_class}",
               "aria-label": route,
               to: update_filters_path(@conn, Filters.toggle_route(@filters, route))
             ) %>


### PR DESCRIPTION
**Asana:** [🏹 Vertically align line icons and pill boxes](https://app.asana.com/0/881264583703207/1199550046000737)

![Screen Shot 2021-09-20 at 4 04 37 PM](https://user-images.githubusercontent.com/394835/134067681-c9c9c556-2ec9-4a87-b012-d2acf52979d8.png)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
