### PR TITLE
fix: Text color for pending disruptions on calendar

### DIFF
--- a/assets/css/disruption_calendar.css
+++ b/assets/css/disruption_calendar.css
@@ -14,6 +14,10 @@
   color: #aaa;
 }
 
+.fc-event.status-pending .fc-event-title {
+  color: #1e2127;
+}
+
 .fc-event.status-approved.route-Red {
   background-color: #da291c;
 }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] font color change for pending disruptions on arrow calendar](https://app.asana.com/0/584764604969369/1201481447960456/f)

Added css color event for text of pending disruption status.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
