### PR TITLE
refactor: remove `source_label` table sort

### DIFF
--- a/lib/arrow_web/controllers/disruption_controller/filters/table.ex
+++ b/lib/arrow_web/controllers/disruption_controller/filters/table.ex
@@ -5,10 +5,10 @@ defmodule ArrowWeb.DisruptionController.Filters.Table do
 
   import ArrowWeb.DisruptionController.Filters.Helpers
 
-  @type sort :: :id | :source_label | :start_date
+  @type sort :: :id | :start_date
   @type t :: %__MODULE__{include_past?: boolean, sort: {:asc | :desc, sort}}
 
-  defstruct include_past?: false, sort: {:asc, :source_label}
+  defstruct include_past?: false, sort: {:asc, :start_date}
 
   @impl true
   def from_params(params) when is_map(params) do

--- a/lib/arrow_web/controllers/disruption_controller/index.ex
+++ b/lib/arrow_web/controllers/disruption_controller/index.ex
@@ -49,10 +49,6 @@ defmodule ArrowWeb.DisruptionController.Index do
     from [disruptions: d] in query, order_by: {^direction, d.id}
   end
 
-  defp apply_filter({:sort, {direction, :source_label}}, query) do
-    from [adjustments: a] in query, order_by: {^direction, a.source_label}
-  end
-
   defp apply_filter({:sort, {direction, :start_date}}, query) do
     from [revisions: r] in query, order_by: {^direction, r.start_date}
   end

--- a/test/arrow_web/controllers/disruption_controller/filters_test.exs
+++ b/test/arrow_web/controllers/disruption_controller/filters_test.exs
@@ -58,7 +58,7 @@ defmodule ArrowWeb.DisruptionController.FiltersTest do
     end
 
     test "table view: sort has a default and can be expressed as ascending or descending" do
-      assert_equivalent(%{}, %Filters{view: %Table{sort: {:asc, :source_label}}})
+      assert_equivalent(%{}, %Filters{view: %Table{sort: {:asc, :start_date}}})
       assert_equivalent(%{"sort" => "id"}, %Filters{view: %Table{sort: {:asc, :id}}})
       assert_equivalent(%{"sort" => "-id"}, %Filters{view: %Table{sort: {:desc, :id}}})
     end

--- a/test/arrow_web/controllers/disruption_controller/index_test.exs
+++ b/test/arrow_web/controllers/disruption_controller/index_test.exs
@@ -140,16 +140,6 @@ defmodule ArrowWeb.DisruptionController.IndexTest do
       assert [%{id: ^id2}, %{id: ^id1}] = filtered(sort: {:desc, :id})
     end
 
-    test "sorts by adjustment labels" do
-      adj1 = insert(:adjustment, source_label: "Adj1")
-      adj2 = insert(:adjustment, source_label: "Adj2")
-      adj3 = insert(:adjustment, source_label: "Adj3")
-      %{disruption_id: id1} = insert(:disruption_revision, adjustments: [adj2, adj3])
-      %{disruption_id: id2} = insert(:disruption_revision, adjustments: [adj1, adj3])
-
-      assert [%{id: ^id2}, %{id: ^id1}] = filtered(sort: {:asc, :source_label})
-    end
-
     test "sorts by disruption start date" do
       %{disruption_id: id2} = insert(:disruption_revision, start_date: ~D[2021-01-02])
       %{disruption_id: id1} = insert(:disruption_revision, start_date: ~D[2021-01-01])


### PR DESCRIPTION
**Asana:** extra task — noticed this while implementing #818

The ability to explicitly select this sort was removed in #770, but it was still supported and used as the default sort, despite adjustment labels no longer appearing in the table. This changes the default sort to ascending by start date, the only remaining sort other than ID. It's a somewhat arbitrary choice, but we can always change it to ID if feedback indicates that's a more useful default.

We agreed this should be updated somehow during a [Slack conversation](https://mbta.slack.com/archives/CF9QKK2AF/p1632510493307200) a while back, but I can't find any Asana tasks that might have been created from it. The same conversation also mentions making the search feature work with descriptions — for that, see #820.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
