### PR TITLE
feat: filtering by ROW status

### DIFF
--- a/lib/arrow_web/controllers/disruption_controller/filters/table.ex
+++ b/lib/arrow_web/controllers/disruption_controller/filters/table.ex
@@ -6,27 +6,27 @@ defmodule ArrowWeb.DisruptionController.Filters.Table do
   import ArrowWeb.DisruptionController.Filters.Helpers
 
   @type sort :: :id | :source_label | :start_date
-  @type t :: %__MODULE__{include_past: boolean, sort: {:asc | :desc, sort}}
+  @type t :: %__MODULE__{include_past?: boolean, sort: {:asc | :desc, sort}}
 
-  defstruct include_past: false, sort: {:asc, :source_label}
+  defstruct include_past?: false, sort: {:asc, :source_label}
 
   @impl true
   def from_params(params) when is_map(params) do
     %__MODULE__{
-      include_past: not is_nil(params["include_past"]),
+      include_past?: not is_nil(params["include_past"]),
       sort: parse_sort(params["sort"])
     }
   end
 
   @impl true
-  def resettable?(%__MODULE__{include_past: true}), do: true
+  def resettable?(%__MODULE__{include_past?: true}), do: true
   def resettable?(_), do: false
 
   @impl true
-  def reset(%__MODULE__{} = table), do: %{table | include_past: false}
+  def reset(%__MODULE__{} = table), do: %{table | include_past?: false}
 
   @impl true
-  def to_params(%__MODULE__{include_past: include_past, sort: sort}) do
+  def to_params(%__MODULE__{include_past?: include_past, sort: sort}) do
     %{}
     |> put_if(include_past, "include_past", "true")
     |> put_if(sort != %__MODULE__{}.sort, "sort", encode_sort(sort))

--- a/lib/arrow_web/controllers/disruption_controller/index.ex
+++ b/lib/arrow_web/controllers/disruption_controller/index.ex
@@ -15,6 +15,10 @@ defmodule ArrowWeb.DisruptionController.Index do
     from [revisions: r] in query, where: is_nil(r.end_date) or r.end_date > ^cutoff
   end
 
+  defp apply_filter({:only_approved, true}, query) do
+    from [revisions: r] in query, where: r.row_approved
+  end
+
   @empty_set MapSet.new()
 
   defp apply_filter({:routes, routes}, query) when routes != @empty_set do

--- a/lib/arrow_web/controllers/disruption_controller/index.ex
+++ b/lib/arrow_web/controllers/disruption_controller/index.ex
@@ -10,7 +10,7 @@ defmodule ArrowWeb.DisruptionController.Index do
   @spec all(Filters.t() | nil) :: [Disruption.t()]
   def all(filters \\ nil), do: base_query() |> apply_filters(filters) |> Repo.all()
 
-  defp apply_filter({:include_past, false}, query) do
+  defp apply_filter({:include_past?, false}, query) do
     cutoff = Date.utc_today() |> Date.add(-7)
     from [revisions: r] in query, where: is_nil(r.end_date) or r.end_date > ^cutoff
   end

--- a/lib/arrow_web/controllers/disruption_controller/index.ex
+++ b/lib/arrow_web/controllers/disruption_controller/index.ex
@@ -15,9 +15,13 @@ defmodule ArrowWeb.DisruptionController.Index do
     from [revisions: r] in query, where: is_nil(r.end_date) or r.end_date > ^cutoff
   end
 
-  defp apply_filter({:only_approved, true}, query) do
+  defp apply_filter({:include_past?, true}, query), do: query
+
+  defp apply_filter({:only_approved?, true}, query) do
     from [revisions: r] in query, where: r.row_approved
   end
+
+  defp apply_filter({:only_approved?, false}, query), do: query
 
   @empty_set MapSet.new()
 
@@ -31,9 +35,13 @@ defmodule ArrowWeb.DisruptionController.Index do
     from [adjustments: a] in query, where: ^condition
   end
 
