### PR TITLE
feat: show no-adjustments disruptions on calendar 

### DIFF
--- a/assets/css/disruption_calendar.css
+++ b/assets/css/disruption_calendar.css
@@ -1,3 +1,9 @@
+.fc-h-event {
+  /* replace colored border with padding */
+  border: none;
+  padding: 2px;
+}
+
 .fc-event.route-Red {
   background-color: #da291c;
 }

--- a/assets/css/disruption_calendar.css
+++ b/assets/css/disruption_calendar.css
@@ -4,6 +4,16 @@
   padding: 2px;
 }
 
+.fc-event.route-none {
+  background-color: #fff;
+  border: 2px dashed #ccc;
+  padding: 0;
+}
+
+.fc-event.route-none .fc-event-title {
+  color: #aaa;
+}
+
 .fc-event.route-Red {
   background-color: #da291c;
 }

--- a/lib/arrow_web/views/disruption_view/calendar.ex
+++ b/lib/arrow_web/views/disruption_view/calendar.ex
@@ -17,6 +17,10 @@ defmodule ArrowWeb.DisruptionView.Calendar do
     Enum.flat_map(disruptions, &events/1)
   end
 
+  defp events(%Disruption{id: id, revisions: [%{adjustments: []} = revision]}) do
+    events(id, revision, %Adjustment{route_id: "none", source_label: "(disruption #{id})"})
+  end
+
   defp events(%Disruption{id: id, revisions: [%{adjustments: adjustments} = revision]}) do
     Enum.flat_map(adjustments, &events(id, revision, &1))
   end

--- a/test/arrow_web/views/disruption_view/calendar_test.exs
+++ b/test/arrow_web/views/disruption_view/calendar_test.exs
@@ -92,13 +92,13 @@ defmodule ArrowWeb.DisruptionView.CalendarTest do
       assert DCalendar.props([]) == %{events: []}
     end
 
-    test "returns no events for disruptions with no adjustments" do
+    test "outputs a single event for a disruption with no adjustments" do
       disruption = %Disruption{
         id: 123,
         revisions: [
           %DisruptionRevision{
-            start_date: ~D[2021-01-01],
-            end_date: ~D[2021-01-31],
+            start_date: ~D[2021-01-04],
+            end_date: ~D[2021-01-04],
             adjustments: [],
             days_of_week: [%DayOfWeek{day_name: "monday", start_time: nil, end_time: nil}],
             exceptions: []
@@ -106,7 +106,17 @@ defmodule ArrowWeb.DisruptionView.CalendarTest do
         ]
       }
 
-      assert DCalendar.props([disruption]) == %{events: []}
+      expected_events = [
+        %{
+          title: "(disruption 123)",
+          classNames: "route-none",
+          start: ~D[2021-01-04],
+          end: ~D[2021-01-05],
+          url: "/disruptions/123"
+        }
+      ]
+
+      assert DCalendar.props([disruption]) == %{events: expected_events}
     end
   end
 end


### PR DESCRIPTION
**Asana:** [🏹 Disruptions can be created without adjustment](https://app.asana.com/0/584764604969369/1200681721075715)

We didn't say much in the task about _how_ these disruptions should be shown on the calendar, so I made up a distinct appearance for them and used the disruption ID as the title, to provide a way to distinguish between multiple disruptions with no adjustments (and since we already use disruption IDs prominently elsewhere in the UI).

![Screen Shot 2021-12-01 at 4 08 02 PM](https://user-images.githubusercontent.com/394835/144315999-4b25a139-b9f6-401e-8313-2853e7456bb3.png)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
