### PR TITLE
feat: include descriptions in index search

### DIFF
--- a/lib/arrow_web/controllers/disruption_controller/index.ex
+++ b/lib/arrow_web/controllers/disruption_controller/index.ex
@@ -40,7 +40,8 @@ defmodule ArrowWeb.DisruptionController.Index do
   defp apply_filter({:only_approved?, false}, query), do: query
 
   defp apply_filter({:search, search}, query) when is_binary(search) do
-    from [adjustments: a] in query, where: ilike(a.source_label, ^"%#{search}%")
+    from [revisions: r, adjustments: a] in query,
+      where: ilike(r.description, ^"%#{search}%") or ilike(a.source_label, ^"%#{search}%")
   end
 
   defp apply_filter({:search, nil}, query), do: query

--- a/test/arrow_web/controllers/disruption_controller/index_test.exs
+++ b/test/arrow_web/controllers/disruption_controller/index_test.exs
@@ -90,13 +90,15 @@ defmodule ArrowWeb.DisruptionController.IndexTest do
       assert [%{id: ^new_id}, %{id: ^old_id}] = filtered(include_past?: true)
     end
 
-    test "filters by a case-insensitive search term in adjustment labels" do
-      adj1 = build(:adjustment, source_label: "SomethingNewer")
-      %{disruption_id: id} = insert(:disruption_revision, adjustments: [adj1])
-      adj2 = build(:adjustment, source_label: "SomethingOlder")
+    test "filters by a case-insensitive search term in descriptions and adjustment labels" do
+      adj1 = build(:adjustment, source_label: "TrackChange")
+      %{disruption_id: id1} = insert(:disruption_revision, adjustments: [adj1])
+      adj2 = build(:adjustment, source_label: "StationClosed")
       insert(:disruption_revision, adjustments: [adj2])
+      %{disruption_id: id2} = insert(:disruption_revision, description: "Track change")
+      insert(:disruption_revision, description: "Station closed")
 
-      assert [%{id: ^id}] = filtered(search: "new")
+      assert [%{id: ^id1}, %{id: ^id2}] = filtered(search: "track")
     end
 
     test "filters by kind with existing adjustments" do


### PR DESCRIPTION
**Asana:** extra task — noticed this while implementing #818 

When "descriptions" were introduced in #770 and took the place of adjustment labels in the index table, the search feature was not updated to search within them. Now it does.

We agreed this should be updated during a [Slack conversation](https://mbta.slack.com/archives/CF9QKK2AF/p1632510493307200) a while back, but I can't find any Asana tasks that might have been created from it. The same conversation also mentions cleaning up the default table sorting — for that, see #819.

Open question: This updates the search function to search descriptions _in addition to_ adjustment labels. Should it search _only_ in descriptions? On the one hand, searching within a field that isn't shown anywhere in the results could be confusing behavior. On the other hand, if you search for e.g. "Alewife" you might want to see disruptions with adjustments involving "Alewife" even if that is not stated in their description.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