+  defp apply_filter({:routes, routes}, query) when routes == @empty_set, do: query
+
   defp apply_filter({:search, search}, query) when is_binary(search) do
     from [adjustments: a] in query, where: ilike(a.source_label, ^"%#{search}%")
   end
+
+  defp apply_filter({:search, nil}, query), do: query
 
   defp apply_filter({:sort, {direction, :id}}, query) do
     from [disruptions: d] in query, order_by: {^direction, d.id}
@@ -46,8 +54,6 @@ defmodule ArrowWeb.DisruptionController.Index do
   defp apply_filter({:sort, {direction, :start_date}}, query) do
     from [revisions: r] in query, order_by: {^direction, r.start_date}
   end
-
-  defp apply_filter(_, query), do: query
 
   defp apply_filters(query, nil), do: query
 

--- a/lib/arrow_web/templates/disruption/index.html.eex
+++ b/lib/arrow_web/templates/disruption/index.html.eex
@@ -51,8 +51,8 @@
         <%= link("include past",
               class:
                 "mx-2 btn btn-outline-secondary" <>
-                  if(@filters.view.include_past, do: " active", else: ""),
-              to: update_view_path(@conn, @filters, :include_past, !@filters.view.include_past)
+                  if(@filters.view.include_past?, do: " active", else: ""),
+              to: update_view_path(@conn, @filters, :include_past?, !@filters.view.include_past?)
             ) %>
       <% end %>
 

--- a/lib/arrow_web/templates/disruption/index.html.eex
+++ b/lib/arrow_web/templates/disruption/index.html.eex
@@ -56,6 +56,13 @@
             ) %>
       <% end %>
 
