### PR TITLE
fix: pin Postgres version used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       DATABASE_HOST: localhost
     services:
       postgres:
-        image: postgres
+        image: postgres:11
         ports:
           - 5432:5432
         env:
@@ -116,7 +116,7 @@ jobs:
       DATABASE_HOST: localhost
     services:
       postgres:
-        image: postgres
+        image: postgres:11
         ports:
           - 5432:5432
         env:


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Pin Postgres version in CI](https://app.asana.com/0/584764604969369/1201107259989900/f)

Simple update, the `postgres` service in our CI workflow now uses `postgres:11` instead of just `postgres`, which tells Docker to pull `postgres:latest` by default. This should fix `master`.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
