### PR TITLE
refactor: use introspection to clone revisions

### DIFF
--- a/lib/arrow_web/controllers/disruption_controller.ex
+++ b/lib/arrow_web/controllers/disruption_controller.ex
@@ -33,7 +33,7 @@ defmodule ArrowWeb.DisruptionController do
 
   def create(conn, %{"revision" => attrs}) do
     case Disruption.create(attrs) do
-      {:ok, id} ->
+      {:ok, %{disruption_id: id}} ->
         conn
         |> put_flash(:info, "Disruption created successfully.")
         |> redirect(to: Routes.disruption_path(conn, :show, id))
@@ -47,7 +47,7 @@ defmodule ArrowWeb.DisruptionController do
 
   def update(conn, %{"id" => id, "revision" => attrs}) do
     case Disruption.update(id, attrs) do
-      {:ok, id} ->
+      {:ok, _revision} ->
         conn
         |> put_flash(:info, "Disruption updated successfully.")
         |> redirect(to: Routes.disruption_path(conn, :show, id))

--- a/test/arrow_web/controllers/api/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/api/disruption_controller_test.exs
@@ -30,18 +30,18 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
           end_date: ~D[2019-11-01]
         )
 
-      {:ok, new_d1_id} = Disruption.update(d1.id, %{end_date: ~D[2019-12-01]})
+      {:ok, _revision} = Disruption.update(d1.id, %{end_date: ~D[2019-12-01]})
 
       new_d1 =
         Disruption
-        |> Repo.get(new_d1_id)
+        |> Repo.get(d1.id)
         |> Repo.preload([:revisions])
 
       new_d1
       |> Changeset.change(%{published_revision_id: Enum.at(new_d1.revisions, -1).id})
       |> Repo.update!()
 
-      {:ok, _newer_d1_id} = Disruption.update(d1.id, %{end_date: ~D[2020-01-01]})
+      {:ok, _revision} = Disruption.update(d1.id, %{end_date: ~D[2020-01-01]})
 
       res = json_response(get(conn, "/api/disruptions"), 200)
 


### PR DESCRIPTION
Docs: https://hexdocs.pm/ecto/3.7.1/Ecto.Schema.html#module-reflection

This avoids duplicating all the field names of revisions and their associations, so we don't have to remember to also update the clone function whenever a field is added or removed.

By creating a changeset for the clone instead of immediately saving it to the database, we also avoid the need to wrap updates and deletes in a transaction.

We still duplicate the names of associations — theoretically we could also avoid this with introspection, but it's less clear that doing so would be worth the complexity.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
