### PR TITLE
dev: fix missing `export` in `.envrc.example`

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,2 +1,4 @@
-DATABASE_USERNAME=postgres
-DATABASE_PASSWORD=postgres
+export ARROW_DOMAIN=https://arrow.mbta.com
+export ARROW_API_KEY=
+export DATABASE_USERNAME=postgres
+export DATABASE_PASSWORD=postgres

--- a/lib/mix/tasks/copy_db.ex
+++ b/lib/mix/tasks/copy_db.ex
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.CopyDb do
   @impl Mix.Task
   def run(_args) do
     api_key = System.get_env("ARROW_API_KEY")
-    domain = System.get_env("ARROW_DOMAIN", "https://arrow-dev.mbtace.com")
+    domain = System.get_env("ARROW_DOMAIN", "https://arrow.mbta.com")
     fetch_module = Application.get_env(:arrow, :http_client)
 
     Ecto.Migrator.with_repo(Arrow.Repo, fn repo ->


### PR DESCRIPTION
The example file didn't assign the env vars using `export`, which is required to work with `direnv` and also to use the file as a standalone shell script.

This also adds the `ARROW_DOMAIN` and `ARROW_API_KEY` values used by `mix copy_db` to the example file, and changes the default domain to be the production app, since this is the one we typically use.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
