### PR TITLE
fix: ROW status tweaks

### DIFF
--- a/assets/src/components/DisruptionForm.tsx
+++ b/assets/src/components/DisruptionForm.tsx
@@ -14,7 +14,7 @@ type DaysOfWeek = { [dayName: string]: TimeRange }
 type DisruptionRevision = {
   startDate: string | null
   endDate: string | null
-  rowConfirmed: boolean
+  rowApproved: boolean
   adjustments: Adjustment[]
   daysOfWeek: DaysOfWeek
   exceptions: string[]
@@ -82,14 +82,14 @@ const DisruptionForm = ({
   disruptionRevision: {
     startDate: initialStartDate,
     endDate: initialEndDate,
-    rowConfirmed: initialRowConfirmed,
+    rowApproved: initialRowApproved,
     adjustments: initialAdjustments,
     daysOfWeek: initialDaysOfWeek,
     exceptions: initialExceptions,
     tripShortNames: initialTripShortNames,
   },
 }: DisruptionFormProps) => {
-  const [isRowConfirmed, setIsRowConfirmed] = useState(initialRowConfirmed)
+  const [isRowApproved, setIsRowApproved] = useState(initialRowApproved)
 
   const [transitMode, setTransitMode] = useState<TransitMode>(
     initialAdjustments.length === 0
@@ -149,11 +149,11 @@ const DisruptionForm = ({
             <input
               className="form-check-input"
               type="radio"
-              name="revision[row_confirmed]"
+              name="revision[row_approved]"
               value={`${rowValue}`}
-              checked={rowValue === isRowConfirmed}
+              checked={rowValue === isRowApproved}
               onChange={() => {
-                setIsRowConfirmed(rowValue)
+                setIsRowApproved(rowValue)
               }}
             />
             {rowLabel}

--- a/assets/tests/components/DisruptionForm.test.tsx
+++ b/assets/tests/components/DisruptionForm.test.tsx
@@ -15,7 +15,7 @@ describe("DisruptionForm", () => {
   const blankRevision = {
     startDate: null,
     endDate: null,
-    rowConfirmed: true,
+    rowApproved: true,
     adjustments: [],
     daysOfWeek: {},
     exceptions: [],
@@ -34,7 +34,7 @@ describe("DisruptionForm", () => {
             ...blankRevision,
             startDate: "2021-01-01",
             endDate: "2021-01-31",
-            rowConfirmed: true,
+            rowApproved: true,
             adjustments: [{ id: 3, label: "Lowell", routeId: "CR-Lowell" }],
             daysOfWeek: {
               monday: { start: null, end: null },

--- a/lib/arrow/db_structure.ex
+++ b/lib/arrow/db_structure.ex
@@ -47,6 +47,7 @@ defmodule Arrow.DBStructure do
           :id,
           :start_date,
           :end_date,
+          :row_approved,
           :is_active,
           :disruption_id,
           :inserted_at,

--- a/lib/arrow/disruption_revision.ex
+++ b/lib/arrow/disruption_revision.ex
@@ -15,6 +15,7 @@ defmodule Arrow.DisruptionRevision do
           id: id,
           end_date: Date.t() | nil,
           start_date: Date.t() | nil,
+          row_approved: boolean(),
           is_active: boolean(),
           disruption: Disruption.t() | Ecto.Association.NotLoaded.t(),
           days_of_week: [DayOfWeek.t()] | Ecto.Association.NotLoaded.t(),
@@ -29,7 +30,7 @@ defmodule Arrow.DisruptionRevision do
     field(:end_date, :date)
     field(:start_date, :date)
     field(:is_active, :boolean)
-    field(:row_confirmed, :boolean, default: true)
+    field(:row_approved, :boolean, default: true)
 
     belongs_to(:disruption, Disruption)
     has_many(:days_of_week, DayOfWeek, on_replace: :delete)
@@ -50,7 +51,7 @@ defmodule Arrow.DisruptionRevision do
   @spec changeset(t(), map) :: Changeset.t(t())
   def changeset(revision, attrs) do
     revision
-    |> Changeset.cast(attrs, [:start_date, :end_date, :row_confirmed])
+    |> Changeset.cast(attrs, [:start_date, :end_date, :row_approved])
     |> Changeset.put_assoc(:adjustments, Adjustment.from_revision_attrs(attrs))
     |> Changeset.cast_assoc(:days_of_week,
       with: &DayOfWeek.changeset/2,
@@ -59,7 +60,7 @@ defmodule Arrow.DisruptionRevision do
     )
     |> Changeset.cast_assoc(:exceptions, with: &Exception.changeset/2)
     |> Changeset.cast_assoc(:trip_short_names, with: &TripShortName.changeset/2)
-    |> Changeset.validate_required([:start_date, :end_date, :row_confirmed])
+    |> Changeset.validate_required([:start_date, :end_date, :row_approved])
     |> Changeset.validate_length(:days_of_week, min: 1)
     |> validate_days_of_week_between_start_and_end_date()
     |> validate_exceptions_are_applicable()
@@ -101,9 +102,10 @@ defmodule Arrow.DisruptionRevision do
       :disruption_id,
       :start_date,
       :end_date,
+      :row_approved,
       :is_active
     ])
-    |> Ecto.Changeset.validate_required([:disruption_id, :is_active])
+    |> Ecto.Changeset.validate_required([:disruption_id, :is_active, :row_approved])
     |> Ecto.Changeset.put_assoc(:adjustments, adjustments)
     |> Ecto.Changeset.put_assoc(:days_of_week, days_of_week)
     |> Ecto.Changeset.put_assoc(:exceptions, exceptions)

--- a/lib/arrow_web/templates/disruption/_table.html.eex
+++ b/lib/arrow_web/templates/disruption/_table.html.eex
@@ -5,7 +5,7 @@
       <th><%= sort_link(@conn, @filters, :start_date, "date range") %></th>
       <th>except</th>
       <th>time period</th>
-      <th>status</th>
+      <th>GTFS status</th>
       <th><%= sort_link(@conn, @filters, :id, "ID") %></th>
     </tr>
   </thead>

--- a/lib/arrow_web/templates/disruption/show.html.eex
+++ b/lib/arrow_web/templates/disruption/show.html.eex
@@ -40,6 +40,16 @@
 
       <div class="col-md-10 <%= inactive_class %>">
         <div class="mb-3">
+          <h4>approval status</h4>
+
+          <div class="pl-3">
+            <span class="m-disruption-details__row_status">
+              <%= if @revision.row_approved, do: "Approved", else: "Pending" %>
+            </span>
+          </div>
+        </div>
+
+        <div class="mb-3">
           <h4>date range</h4>
 
           <div class="pl-3">

--- a/lib/arrow_web/templates/disruption/show.html.eex
+++ b/lib/arrow_web/templates/disruption/show.html.eex
@@ -43,9 +43,7 @@
           <h4>approval status</h4>
 
           <div class="pl-3">
-            <span class="m-disruption-details__row_status">
-              <%= if @revision.row_approved, do: "Approved", else: "Pending" %>
-            </span>
+            <%= if @revision.row_approved, do: "Approved", else: "Pending" %>
           </div>
         </div>
 

--- a/lib/arrow_web/templates/feed/disruption_summary.html.eex
+++ b/lib/arrow_web/templates/feed/disruption_summary.html.eex
@@ -4,7 +4,7 @@
     <div class="flex flex-col md:flex-row">
       <div class="flex-1">
         <dt class="mt-3">ROW Status</dt>
-        <dd> <%= if @revision.row_confirmed, do: "Confirmed", else: "Pending" %></dd>
+        <dd> <%= if @revision.row_approved, do: "Approved", else: "Pending" %></dd>
 
         <dt class="mt-3">Adjustments</dt>
         <dd>

--- a/lib/arrow_web/views/api/disruption_revision_view.ex
+++ b/lib/arrow_web/views/api/disruption_revision_view.ex
@@ -2,7 +2,7 @@ defmodule ArrowWeb.API.DisruptionRevisionView do
   use ArrowWeb, :view
   use JaSerializer.PhoenixView
 
-  attributes([:start_date, :end_date, :is_active, :inserted_at])
+  attributes([:start_date, :end_date, :row_approved, :is_active, :inserted_at])
 
   has_many :adjustments,
     serializer: ArrowWeb.API.AdjustmentView,

--- a/lib/arrow_web/views/disruption_view/form.ex
+++ b/lib/arrow_web/views/disruption_view/form.ex
@@ -11,7 +11,7 @@ defmodule ArrowWeb.DisruptionView.Form do
     %DisruptionRevision{
       start_date: start_date,
       end_date: end_date,
-      row_confirmed: row_confirmed,
+      row_approved: row_approved,
       adjustments: adjustments,
       days_of_week: days_of_week,
       exceptions: exceptions,
@@ -23,7 +23,7 @@ defmodule ArrowWeb.DisruptionView.Form do
       "disruptionRevision" => %{
         "startDate" => start_date,
         "endDate" => end_date,
-        "rowConfirmed" => row_confirmed,
+        "rowApproved" => row_approved,
         "adjustments" => Enum.map(adjustments, &encode_adjustment/1),
         "daysOfWeek" => days_of_week |> Enum.map(&encode_day_of_week/1) |> Enum.into(%{}),
         "exceptions" => Enum.map(exceptions, & &1.excluded_date),

--- a/priv/repo/migrations/20210922191945_row_status_name_change.exs
+++ b/priv/repo/migrations/20210922191945_row_status_name_change.exs
@@ -2,9 +2,6 @@ defmodule Arrow.Repo.Migrations.RowStatusNameChange do
   use Ecto.Migration
 
   def change do
-    alter table(:disruption_revisions) do
-      remove :row_confirmed
-      add :row_approved, :boolean, null: false, default: true
-    end
+    rename table(:disruption_revisions), :row_confirmed, to: :row_approved
   end
 end

--- a/priv/repo/migrations/20210922191945_row_status_name_change.exs
+++ b/priv/repo/migrations/20210922191945_row_status_name_change.exs
@@ -1,0 +1,10 @@
+defmodule Arrow.Repo.Migrations.RowStatusNameChange do
+  use Ecto.Migration
+
+  def change do
+    alter table(:disruption_revisions) do
+      remove :row_confirmed
+      add :row_approved, :boolean, null: false, default: true
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -205,7 +205,7 @@ CREATE TABLE public.disruption_revisions (
     disruption_id bigint NOT NULL,
     author character varying(255),
     is_active boolean DEFAULT true,
-    row_confirmed boolean DEFAULT true NOT NULL
+    row_approved boolean DEFAULT true NOT NULL
 );
 
 
@@ -567,3 +567,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20200909124316);
 INSERT INTO public."schema_migrations" (version) VALUES (20200925153736);
 INSERT INTO public."schema_migrations" (version) VALUES (20210816185635);
 INSERT INTO public."schema_migrations" (version) VALUES (20210921192435);
+INSERT INTO public."schema_migrations" (version) VALUES (20210922191945);

--- a/test/arrow/db_structure_test.exs
+++ b/test/arrow/db_structure_test.exs
@@ -94,7 +94,8 @@ defmodule Arrow.DBStructureTest do
             inserted_at: ~U[2020-09-29 15:17:42.000000Z],
             is_active: true,
             start_date: ~D[2020-01-01],
-            updated_at: ~U[2020-09-29 15:17:42.000000Z]
+            updated_at: ~U[2020-09-29 15:17:42.000000Z],
+            row_approved: true
           }
         ],
         "disruption_trip_short_names" => [],

--- a/test/arrow/disruption_test.exs
+++ b/test/arrow/disruption_test.exs
@@ -71,7 +71,7 @@ defmodule Arrow.DisruptionTest do
       attrs = %{
         "start_date" => "2021-01-01",
         "end_date" => "2021-12-31",
-        "row_confirmed" => "true",
+        "row_approved" => "true",
         "adjustments" => [%{"id" => insert(:adjustment).id}],
         "days_of_week" => [%{"day_name" => "monday", "start_time" => "20:00:00"}],
         "exceptions" => [%{"excluded_date" => "2021-01-11"}],
@@ -90,7 +90,7 @@ defmodule Arrow.DisruptionTest do
       assert dr.disruption_id == d.id
       assert dr.start_date == ~D[2021-01-01]
       assert dr.end_date == ~D[2021-12-31]
-      assert dr.row_confirmed == true
+      assert dr.row_approved == true
 
       assert [%DayOfWeek{day_name: "monday", start_time: ~T[20:00:00], end_time: nil}] =
                dr.days_of_week
@@ -188,7 +188,7 @@ defmodule Arrow.DisruptionTest do
       attrs = %{
         "start_date" => "2021-01-01",
         "end_date" => "2021-11-30",
-        "row_confirmed" => false,
+        "row_approved" => false,
         "days_of_week" => [%{"day_name" => "monday", "start_time" => "20:45:00"}],
         "exceptions" => [%{"excluded_date" => "2021-01-11"}, %{"excluded_date" => "2021-01-18"}],
         "trip_short_names" => [%{"trip_short_name" => "777"}, %{"trip_short_name" => "888"}]
@@ -209,7 +209,7 @@ defmodule Arrow.DisruptionTest do
       assert new_dr.is_active
       assert new_dr.start_date == ~D[2021-01-01]
       assert new_dr.end_date == ~D[2021-11-30]
-      assert new_dr.row_confirmed == false
+      assert new_dr.row_approved == false
 
       assert [%DayOfWeek{day_name: "monday", start_time: ~T[20:45:00], end_time: nil}] =
                new_dr.days_of_week

--- a/test/arrow_web/controllers/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/disruption_controller_test.exs
@@ -53,7 +53,7 @@ defmodule ArrowWeb.DisruptionControllerTest do
         "revision" => %{
           "start_date" => "2021-01-01",
           "end_date" => "2021-01-07",
-          "row_confirmed" => "false",
+          "row_approved" => "false",
           "days_of_week" => %{
             "0" => %{"day_name" => "friday", "start_time" => "20:45:00"},
             "1" => %{"day_name" => "saturday"}

--- a/test/arrow_web/views/disruption_view/form_test.exs
+++ b/test/arrow_web/views/disruption_view/form_test.exs
@@ -17,7 +17,7 @@ defmodule ArrowWeb.DisruptionView.FormTest do
         %DisruptionRevision{
           start_date: ~D[2021-01-01],
           end_date: ~D[2021-01-31],
-          row_confirmed: true,
+          row_approved: true,
           adjustments: [hd(adjustments)],
           days_of_week: [%DayOfWeek{day_name: "monday", start_time: ~T[21:15:00], end_time: nil}],
           exceptions: [%Exception{excluded_date: ~D[2021-01-11]}],
@@ -36,7 +36,7 @@ defmodule ArrowWeb.DisruptionView.FormTest do
         "disruptionRevision" => %{
           "startDate" => ~D[2021-01-01],
           "endDate" => ~D[2021-02-28],
-          "rowConfirmed" => true,
+          "rowApproved" => true,
           "adjustments" => [%{"id" => 1, "label" => "Kendall", "routeId" => "Red"}],
           "daysOfWeek" => %{"monday" => %{"start" => ~T[21:15:00], "end" => nil}},
           "exceptions" => [~D[2021-01-11]],

--- a/test/integration/disruptions_test.exs
+++ b/test/integration/disruptions_test.exs
@@ -59,7 +59,7 @@ defmodule Arrow.Integration.DisruptionsTest do
 
     assert revision.start_date == now |> DateTime.to_date()
     assert revision.end_date == now |> DateTime.to_date()
-    assert revision.row_confirmed == false
+    assert revision.row_approved == false
     assert Enum.count(revision.days_of_week) == 1
     revision_day = Enum.at(revision.days_of_week, 0)
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

Tweaks and fix-ups to #769.

The largest change is renaming the column from `row_confirmed` to `row_approved`. I don't know where I got "confirmed" in my head before, but the mocks are pretty consistent in calling it "approved". The presentation layer doesn't *have* to match exactly the data layer, but might as well get started off on the right foot.

I added `row_approved` to a few more places: The API that gtfs_creator uses, `clone!`, `db_structure`, a type spec.

I added a simple `approval status` to the show page. I found mocks to a version of the show page we'll have in the future with a sidebar with notes and some other things. So I didn't copy the design exactly, which won't work now, but I did use the wording. I made a couple tickets regarding that mock to make sure getting it to look like that won't fall through the cracks.

I updated the "status" column on the homepage table to be "GTFS status" to make it a little less confusing until we get to the ROW status on table ticket.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
