### PR TITLE
feat: Add ROW status concept

### DIFF
--- a/assets/src/components/DisruptionForm.tsx
+++ b/assets/src/components/DisruptionForm.tsx
@@ -89,8 +89,7 @@ const DisruptionForm = ({
     tripShortNames: initialTripShortNames,
   },
 }: DisruptionFormProps) => {
-  const [isRowConfirmed, setIsRowConfirmed] =
-    useState<boolean>(initialRowConfirmed)
+  const [isRowConfirmed, setIsRowConfirmed] = useState(initialRowConfirmed)
 
   const [transitMode, setTransitMode] = useState<TransitMode>(
     initialAdjustments.length === 0
@@ -150,7 +149,7 @@ const DisruptionForm = ({
             <input
               className="form-check-input"
               type="radio"
-              name="row_confirmed"
+              name="revision[row_confirmed]"
               value={`${rowValue}`}
               checked={rowValue === isRowConfirmed}
               onChange={() => {

--- a/assets/src/components/DisruptionForm.tsx
+++ b/assets/src/components/DisruptionForm.tsx
@@ -14,6 +14,7 @@ type DaysOfWeek = { [dayName: string]: TimeRange }
 type DisruptionRevision = {
   startDate: string | null
   endDate: string | null
+  rowConfirmed: boolean
   adjustments: Adjustment[]
   daysOfWeek: DaysOfWeek
   exceptions: string[]
@@ -28,6 +29,11 @@ const days = [
   "friday",
   "saturday",
   "sunday",
+]
+
+const rowStatusLabels: [boolean, string][] = [
+  [true, "Approved"],
+  [false, "Pending"],
 ]
 
 const transitModeLabels: [TransitMode, string][] = [
@@ -76,12 +82,16 @@ const DisruptionForm = ({
   disruptionRevision: {
     startDate: initialStartDate,
     endDate: initialEndDate,
+    rowConfirmed: initialRowConfirmed,
     adjustments: initialAdjustments,
     daysOfWeek: initialDaysOfWeek,
     exceptions: initialExceptions,
     tripShortNames: initialTripShortNames,
   },
 }: DisruptionFormProps) => {
+  const [isRowConfirmed, setIsRowConfirmed] =
+    useState<boolean>(initialRowConfirmed)
+
   const [transitMode, setTransitMode] = useState<TransitMode>(
     initialAdjustments.length === 0
       ? TransitMode.Subway
@@ -133,6 +143,24 @@ const DisruptionForm = ({
 
   return (
     <>
+      <fieldset>
+        <legend>approval status</legend>
+        {rowStatusLabels.map(([rowValue, rowLabel]) => (
+          <label key={rowLabel} className="form-check form-check-label">
+            <input
+              className="form-check-input"
+              type="radio"
+              name="row_confirmed"
+              value={`${rowValue}`}
+              checked={rowValue === isRowConfirmed}
+              onChange={() => {
+                setIsRowConfirmed(rowValue)
+              }}
+            />
+            {rowLabel}
+          </label>
+        ))}
+      </fieldset>
       <fieldset>
         <legend>mode</legend>
 

--- a/assets/tests/components/DisruptionForm.test.tsx
+++ b/assets/tests/components/DisruptionForm.test.tsx
@@ -15,6 +15,7 @@ describe("DisruptionForm", () => {
   const blankRevision = {
     startDate: null,
     endDate: null,
+    rowConfirmed: true,
     adjustments: [],
     daysOfWeek: {},
     exceptions: [],
@@ -33,6 +34,7 @@ describe("DisruptionForm", () => {
             ...blankRevision,
             startDate: "2021-01-01",
             endDate: "2021-01-31",
+            rowConfirmed: true,
             adjustments: [{ id: 3, label: "Lowell", routeId: "CR-Lowell" }],
             daysOfWeek: {
               monday: { start: null, end: null },

--- a/lib/arrow/disruption_revision.ex
+++ b/lib/arrow/disruption_revision.ex
@@ -29,7 +29,7 @@ defmodule Arrow.DisruptionRevision do
     field(:end_date, :date)
     field(:start_date, :date)
     field(:is_active, :boolean)
-    field(:row_confirmed, :boolean, default: false)
+    field(:row_confirmed, :boolean, default: true)
 
     belongs_to(:disruption, Disruption)
     has_many(:days_of_week, DayOfWeek, on_replace: :delete)

--- a/lib/arrow/disruption_revision.ex
+++ b/lib/arrow/disruption_revision.ex
@@ -29,6 +29,7 @@ defmodule Arrow.DisruptionRevision do
     field(:end_date, :date)
     field(:start_date, :date)
     field(:is_active, :boolean)
+    field(:row_confirmed, :boolean, default: false)
 
     belongs_to(:disruption, Disruption)
     has_many(:days_of_week, DayOfWeek, on_replace: :delete)
@@ -49,7 +50,7 @@ defmodule Arrow.DisruptionRevision do
   @spec changeset(t(), map) :: Changeset.t(t())
   def changeset(revision, attrs) do
     revision
-    |> Changeset.cast(attrs, [:start_date, :end_date])
+    |> Changeset.cast(attrs, [:start_date, :end_date, :row_confirmed])
     |> Changeset.put_assoc(:adjustments, Adjustment.from_revision_attrs(attrs))
     |> Changeset.cast_assoc(:days_of_week,
       with: &DayOfWeek.changeset/2,
@@ -58,7 +59,7 @@ defmodule Arrow.DisruptionRevision do
     )
     |> Changeset.cast_assoc(:exceptions, with: &Exception.changeset/2)
     |> Changeset.cast_assoc(:trip_short_names, with: &TripShortName.changeset/2)
-    |> Changeset.validate_required([:start_date, :end_date])
+    |> Changeset.validate_required([:start_date, :end_date, :row_confirmed])
     |> Changeset.validate_length(:days_of_week, min: 1)
     |> validate_days_of_week_between_start_and_end_date()
     |> validate_exceptions_are_applicable()

--- a/lib/arrow_web/controllers/disruption_controller.ex
+++ b/lib/arrow_web/controllers/disruption_controller.ex
@@ -32,6 +32,8 @@ defmodule ArrowWeb.DisruptionController do
   end
 
   def create(conn, %{"revision" => attrs}) do
+    attrs = update_in(attrs["row_confirmed"], &boolify_row_value/1)
+
     case Disruption.create(attrs) do
       {:ok, id} ->
         conn
@@ -46,6 +48,8 @@ defmodule ArrowWeb.DisruptionController do
   end
 
   def update(conn, %{"id" => id, "revision" => attrs}) do
+    attrs = update_in(attrs["row_confirmed"], &boolify_row_value/1)
+
     case Disruption.update(id, attrs) do
       {:ok, id} ->
         conn
@@ -69,4 +73,7 @@ defmodule ArrowWeb.DisruptionController do
     |> Changeset.traverse_errors(&ErrorHelpers.translate_error/1)
     |> ErrorHelpers.flatten_errors()
   end
+
+  defp boolify_row_value("false"), do: false
+  defp boolify_row_value(_), do: true
 end

--- a/lib/arrow_web/controllers/disruption_controller.ex
+++ b/lib/arrow_web/controllers/disruption_controller.ex
@@ -32,8 +32,6 @@ defmodule ArrowWeb.DisruptionController do
   end
 
   def create(conn, %{"revision" => attrs}) do
-    attrs = update_in(attrs["row_confirmed"], &boolify_row_value/1)
-
     case Disruption.create(attrs) do
       {:ok, id} ->
         conn
@@ -48,8 +46,6 @@ defmodule ArrowWeb.DisruptionController do
   end
 
   def update(conn, %{"id" => id, "revision" => attrs}) do
-    attrs = update_in(attrs["row_confirmed"], &boolify_row_value/1)
-
     case Disruption.update(id, attrs) do
       {:ok, id} ->
         conn
@@ -73,7 +69,4 @@ defmodule ArrowWeb.DisruptionController do
     |> Changeset.traverse_errors(&ErrorHelpers.translate_error/1)
     |> ErrorHelpers.flatten_errors()
   end
-
-  defp boolify_row_value("false"), do: false
-  defp boolify_row_value(_), do: true
 end

--- a/lib/arrow_web/templates/feed/disruption_summary.html.eex
+++ b/lib/arrow_web/templates/feed/disruption_summary.html.eex
@@ -3,6 +3,9 @@
   <dl>
     <div class="flex flex-col md:flex-row">
       <div class="flex-1">
+        <dt class="mt-3">ROW Status</dt>
+        <dd> <%= if @revision.row_confirmed, do: "Confirmed", else: "Pending" %></dd>
+
         <dt class="mt-3">Adjustments</dt>
         <dd>
           <%= for a <- @revision.adjustments do %>

--- a/lib/arrow_web/views/disruption_view/form.ex
+++ b/lib/arrow_web/views/disruption_view/form.ex
@@ -11,6 +11,7 @@ defmodule ArrowWeb.DisruptionView.Form do
     %DisruptionRevision{
       start_date: start_date,
       end_date: end_date,
+      row_confirmed: row_confirmed,
       adjustments: adjustments,
       days_of_week: days_of_week,
       exceptions: exceptions,
@@ -22,6 +23,7 @@ defmodule ArrowWeb.DisruptionView.Form do
       "disruptionRevision" => %{
         "startDate" => start_date,
         "endDate" => end_date,
+        "rowConfirmed" => row_confirmed,
         "adjustments" => Enum.map(adjustments, &encode_adjustment/1),
         "daysOfWeek" => days_of_week |> Enum.map(&encode_day_of_week/1) |> Enum.into(%{}),
         "exceptions" => Enum.map(exceptions, & &1.excluded_date),

--- a/priv/repo/migrations/20210921192435_add_row_status.exs
+++ b/priv/repo/migrations/20210921192435_add_row_status.exs
@@ -1,0 +1,9 @@
+defmodule Arrow.Repo.Migrations.AddRowStatus do
+  use Ecto.Migration
+
+  def change do
+    alter table(:disruption_revisions) do
+      add :row_confirmed, :boolean, null: false, default: true
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.18
+-- Dumped from database version 11.13
 -- Dumped by pg_dump version 13.4
 
 SET statement_timeout = 0;
@@ -204,7 +204,8 @@ CREATE TABLE public.disruption_revisions (
     updated_at timestamp with time zone NOT NULL,
     disruption_id bigint NOT NULL,
     author character varying(255),
-    is_active boolean DEFAULT true
+    is_active boolean DEFAULT true,
+    row_confirmed boolean DEFAULT true NOT NULL
 );
 
 
@@ -565,3 +566,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20200812222513);
 INSERT INTO public."schema_migrations" (version) VALUES (20200909124316);
 INSERT INTO public."schema_migrations" (version) VALUES (20200925153736);
 INSERT INTO public."schema_migrations" (version) VALUES (20210816185635);
+INSERT INTO public."schema_migrations" (version) VALUES (20210921192435);

--- a/test/arrow/disruption_test.exs
+++ b/test/arrow/disruption_test.exs
@@ -71,6 +71,7 @@ defmodule Arrow.DisruptionTest do
       attrs = %{
         "start_date" => "2021-01-01",
         "end_date" => "2021-12-31",
+        "row_confirmed" => "true",
         "adjustments" => [%{"id" => insert(:adjustment).id}],
         "days_of_week" => [%{"day_name" => "monday", "start_time" => "20:00:00"}],
         "exceptions" => [%{"excluded_date" => "2021-01-11"}],
@@ -89,6 +90,7 @@ defmodule Arrow.DisruptionTest do
       assert dr.disruption_id == d.id
       assert dr.start_date == ~D[2021-01-01]
       assert dr.end_date == ~D[2021-12-31]
+      assert dr.row_confirmed == true
 
       assert [%DayOfWeek{day_name: "monday", start_time: ~T[20:00:00], end_time: nil}] =
                dr.days_of_week
@@ -186,6 +188,7 @@ defmodule Arrow.DisruptionTest do
       attrs = %{
         "start_date" => "2021-01-01",
         "end_date" => "2021-11-30",
+        "row_confirmed" => false,
         "days_of_week" => [%{"day_name" => "monday", "start_time" => "20:45:00"}],
         "exceptions" => [%{"excluded_date" => "2021-01-11"}, %{"excluded_date" => "2021-01-18"}],
         "trip_short_names" => [%{"trip_short_name" => "777"}, %{"trip_short_name" => "888"}]
@@ -206,6 +209,7 @@ defmodule Arrow.DisruptionTest do
       assert new_dr.is_active
       assert new_dr.start_date == ~D[2021-01-01]
       assert new_dr.end_date == ~D[2021-11-30]
+      assert new_dr.row_confirmed == false
 
       assert [%DayOfWeek{day_name: "monday", start_time: ~T[20:45:00], end_time: nil}] =
                new_dr.days_of_week

--- a/test/arrow_web/controllers/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/disruption_controller_test.exs
@@ -53,6 +53,7 @@ defmodule ArrowWeb.DisruptionControllerTest do
         "revision" => %{
           "start_date" => "2021-01-01",
           "end_date" => "2021-01-07",
+          "row_confirmed" => "false",
           "days_of_week" => %{
             "0" => %{"day_name" => "friday", "start_time" => "20:45:00"},
             "1" => %{"day_name" => "saturday"}

--- a/test/arrow_web/views/disruption_view/form_test.exs
+++ b/test/arrow_web/views/disruption_view/form_test.exs
@@ -17,6 +17,7 @@ defmodule ArrowWeb.DisruptionView.FormTest do
         %DisruptionRevision{
           start_date: ~D[2021-01-01],
           end_date: ~D[2021-01-31],
+          row_confirmed: true,
           adjustments: [hd(adjustments)],
           days_of_week: [%DayOfWeek{day_name: "monday", start_time: ~T[21:15:00], end_time: nil}],
           exceptions: [%Exception{excluded_date: ~D[2021-01-11]}],
@@ -35,6 +36,7 @@ defmodule ArrowWeb.DisruptionView.FormTest do
         "disruptionRevision" => %{
           "startDate" => ~D[2021-01-01],
           "endDate" => ~D[2021-02-28],
+          "rowConfirmed" => true,
           "adjustments" => [%{"id" => 1, "label" => "Kendall", "routeId" => "Red"}],
           "daysOfWeek" => %{"monday" => %{"start" => ~T[21:15:00], "end" => nil}},
           "exceptions" => [~D[2021-01-11]],

--- a/test/integration/disruptions_test.exs
+++ b/test/integration/disruptions_test.exs
@@ -36,6 +36,7 @@ defmodule Arrow.Integration.DisruptionsTest do
       |> visit("/")
       |> click(link("create new"))
       |> assert_text("create new disruption")
+      |> click(text("Pending"))
       |> click(text("Select..."))
       |> click(text(adjustment.source_label))
       |> fill_in(text_field("start"), with: date)
@@ -58,6 +59,7 @@ defmodule Arrow.Integration.DisruptionsTest do
 
     assert revision.start_date == now |> DateTime.to_date()
     assert revision.end_date == now |> DateTime.to_date()
+    assert revision.row_confirmed == false
     assert Enum.count(revision.days_of_week) == 1
     revision_day = Enum.at(revision.days_of_week, 0)
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Add ROW status concept](https://app.asana.com/0/584764604969369/1200687441670232)

Adds the concept of "ROW status" to the app, where a Disruption (revision) can be either approved or pending. A subsequent PR will update GTFS Creator to ignore pending disruptions.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
