### PR TITLE
feat: default time range for subway disruptions

### DIFF
--- a/assets/src/components/DisruptionForm.tsx
+++ b/assets/src/components/DisruptionForm.tsx
@@ -48,6 +48,14 @@ const adjustmentSelectOption = (adjustment: Adjustment) => {
   }
 }
 
+const defaultTimeRange = (mode: TransitMode, day: string): TimeRange => {
+  if (mode === TransitMode.Subway && day !== "saturday" && day !== "sunday") {
+    return { start: "20:45:00", end: null }
+  } else {
+    return { start: null, end: null }
+  }
+}
+
 const modeForRoute = (route: string): TransitMode =>
   route.startsWith("CR-") ? TransitMode.CommuterRail : TransitMode.Subway
 
@@ -100,7 +108,10 @@ const DisruptionForm = ({
     new Map(days.map((day) => [day, initialDaysOfWeek[day] || null]))
   )
   const toggleDayOfWeek = (day: string) => {
-    const newValue = daysOfWeek.get(day) ? null : { start: null, end: null }
+    const newValue = daysOfWeek.get(day)
+      ? null
+      : defaultTimeRange(transitMode, day)
+
     setDaysOfWeek((prev) => new Map(prev).set(day, newValue))
   }
 

--- a/assets/tests/components/DisruptionForm.test.tsx
+++ b/assets/tests/components/DisruptionForm.test.tsx
@@ -56,8 +56,8 @@ describe("DisruptionForm", () => {
     userEvent.click(days.getByText("Wed"))
     const wednesday = withinFieldset("Wednesday")
     userEvent.click(wednesday.getByLabelText("Start of service"))
-    userEvent.selectOptions(wednesday.getByLabelText("start hour"), "8")
-    userEvent.selectOptions(wednesday.getByLabelText("start minute"), "45")
+    userEvent.selectOptions(wednesday.getByLabelText("start hour"), "4")
+    userEvent.selectOptions(wednesday.getByLabelText("start minute"), "30")
     userEvent.selectOptions(wednesday.getByLabelText("start meridiem"), "PM")
     userEvent.click(screen.getAllByLabelText("remove")[0])
     userEvent.click(screen.getByRole("button", { name: /add an exception/ }))
@@ -72,7 +72,7 @@ describe("DisruptionForm", () => {
       "revision[days_of_week][0][start_time]": "20:00:00",
       "revision[days_of_week][0][end_time]": "",
       "revision[days_of_week][1][day_name]": "wednesday",
-      "revision[days_of_week][1][start_time]": "20:45:00",
+      "revision[days_of_week][1][start_time]": "16:30:00",
       "revision[days_of_week][1][end_time]": "",
       "revision[exceptions][][excluded_date]": ["2021-01-12", "2021-01-13"],
       "revision[trip_short_names][][trip_short_name]": ["trip1", "trip3"],
@@ -101,5 +101,26 @@ describe("DisruptionForm", () => {
     expect(adjusts.queryByText("Bowdoin")).not.toBeInTheDocument()
     expect(adjusts.queryByText("Lowell")).toBeInTheDocument()
     expect(adjusts.queryByText("Worcester")).toBeInTheDocument()
+  })
+
+  test("defaults subway disruptions to start at 8:45PM on weekdays", () => {
+    render(
+      <DisruptionForm
+        allAdjustments={adjustments}
+        disruptionRevision={blankRevision}
+      />
+    )
+
+    userEvent.click(screen.getByLabelText("Subway"))
+    userEvent.click(withinFieldset("Choose days of week").getByText("Mon"))
+    const monday = withinFieldset("Monday")
+    expect(monday.getByLabelText("start hour")).toHaveValue("8")
+    expect(monday.getByLabelText("start minute")).toHaveValue("45")
+    expect(monday.getByLabelText("start meridiem")).toHaveValue("PM")
+
+    userEvent.click(screen.getByLabelText("Commuter Rail"))
+    userEvent.click(withinFieldset("Choose days of week").getByText("Tue"))
+    const tuesday = withinFieldset("Tuesday")
+    expect(tuesday.getByLabelText("Start of service")).toBeChecked()
   })
 })

--- a/test/integration/disruptions_test.exs
+++ b/test/integration/disruptions_test.exs
@@ -64,7 +64,7 @@ defmodule Arrow.Integration.DisruptionsTest do
     assert revision_day.day_name ==
              now |> Calendar.strftime("%A") |> String.downcase()
 
-    assert revision_day.start_time == nil
+    assert revision_day.start_time == ~T[20:45:00]
     assert revision_day.end_time == nil
     assert Enum.at(revision.adjustments, 0).source_label == adjustment.source_label
   end


### PR DESCRIPTION
**Asana:** [🏹 Weekday disruptions have default start time of 845pm ](https://app.asana.com/0/881264583703207/1200908109398090)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
