### PR TITLE
chore: Add submit button for marking disruption approval status on sh…

### DIFF
--- a/lib/arrow_web/controllers/disruption_controller.ex
+++ b/lib/arrow_web/controllers/disruption_controller.ex
@@ -9,8 +9,17 @@ defmodule ArrowWeb.DisruptionController do
   alias Plug.Conn
 
   plug(Authorize, :create_disruption when action in [:new, :create])
-  plug(Authorize, :update_disruption when action in [:edit, :update])
+  plug(Authorize, :update_disruption when action in [:edit, :update, :update_row_status])
   plug(Authorize, :delete_disruption when action in [:delete])
+
+  @spec update_row_status(Conn.t(), Conn.params()) :: Conn.t()
+  def update_row_status(conn, %{"id" => id, "revision" => attrs}) do
+    {:ok, _} = Disruption.update(id, attrs)
+
+    conn
+    |> put_flash(:info, "Disruption updated successfully.")
+    |> redirect(to: Routes.disruption_path(conn, :show, id))
+  end
 
   @spec index(Conn.t(), Conn.params()) :: Conn.t()
   def index(%{assigns: %{current_user: user}} = conn, params) do

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -47,6 +47,7 @@ defmodule ArrowWeb.Router do
     get("/mytoken", MyTokenController, :show)
     get("/", DisruptionController, :index)
     resources("/disruptions", DisruptionController, except: [:index])
+    put("/disruptions/:id/row_status", DisruptionController, :update_row_status)
   end
 
   scope "/", ArrowWeb do

--- a/lib/arrow_web/templates/disruption/show.html.heex
+++ b/lib/arrow_web/templates/disruption/show.html.heex
@@ -85,7 +85,15 @@
       </div>
 
       <%= if @revision.is_active and Permissions.authorize?(:update_disruption, @user) do %>
-        <div class="col-md-2">
+        <div class="col-md-4">
+          <%= form_tag Routes.disruption_path(@conn, :update_row_status, @revision.disruption_id), method: "put" do %>
+            <%= hidden_input :revision, :row_approved, value: !@revision.row_approved %>
+            <%= submit mark_as_approved_or_pending(@revision.row_approved), class: "btn btn-primary w-100"%>
+          <% end %>
+        </div>
+      <% end %>
+      <%= if @revision.is_active and Permissions.authorize?(:update_disruption, @user) do %>
+        <div class="col-md-3">
           <%= link("edit",
                 class: "btn btn-primary w-100",
                 to: Routes.disruption_path(@conn, :edit, @id)

--- a/lib/arrow_web/views/disruption_view.ex
+++ b/lib/arrow_web/views/disruption_view.ex
@@ -73,4 +73,12 @@ defmodule ArrowWeb.DisruptionView do
   defp update_view_path(conn, %{view: view} = filters, key, value) do
     update_filters_path(conn, %{filters | view: %{view | key => value}})
   end
+
+  defp mark_as_approved_or_pending(true) do
+    "mark as pending"
+  end
+
+  defp mark_as_approved_or_pending(false) do
+    "mark as approved"
+  end
 end

--- a/test/arrow_web/controllers/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/disruption_controller_test.exs
@@ -229,6 +229,27 @@ defmodule ArrowWeb.DisruptionControllerTest do
     end
   end
 
+  describe "update_row_status/2" do
+    @tag :authenticated_admin
+    test "admin can update a disruption row status", %{conn: conn} do
+      %{disruption_id: id} = insert(:disruption_revision, row_approved: false)
+
+      params = %{
+        "revision" => string_params_for(:disruption_revision, row_approved: "true")
+      }
+
+      location =
+        conn
+        |> put(Routes.disruption_path(conn, :update_row_status, id), params)
+        |> redirected_to()
+
+      assert %{row_approved: true} =
+               Repo.get!(DisruptionRevision, Disruption.latest_revision_id(id))
+
+      assert location == Routes.disruption_path(conn, :show, id)
+    end
+  end
+
   defp insert_revision_with_everything do
     insert(:disruption_revision,
       days_of_week: [build(:day_of_week)],


### PR DESCRIPTION
…ow page

#### Summary of changes
**Asana Ticket:** [Mark disruption pending/approved from show page](https://app.asana.com/0/584764604969369/1201029740414123/f)

Added new action in DisruptionController for HTML button submit on show page. The HTML button submit allows client to change disruption status from approved to pending and vice versa. 

Screenshot of button with `mark as approved`:

![Screen Shot 2021-12-14 at 3 14 30 PM](https://user-images.githubusercontent.com/10501983/146073010-8cf1cb9b-613d-4093-afec-197d12e8b52b.png)

Screenshot of button switched to `mark as pending` (after clicking on it):

![Screen Shot 2021-12-14 at 3 14 46 PM](https://user-images.githubusercontent.com/10501983/146073038-c1386f89-7b35-4954-bda3-1fd25ec3ca1a.png)

Screenshot of button switched back to `mark as approved` (after clicking on it):

![Screen Shot 2021-12-14 at 3 15 03 PM](https://user-images.githubusercontent.com/10501983/146073068-585bc905-e200-4a29-8c4a-ca78a071a92c.png)


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
