### PR TITLE
chore: Added color feature for pending disruption status

### DIFF
--- a/assets/css/disruption_calendar.css
+++ b/assets/css/disruption_calendar.css
@@ -14,26 +14,50 @@
   color: #aaa;
 }
 
-.fc-event.route-Red {
+.fc-event.status-approved.route-Red {
   background-color: #da291c;
 }
 
-.fc-event.route-Blue {
+.fc-event.status-pending.route-Red {
+  background-color: #f4bfbb;
+}
+
+.fc-event.status-approved.route-Blue {
   background-color: #003da5;
 }
 
-.fc-event.route-Orange {
+.fc-event.status-pending.route-Blue {
+  background-color: #b3c5e4;
+}
+
+.fc-event.status-approved.route-Orange {
   background-color: #ed8b00;
 }
 
-.fc-event.route-Mattapan {
+.fc-event.status-pending.route-Orange {
+  background-color: #f9d6a6;
+}
+
+.fc-event.status-approved.route-Mattapan {
   background-color: #da291c;
 }
 
-.fc-event[class*="route-Green"] {
+.fc-event.status-pending.route-Mattapan {
+  background-color: #f4bfbb;
+}
+
+.fc-event.status-approved[class*="route-Green"] {
   background-color: #00843d;
 }
 
-.fc-event[class*="route-CR"] {
+.fc-event.status-pending[class*="route-Green"] {
+  background-color: #cce6d8;
+}
+
+.fc-event.status-approved[class*="route-CR"] {
   background-color: #80276c;
+}
+
+.fc-event.status-pending[class*="route-CR"] {
+  background-color: #d98fd3;
 }

--- a/lib/arrow_web/views/disruption_view/calendar.ex
+++ b/lib/arrow_web/views/disruption_view/calendar.ex
@@ -31,7 +31,8 @@ defmodule ArrowWeb.DisruptionView.Calendar do
            start_date: start_date,
            end_date: end_date,
            days_of_week: days_of_week,
-           exceptions: exceptions
+           exceptions: exceptions,
+           row_approved: row_approved
          },
          %Adjustment{route_id: route_id, source_label: source_label}
        ) do
@@ -46,7 +47,7 @@ defmodule ArrowWeb.DisruptionView.Calendar do
     |> Enum.map(fn {event_start, event_end} ->
       %{
         title: source_label,
-        classNames: "route-#{route_id}",
+        classNames: "#{row_status_class(row_approved)} route-#{route_id}",
         start: event_start,
         # end date is treated as exclusive
         end: Date.add(event_end, 1),
@@ -54,6 +55,9 @@ defmodule ArrowWeb.DisruptionView.Calendar do
       }
     end)
   end
+
+  defp row_status_class(true), do: "status-approved"
+  defp row_status_class(false), do: "status-pending"
 
   # Starting a new chunk
   defp chunk_dates(date, []), do: {:cont, [date]}

--- a/test/arrow_web/views/disruption_view/calendar_test.exs
+++ b/test/arrow_web/views/disruption_view/calendar_test.exs
@@ -29,56 +29,56 @@ defmodule ArrowWeb.DisruptionView.CalendarTest do
       expected_events = [
         %{
           title: "Wonderland",
-          classNames: "route-Blue",
+          classNames: "status-approved route-Blue",
           start: ~D[2021-01-04],
           end: ~D[2021-01-06],
           url: "/disruptions/123"
         },
         %{
           title: "Wonderland",
-          classNames: "route-Blue",
+          classNames: "status-approved route-Blue",
           start: ~D[2021-01-12],
           end: ~D[2021-01-13],
           url: "/disruptions/123"
         },
         %{
           title: "Wonderland",
-          classNames: "route-Blue",
+          classNames: "status-approved route-Blue",
           start: ~D[2021-01-18],
           end: ~D[2021-01-20],
           url: "/disruptions/123"
         },
         %{
           title: "Wonderland",
-          classNames: "route-Blue",
+          classNames: "status-approved route-Blue",
           start: ~D[2021-01-25],
           end: ~D[2021-01-27],
           url: "/disruptions/123"
         },
         %{
           title: "Wellington",
-          classNames: "route-Orange",
+          classNames: "status-approved route-Orange",
           start: ~D[2021-01-04],
           end: ~D[2021-01-06],
           url: "/disruptions/123"
         },
         %{
           title: "Wellington",
-          classNames: "route-Orange",
+          classNames: "status-approved route-Orange",
           start: ~D[2021-01-12],
           end: ~D[2021-01-13],
           url: "/disruptions/123"
         },
         %{
           title: "Wellington",
-          classNames: "route-Orange",
+          classNames: "status-approved route-Orange",
           start: ~D[2021-01-18],
           end: ~D[2021-01-20],
           url: "/disruptions/123"
         },
         %{
           title: "Wellington",
-          classNames: "route-Orange",
+          classNames: "status-approved route-Orange",
           start: ~D[2021-01-25],
           end: ~D[2021-01-27],
           url: "/disruptions/123"
@@ -109,7 +109,7 @@ defmodule ArrowWeb.DisruptionView.CalendarTest do
       expected_events = [
         %{
           title: "(disruption 123)",
-          classNames: "route-none",
+          classNames: "status-approved route-none",
           start: ~D[2021-01-04],
           end: ~D[2021-01-05],
           url: "/disruptions/123"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 ROW status on calendar](https://app.asana.com/0/584764604969369/1200687441670238/f)

[Includes changes in css file for added color events, associated with pending disruption status vs approved disruption status. Change is picked up in DCalendar template.]

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
