### PR TITLE
fix: can't remove all exceptions from a disruption

### DIFF
--- a/lib/arrow_web/controllers/disruption_controller.ex
+++ b/lib/arrow_web/controllers/disruption_controller.ex
@@ -46,7 +46,7 @@ defmodule ArrowWeb.DisruptionController do
   end
 
   def update(conn, %{"id" => id, "revision" => attrs}) do
-    case Disruption.update(id, attrs) do
+    case Disruption.update(id, put_new_assocs(attrs)) do
       {:ok, _revision} ->
         conn
         |> put_flash(:info, "Disruption updated successfully.")
@@ -68,5 +68,15 @@ defmodule ArrowWeb.DisruptionController do
     changeset
     |> Changeset.traverse_errors(&ErrorHelpers.translate_error/1)
     |> ErrorHelpers.flatten_errors()
+  end
+
+  defp put_new_assocs(attrs) do
+    # Ensure a form submission with no instances of an association is interpreted as "delete all
+    # existing records" rather than "leave existing records alone"
+    attrs
+    |> Map.put_new("adjustments", [])
+    |> Map.put_new("days_of_week", [])
+    |> Map.put_new("exceptions", [])
+    |> Map.put_new("trip_short_names", [])
   end
 end


### PR DESCRIPTION
**Asana:** [🐛🏹 Cannot delete exception dates from disruptions](https://app.asana.com/0/584764604969369/1201130959779278)

The controller seemed like the appropriate place to bridge the gap between the intended "put" semantics of the form and the "patch" semantics of changesets.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