+      <%= link("approved",
+            class:
+              "mx-2 btn btn-outline-secondary" <>
+                if(@filters.only_approved?, do: " active", else: ""),
+            to: update_filters_path(@conn, Filters.toggle_only_approved(@filters))
+          ) %>
+
       <%= if Filters.resettable?(@filters) do %>
         <%= link("reset filters",
               class: "btn btn-link",

--- a/test/arrow_web/controllers/disruption_controller/filters_test.exs
+++ b/test/arrow_web/controllers/disruption_controller/filters_test.exs
@@ -43,10 +43,14 @@ defmodule ArrowWeb.DisruptionController.FiltersTest do
     end
 
     test "table view: include_past is indicated with a param if true" do
-      assert_equivalent(%{"include_past" => "true"}, %Filters{view: %Table{include_past: true}})
-      assert from_params(%{"include_past" => "abc"}) == %Filters{view: %Table{include_past: true}}
-      assert from_params(%{"include_past" => nil}) == %Filters{view: %Table{include_past: false}}
-      assert to_params(%Filters{view: %Table{include_past: false}}) == %{}
+      assert_equivalent(%{"include_past" => "true"}, %Filters{view: %Table{include_past?: true}})
+
+      assert from_params(%{"include_past" => "abc"}) == %Filters{
+               view: %Table{include_past?: true}
+             }
+
+      assert from_params(%{"include_past" => nil}) == %Filters{view: %Table{include_past?: false}}
+      assert to_params(%Filters{view: %Table{include_past?: false}}) == %{}
     end
 
     test "table view: sort has a default and can be expressed as ascending or descending" do
@@ -67,7 +71,7 @@ defmodule ArrowWeb.DisruptionController.FiltersTest do
     test "flattens base and view-specific filters into a map" do
       routes = set(~w(Red Blue))
       calendar_filters = %Filters{routes: routes, search: "test", view: %Calendar{}}
-      table_filters = %{calendar_filters | view: %Table{include_past: true, sort: {:asc, :id}}}
+      table_filters = %{calendar_filters | view: %Table{include_past?: true, sort: {:asc, :id}}}
 
       assert Filters.flatten(calendar_filters) == %{
                routes: routes,
@@ -78,7 +82,7 @@ defmodule ArrowWeb.DisruptionController.FiltersTest do
       table_expected = %{
         routes: routes,
         search: "test",
-        include_past: true,
+        include_past?: true,
         only_approved?: false,
         sort: {:asc, :id}
       }
@@ -92,7 +96,7 @@ defmodule ArrowWeb.DisruptionController.FiltersTest do
       refute Filters.resettable?(%Filters{})
       refute Filters.resettable?(%Filters{view: %Calendar{}})
       assert Filters.resettable?(%Filters{search: "test"})
-      assert Filters.resettable?(%Filters{view: %Table{include_past: true}})
+      assert Filters.resettable?(%Filters{view: %Table{include_past?: true}})
       assert Filters.resettable?(%Filters{only_approved?: true})
     end
 
@@ -107,7 +111,7 @@ defmodule ArrowWeb.DisruptionController.FiltersTest do
         search: "test",
         routes: set(~w(Red)),
         only_approved?: true,
-        view: %Table{include_past: true}
+        view: %Table{include_past?: true}
       }
 
       assert Filters.reset(filters) == %Filters{}

--- a/test/arrow_web/controllers/disruption_controller/index_test.exs
+++ b/test/arrow_web/controllers/disruption_controller/index_test.exs
@@ -76,7 +76,7 @@ defmodule ArrowWeb.DisruptionController.IndexTest do
   describe "all/1" do
     defp filters(attrs) do
       # Undo the default date filter and sort by ID for consistent ordering
-      struct(%Filters{view: struct(%Table{include_past: true, sort: {:asc, :id}}, attrs)}, attrs)
+      struct(%Filters{view: struct(%Table{include_past?: true, sort: {:asc, :id}}, attrs)}, attrs)
     end
 
     defp filtered(attrs), do: attrs |> filters() |> Index.all()
@@ -86,8 +86,8 @@ defmodule ArrowWeb.DisruptionController.IndexTest do
       %{disruption_id: new_id} = insert(:disruption_revision, end_date: today)
       %{disruption_id: old_id} = insert(:disruption_revision, end_date: Date.add(today, -8))
 
-      assert [%{id: ^new_id}] = filtered(include_past: false)
-      assert [%{id: ^new_id}, %{id: ^old_id}] = filtered(include_past: true)
+      assert [%{id: ^new_id}] = filtered(include_past?: false)
+      assert [%{id: ^new_id}, %{id: ^old_id}] = filtered(include_past?: true)
     end
 
     test "filters by a case-insensitive search term in adjustment labels" do

--- a/test/integration/disruptions_test.exs
+++ b/test/integration/disruptions_test.exs
@@ -72,7 +72,7 @@ defmodule Arrow.Integration.DisruptionsTest do
     assert Enum.at(revision.adjustments, 0).source_label == adjustment.source_label
   end
 
-  feature "can filter disruptions", %{session: session} do
+  feature "can filter disruptions by route", %{session: session} do
     revision = insert(create_disruption_revision())
 
     session
@@ -80,6 +80,32 @@ defmodule Arrow.Integration.DisruptionsTest do
     |> assert_text(revision.description)
     |> click(xpath("//a[@aria-label='Blue']"))
     |> refute_has(text(revision.description))
+  end
+
+  feature "can filter disruptions by ROW status", %{session: session} do
+    approved = insert(:disruption_revision, %{row_approved: true})
+    pending = insert(:disruption_revision, %{row_approved: false})
+
+    session
+    |> visit("/")
+    |> assert_text(approved.description)
+    |> assert_text(pending.description)
+    |> click(link("approved"))
+    |> assert_text(approved.description)
+    |> refute_has(text(pending.description))
+  end
+
+  feature "can show past disruptions", %{session: session} do
+    today = Date.utc_today()
+    week_ago = Date.add(today, -7)
+    yesterday = Date.add(today, -1)
+    past = insert(:disruption_revision, %{start_date: week_ago, end_date: yesterday})
+
+    session
+    |> visit("/")
+    |> refute_has(text(past.description))
+    |> click(link("include past"))
+    |> assert_text(past.description)
   end
 
   feature "can view disruption on calendar", %{session: session} do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [ROW status can be filtered](https://app.asana.com/0/584764604969369/1200689411100427/f)

Added a new filter for both the table and calendar views that when activated, only shows ROW approved disruptions.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
