### PR TITLE
fix: don't generate coverage data for deps/

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Arrow.MixProject do
         ignore_warnings: ".dialyzer.ignore-warnings"
       ],
       preferred_cli_env: ["test.integration": :test],
-      test_coverage: [tool: LcovEx]
+      test_coverage: [tool: LcovEx, ignore_paths: ["deps/"]]
     ]
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [fix Arrow coverage reporting](https://app.asana.com/0/584764604969369/1201120775201216/f)

Tells Lcov to ignore the `deps/` path when generating coverage info. We don't want `deps/mox/lib/mox.ex` covered and it breaks coverage reporting.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
