### PR TITLE
feat: Add "notes" to disruptions

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -15,3 +15,4 @@
 @import "./footer.css";
 @import "./header.css";
 @import "./icon.css";
+@import "./notes.css";

--- a/assets/css/disruption_form.css
+++ b/assets/css/disruption_form.css
@@ -27,3 +27,8 @@
   font-size: large;
   font-weight: 200;
 }
+
+.m-disruption-form__legend-optional {
+  color: #888;
+  font-size: medium;
+}

--- a/assets/css/notes.css
+++ b/assets/css/notes.css
@@ -1,0 +1,18 @@
+.m-note__header {
+  color: #666;
+  display: flex;
+  justify-content: space-between;
+}
+
+.m-note__author {
+  align-self: flex-start;
+  font-size: 1rem;
+  font-weight: 200;
+  line-height: 1.5;
+  margin-bottom: 0;
+}
+
+.m-note__timestamp {
+  align-self: flex-end;
+  font-size: 1rem;
+}

--- a/assets/src/components/DisruptionForm.tsx
+++ b/assets/src/components/DisruptionForm.tsx
@@ -149,6 +149,7 @@ interface DisruptionFormProps {
   allAdjustments: Adjustment[]
   disruptionRevision: DisruptionRevision
   iconPaths: { [icon: string]: string }
+  noteBody: string
 }
 
 /**
@@ -172,12 +173,14 @@ const DisruptionForm = ({
     tripShortNames: initialTripShortNames,
   },
   iconPaths,
+  noteBody: initialNoteBody,
 }: DisruptionFormProps) => {
   const [isRowApproved, setIsRowApproved] = useState(initialRowApproved)
   const [description, setDescription] = useState(initialDescription)
   const [adjustmentKind, setAdjustmentKind] = useState(initialAdjustmentKind)
   const [hasAdjustments, setHasAdjustments] = useState(adjustmentKind === null)
   const [adjustments, setAdjustments] = useState(initialAdjustments)
+  const [noteBody, setNoteBody] = useState(initialNoteBody)
 
   const [mode, setMode] = useState<Mode | null>(
     initialMode(adjustments, adjustmentKind)
@@ -550,6 +553,20 @@ const DisruptionForm = ({
             </button>
           </div>
         )}
+      </fieldset>
+
+      <fieldset>
+        <legend>
+          notes{" "}
+          <span className="m-disruption-form__legend-optional">optional</span>
+        </legend>
+        <textarea
+          className="w-100"
+          name="revision[note_body]"
+          value={noteBody}
+          onChange={(event) => setNoteBody(event.target.value)}
+          aria-label="note"
+        />
       </fieldset>
     </>
   )

--- a/assets/tests/components/DisruptionForm.test.tsx
+++ b/assets/tests/components/DisruptionForm.test.tsx
@@ -48,6 +48,7 @@ describe("DisruptionForm", () => {
             tripShortNames: "trip1,trip2",
           }}
           iconPaths={{}}
+          noteBody=""
         />
       </form>
     )
@@ -98,6 +99,7 @@ describe("DisruptionForm", () => {
         allAdjustments={adjustments}
         disruptionRevision={blankRevision}
         iconPaths={{}}
+        noteBody=""
       />
     )
 
@@ -134,6 +136,7 @@ describe("DisruptionForm", () => {
           allAdjustments={adjustments}
           disruptionRevision={blankRevision}
           iconPaths={{}}
+          noteBody=""
         />
       </form>
     )
@@ -154,6 +157,7 @@ describe("DisruptionForm", () => {
           allAdjustments={adjustments}
           disruptionRevision={blankRevision}
           iconPaths={{}}
+          noteBody=""
         />
       </form>
     )
@@ -174,6 +178,7 @@ describe("DisruptionForm", () => {
         allAdjustments={adjustments}
         disruptionRevision={blankRevision}
         iconPaths={{}}
+        noteBody=""
       />
     )
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,6 +23,7 @@ config :arrow,
     create_disruption: [:admin],
     update_disruption: [:admin],
     delete_disruption: [:admin],
+    create_note: [:admin],
     use_api: [:admin],
     view_change_feed: [:admin]
   },

--- a/lib/arrow/disruption.ex
+++ b/lib/arrow/disruption.ex
@@ -10,12 +10,14 @@ defmodule Arrow.Disruption do
   import Ecto.Query
 
   alias Arrow.{DisruptionRevision, Repo}
+  alias Arrow.Disruption.Note
   alias Ecto.Changeset
 
   @type id :: integer
   @type t :: %__MODULE__{
           id: id,
           published_revision: DisruptionRevision.t() | Ecto.Association.NotLoaded.t(),
+          notes: [Note.t()] | Ecto.Association.NotLoaded.t(),
           last_published_at: DateTime.t() | nil,
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
@@ -24,6 +26,7 @@ defmodule Arrow.Disruption do
   schema "disruptions" do
     belongs_to :published_revision, DisruptionRevision
     has_many :revisions, DisruptionRevision
+    has_many :notes, Note
 
     field(:last_published_at, :utc_datetime)
 

--- a/lib/arrow/disruption.ex
+++ b/lib/arrow/disruption.ex
@@ -9,8 +9,8 @@ defmodule Arrow.Disruption do
   use Ecto.Schema
   import Ecto.Query
 
-  alias Arrow.{DisruptionRevision, Repo}
   alias Arrow.Disruption.Note
+  alias Arrow.{DisruptionRevision, Repo}
   alias Ecto.Changeset
 
   @type id :: integer
@@ -52,6 +52,7 @@ defmodule Arrow.Disruption do
       ]
     )
     |> Repo.one!()
+    |> Repo.preload([:notes])
   end
 
   @doc "Creates a new disruption, with its first revision having the given attributes."
@@ -150,5 +151,15 @@ defmodule Arrow.Disruption do
       preload: [revisions: {r, ^DisruptionRevision.associations()}]
     )
     |> Arrow.Repo.all()
+  end
+
+  @doc """
+  Inserts a new note associated with the given disruption_id.
+  """
+  @spec add_note(id, String.t(), map) :: {:ok, Note.t()} | {:error, Changeset.t(Note.t())}
+  def add_note(disruption_id, author, params) do
+    disruption_id
+    |> Note.changeset(author, params)
+    |> Repo.insert()
   end
 end

--- a/lib/arrow/disruption/note.ex
+++ b/lib/arrow/disruption/note.ex
@@ -1,0 +1,40 @@
+defmodule Arrow.Disruption.Note do
+  @moduledoc """
+  Free-form text notes that can be attached to a disruption.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Arrow.Disruption
+
+  @type t :: %__MODULE__{
+          body: String.t(),
+          author: String.t(),
+          disruption: Arrow.Disruption.t() | Ecto.Association.NotLoaded.t(),
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  schema "disruption_notes" do
+    field(:body, :string)
+    field(:author, :string)
+    belongs_to(:disruption, Arrow.Disruption)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc """
+  Produces a changeset to insert a new note. Expects a disruption_id which it
+  belongs to, as well as the author, both generated internally. User-supplied
+  data comes as params.
+  """
+  @spec changeset(Arrow.Disruption.id(), String.t(), map()) :: Ecto.Changeset.t(t())
+  def changeset(disruption_id, author, params) when byte_size(author) > 0 do
+    %Disruption{id: disruption_id}
+    |> Ecto.build_assoc(:notes)
+    |> cast(params, [:body])
+    |> put_change(:author, author)
+    |> validate_required([:body, :author])
+  end
+end

--- a/lib/arrow/disruption_revision.ex
+++ b/lib/arrow/disruption_revision.ex
@@ -19,6 +19,7 @@ defmodule Arrow.DisruptionRevision do
           is_active: boolean(),
           description: String.t(),
           adjustment_kind: atom() | nil,
+          note_body: String.t() | nil,
           disruption: Disruption.t() | Ecto.Association.NotLoaded.t(),
           days_of_week: [DayOfWeek.t()] | Ecto.Association.NotLoaded.t(),
           exceptions: [Exception.t()] | Ecto.Association.NotLoaded.t(),
@@ -35,6 +36,7 @@ defmodule Arrow.DisruptionRevision do
     field(:row_approved, :boolean, default: true)
     field(:description, :string)
     field(:adjustment_kind, Ecto.Enum, values: Adjustment.kinds())
+    field(:note_body, :string, virtual: true)
 
     belongs_to(:disruption, Disruption)
     has_many(:days_of_week, DayOfWeek, on_replace: :delete)
@@ -50,7 +52,7 @@ defmodule Arrow.DisruptionRevision do
   end
 
   @required_fields [:start_date, :end_date, :row_approved, :description]
-  @permitted_fields @required_fields ++ [:adjustment_kind]
+  @permitted_fields @required_fields ++ [:adjustment_kind, :note_body]
 
   @doc """
   Returns a list of either the revision's `adjustment_kind` if it has one, or the distinct kinds

--- a/lib/arrow_web/controllers/disruption_controller.ex
+++ b/lib/arrow_web/controllers/disruption_controller.ex
@@ -54,12 +54,12 @@ defmodule ArrowWeb.DisruptionController do
   @spec create(Conn.t(), Conn.params()) :: Conn.t()
   def create(conn, %{"revision" => attrs}) do
     case Disruption.create(attrs) do
-      {:ok, %{disruption_id: id}} ->
+      {:ok, %{revision: %{disruption_id: id}}} ->
         conn
         |> put_flash(:info, "Disruption created successfully.")
         |> redirect(to: Routes.disruption_path(conn, :show, id))
 
-      {:error, changeset} ->
+      {:error, :revision, changeset, _} ->
         conn
         |> put_flash(
           :errors,
@@ -72,12 +72,12 @@ defmodule ArrowWeb.DisruptionController do
   @spec update(Conn.t(), Conn.params()) :: Conn.t()
   def update(conn, %{"id" => id, "revision" => attrs}) do
     case Disruption.update(id, put_new_assocs(attrs)) do
-      {:ok, _revision} ->
+      {:ok, _multi} ->
         conn
         |> put_flash(:info, "Disruption updated successfully.")
         |> redirect(to: Routes.disruption_path(conn, :show, id))
 
-      {:error, changeset} ->
+      {:error, :revision, changeset, _} ->
         conn
         |> put_flash(
           :errors,

--- a/lib/arrow_web/controllers/disruption_controller.ex
+++ b/lib/arrow_web/controllers/disruption_controller.ex
@@ -30,8 +30,8 @@ defmodule ArrowWeb.DisruptionController do
 
   @spec show(Conn.t(), Conn.params()) :: Conn.t()
   def show(%{assigns: %{current_user: user}} = conn, %{"id" => id}) do
-    %{id: id, revisions: [revision]} = Disruption.get!(id)
-    render(conn, "show.html", id: id, revision: revision, user: user)
+    %{id: id, revisions: [revision], notes: notes} = Disruption.get!(id)
+    render(conn, "show.html", id: id, revision: revision, user: user, notes: notes)
   end
 
   @spec new(Conn.t(), Conn.params()) :: Conn.t()
@@ -61,7 +61,10 @@ defmodule ArrowWeb.DisruptionController do
 
       {:error, changeset} ->
         conn
-        |> put_flash(:errors, {"Disruption could not be created:", errors(changeset)})
+        |> put_flash(
+          :errors,
+          {"Disruption could not be created:", ErrorHelpers.changeset_error_messages(changeset)}
+        )
         |> render("new.html", adjustments: Adjustment.all(), changeset: changeset)
     end
   end
@@ -76,7 +79,10 @@ defmodule ArrowWeb.DisruptionController do
 
       {:error, changeset} ->
         conn
-        |> put_flash(:errors, {"Disruption could not be updated:", errors(changeset)})
+        |> put_flash(
+          :errors,
+          {"Disruption could not be updated:", ErrorHelpers.changeset_error_messages(changeset)}
+        )
         |> render("edit.html", adjustments: Adjustment.all(), changeset: changeset, id: id)
     end
   end
@@ -85,13 +91,6 @@ defmodule ArrowWeb.DisruptionController do
   def delete(conn, %{"id" => id}) do
     _revision = Disruption.delete!(id)
     redirect(conn, to: Routes.disruption_path(conn, :show, id))
-  end
-
-  @spec errors(Changeset.t()) :: [String.t()]
-  defp errors(changeset) do
-    changeset
-    |> Changeset.traverse_errors(&ErrorHelpers.translate_error/1)
-    |> ErrorHelpers.flatten_errors()
   end
 
   @spec put_new_assocs(%{optional(binary) => any}) :: %{binary => any}

--- a/lib/arrow_web/controllers/note_controller.ex
+++ b/lib/arrow_web/controllers/note_controller.ex
@@ -1,0 +1,27 @@
+defmodule ArrowWeb.NoteController do
+  use ArrowWeb, :controller
+
+  alias Arrow.Disruption
+  alias ArrowWeb.ErrorHelpers
+  alias ArrowWeb.Plug.Authorize
+
+  plug(Authorize, :create_note when action in [:create])
+
+  def create(%{assigns: %{current_user: user}} = conn, %{
+        "id" => disruption_id,
+        "note" => note_attrs
+      }) do
+    case Disruption.add_note(String.to_integer(disruption_id), user.id, note_attrs) do
+      {:ok, _} ->
+        redirect(conn, to: Routes.disruption_path(conn, :show, disruption_id))
+
+      {:error, changeset} ->
+        conn
+        |> put_flash(
+          :errors,
+          {"Note could not be created", ErrorHelpers.changeset_error_messages(changeset)}
+        )
+        |> redirect(to: Routes.disruption_path(conn, :show, disruption_id))
+    end
+  end
+end

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -48,6 +48,7 @@ defmodule ArrowWeb.Router do
     get("/", DisruptionController, :index)
     resources("/disruptions", DisruptionController, except: [:index])
     put("/disruptions/:id/row_status", DisruptionController, :update_row_status)
+    post("/disruptions/:id/notes", NoteController, :create)
   end
 
   scope "/", ArrowWeb do

--- a/lib/arrow_web/templates/disruption/_note.html.heex
+++ b/lib/arrow_web/templates/disruption/_note.html.heex
@@ -1,0 +1,7 @@
+<article class="mb-4">
+  <header class="m-note__header">
+    <h4 class="m-note__author"><%= @note.author %></h4>
+    <div class="m-note__timestamp"><%= format_date(@note.inserted_at) %></div>
+  </header>
+  <%= @note.body %>
+</article>

--- a/lib/arrow_web/templates/disruption/edit.html.heex
+++ b/lib/arrow_web/templates/disruption/edit.html.heex
@@ -11,6 +11,7 @@
     cancel_confirmation: "Discard all changes to this disruption?",
     cancel_path: Routes.disruption_path(@conn, :show, @id),
     changeset: @changeset,
-    conn: @conn
+    conn: @conn,
+    note_body: "",
   ) %>
 <% end %>

--- a/lib/arrow_web/templates/disruption/new.html.heex
+++ b/lib/arrow_web/templates/disruption/new.html.heex
@@ -7,6 +7,6 @@
     cancel_confirmation: "Discard all entered data?",
     cancel_path: Routes.disruption_path(@conn, :index),
     changeset: @changeset,
-    conn: @conn
+    conn: @conn,
   ) %>
 <% end %>

--- a/lib/arrow_web/templates/disruption/show.html.heex
+++ b/lib/arrow_web/templates/disruption/show.html.heex
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-lg-7">
+  <section class="col-lg-7">
     <div class="m-disruption-details__header">
       <div class="d-flex align-items-end">
         <h2 class="mb-0">disruption</h2>
@@ -101,5 +101,22 @@
         </div>
       <% end %>
     </div>
-  </div>
+  </section>
+
+  <section class="col-lg-4">
+    <h3>notes</h3>
+
+    <%= if Permissions.authorize?(:create_note, @user) do %>
+      <%= form_tag Routes.note_path(@conn, :create, @id), method: "post", class: "mb-4" do %>
+        <%= textarea(:note, :body, class: "w-100") %>
+        <div>
+          <%= submit "save", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    <% end %>
+
+    <%= for note <- @notes do %>
+      <%= render "_note.html", note: note %>
+    <% end %>
+  </section>
 </div>

--- a/lib/arrow_web/views/disruption_view.ex
+++ b/lib/arrow_web/views/disruption_view.ex
@@ -44,6 +44,14 @@ defmodule ArrowWeb.DisruptionView do
 
   defp format_date(date, fallback \\ "❓")
   defp format_date(%Date{} = date, _fallback), do: Calendar.strftime(date, "%m/%d/%Y")
+
+  defp format_date(%DateTime{} = dt, fallback) do
+    dt
+    |> DateTime.shift_zone!("America/New_York")
+    |> DateTime.to_date()
+    |> format_date(fallback)
+  end
+
   defp format_date(nil, fallback), do: fallback
 
   # Browsers strip any query params in a form's `action` before submitting, so to retain all the
@@ -84,5 +92,9 @@ defmodule ArrowWeb.DisruptionView do
 
   defp mark_as_approved_or_pending(false) do
     "mark as approved"
+  end
+
+  def date(dt) do
+    DateTime.shift_zone!(dt, "America/New_York") |> Calendar.strftime("%m/%d/%y")
   end
 end

--- a/lib/arrow_web/views/disruption_view/form.ex
+++ b/lib/arrow_web/views/disruption_view/form.ex
@@ -18,6 +18,7 @@ defmodule ArrowWeb.DisruptionView.Form do
       row_approved: row_approved,
       description: description,
       adjustment_kind: adjustment_kind,
+      note_body: note_body,
       adjustments: adjustments,
       days_of_week: days_of_week,
       exceptions: exceptions,
@@ -37,7 +38,8 @@ defmodule ArrowWeb.DisruptionView.Form do
         "exceptions" => Enum.map(exceptions, & &1.excluded_date),
         "tripShortNames" => trip_short_names |> Enum.map(& &1.trip_short_name) |> Enum.join(",")
       },
-      "iconPaths" => icon_paths(conn)
+      "iconPaths" => icon_paths(conn),
+      "noteBody" => note_body
     }
   end
 

--- a/lib/arrow_web/views/error_helpers.ex
+++ b/lib/arrow_web/views/error_helpers.ex
@@ -15,6 +15,17 @@ defmodule ArrowWeb.ErrorHelpers do
   end
 
   @doc """
+  Takes a changeset and returns a list of all its error messages.
+  """
+  @spec changeset_error_messages(Ecto.Changeset.t()) :: [String.t()]
+  def changeset_error_messages(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(&translate_error/1)
+    |> flatten_errors()
+  end
+
+  @spec flatten_errors(map) :: list
+  @doc """
   Converts a nested error map as returned from `Ecto.Changeset.traverse_errors/1` into a flat list
   of error messages.
   """

--- a/priv/repo/migrations/20220105203850_disruption_notes.exs
+++ b/priv/repo/migrations/20220105203850_disruption_notes.exs
@@ -1,0 +1,15 @@
+defmodule Arrow.Repo.Migrations.Notes do
+  use Ecto.Migration
+
+  def change do
+    create table("disruption_notes") do
+      add :body, :text, null: false
+      add :author, :string, null: false
+      add :disruption_id, references(:disruptions, on_delete: :delete_all), null: false
+
+      timestamps(type: :timestamptz)
+    end
+
+    create index("disruption_notes", [:disruption_id])
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -193,6 +193,39 @@ ALTER SEQUENCE public.disruption_exceptions_id_seq OWNED BY public.disruption_ex
 
 
 --
+-- Name: disruption_notes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.disruption_notes (
+    id bigint NOT NULL,
+    body text NOT NULL,
+    author character varying(255) NOT NULL,
+    disruption_id bigint NOT NULL,
+    inserted_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: disruption_notes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.disruption_notes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: disruption_notes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.disruption_notes_id_seq OWNED BY public.disruption_notes.id;
+
+
+--
 -- Name: disruption_revisions; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -340,6 +373,13 @@ ALTER TABLE ONLY public.disruption_exceptions ALTER COLUMN id SET DEFAULT nextva
 
 
 --
+-- Name: disruption_notes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_notes ALTER COLUMN id SET DEFAULT nextval('public.disruption_notes_id_seq'::regclass);
+
+
+--
 -- Name: disruption_revisions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -398,6 +438,14 @@ ALTER TABLE ONLY public.disruption_day_of_weeks
 
 ALTER TABLE ONLY public.disruption_exceptions
     ADD CONSTRAINT disruption_exceptions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: disruption_notes disruption_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_notes
+    ADD CONSTRAINT disruption_notes_pkey PRIMARY KEY (id);
 
 
 --
@@ -482,6 +530,13 @@ CREATE INDEX disruption_exceptions_disruption_id_index ON public.disruption_exce
 
 
 --
+-- Name: disruption_notes_disruption_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX disruption_notes_disruption_id_index ON public.disruption_notes USING btree (disruption_id);
+
+
+--
 -- Name: disruption_trip_short_names_disruption_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -525,6 +580,14 @@ ALTER TABLE ONLY public.disruption_day_of_weeks
 
 ALTER TABLE ONLY public.disruption_exceptions
     ADD CONSTRAINT disruption_exceptions_disruption_id_fkey FOREIGN KEY (disruption_revision_id) REFERENCES public.disruption_revisions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: disruption_notes disruption_notes_disruption_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.disruption_notes
+    ADD CONSTRAINT disruption_notes_disruption_id_fkey FOREIGN KEY (disruption_id) REFERENCES public.disruptions(id) ON DELETE CASCADE;
 
 
 --
@@ -572,3 +635,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20210921192435);
 INSERT INTO public."schema_migrations" (version) VALUES (20210922191945);
 INSERT INTO public."schema_migrations" (version) VALUES (20210924180538);
 INSERT INTO public."schema_migrations" (version) VALUES (20211209185029);
+INSERT INTO public."schema_migrations" (version) VALUES (20220105203850);

--- a/test/arrow/disruption/note_test.exs
+++ b/test/arrow/disruption/note_test.exs
@@ -1,0 +1,18 @@
+defmodule Arrow.Disruption.NoteTest do
+  use ExUnit.Case, async: true
+
+  alias Arrow.Disruption.Note
+
+  describe "changeset" do
+    test "valid with all the data" do
+      changeset = Note.changeset(10, "author", %{"body" => "this is the body"})
+      assert changeset.valid?
+    end
+
+    test "invalid without body" do
+      changeset = Note.changeset(10, "author", %{})
+      refute changeset.valid?
+      assert Keyword.get(changeset.errors, :body)
+    end
+  end
+end

--- a/test/arrow/disruption_test.exs
+++ b/test/arrow/disruption_test.exs
@@ -79,7 +79,7 @@ defmodule Arrow.DisruptionTest do
         "description" => "a testing disruption"
       }
 
-      {:ok, _id} = Disruption.create(attrs)
+      {:ok, _multi} = Disruption.create(attrs)
 
       [d] = Repo.all(Disruption)
 
@@ -108,7 +108,7 @@ defmodule Arrow.DisruptionTest do
         "days_of_week" => [%{"day_name" => "monday"}]
       }
 
-      {:error, changeset} = Disruption.create(attrs)
+      {:error, :revision, changeset, _} = Disruption.create(attrs)
 
       assert "can't be after end date" in errors_on(changeset).start_date
     end
@@ -120,7 +120,7 @@ defmodule Arrow.DisruptionTest do
         "days_of_week" => [%{"day_name" => "sunday"}]
       }
 
-      {:error, changeset} = Disruption.create(attrs)
+      {:error, :revision, changeset, _} = Disruption.create(attrs)
 
       assert "should fall between start and end dates" in errors_on(changeset).days_of_week
     end
@@ -133,7 +133,7 @@ defmodule Arrow.DisruptionTest do
         "exceptions" => [%{"excluded_date" => "2020-09-01"}]
       }
 
-      {:error, changeset} = Disruption.create(attrs)
+      {:error, :revision, changeset, _} = Disruption.create(attrs)
 
       assert "should fall between start and end dates" in errors_on(changeset).exceptions
     end
@@ -146,7 +146,7 @@ defmodule Arrow.DisruptionTest do
         "exceptions" => [%{"excluded_date" => "2020-08-18"}, %{"excluded_date" => "2020-08-18"}]
       }
 
-      {:error, changeset} = Disruption.create(attrs)
+      {:error, :revision, changeset, _} = Disruption.create(attrs)
 
       assert "should be unique" in errors_on(changeset).exceptions
     end
@@ -159,7 +159,7 @@ defmodule Arrow.DisruptionTest do
         "exceptions" => [%{"excluded_date" => "2020-08-19"}]
       }
 
-      {:error, changeset} = Disruption.create(attrs)
+      {:error, :revision, changeset, _} = Disruption.create(attrs)
 
       assert "should be applicable to days of week" in errors_on(changeset).exceptions
     end
@@ -167,16 +167,18 @@ defmodule Arrow.DisruptionTest do
     test "can't create disruption without days of week" do
       attrs = %{"start_date" => "2020-08-17", "end_date" => "2020-08-21"}
 
-      {:error, changeset} = Disruption.create(attrs)
+      {:error, :revision, changeset, _} = Disruption.create(attrs)
 
       assert "must be selected" in errors_on(changeset).days_of_week
     end
 
     test "requires exactly one of adjustment kind or non-empty adjustments" do
-      {:error, changeset} = Disruption.create(%{"adjustment_kind" => nil, "adjustments" => []})
+      {:error, :revision, changeset, _} =
+        Disruption.create(%{"adjustment_kind" => nil, "adjustments" => []})
+
       assert "is required without adjustments" in errors_on(changeset).adjustment_kind
 
-      {:error, changeset} =
+      {:error, :revision, changeset, _} =
         Disruption.create(%{
           "adjustment_kind" => "red_line",
           "adjustments" => [%{"id" => insert(:adjustment).id}]
@@ -209,7 +211,7 @@ defmodule Arrow.DisruptionTest do
         "trip_short_names" => [%{"trip_short_name" => "777"}, %{"trip_short_name" => "888"}]
       }
 
-      {:ok, _id} = Disruption.update(id, attrs)
+      {:ok, _multi} = Disruption.update(id, attrs)
 
       dr_ids = Repo.all(from(dr in DisruptionRevision, select: dr.id))
       assert length(dr_ids) == 2
@@ -238,7 +240,7 @@ defmodule Arrow.DisruptionTest do
     test "doesn't create a new revision if there is a validation error" do
       %{disruption_id: id} = insert(:disruption_revision)
 
-      {:error, _} = Disruption.update(id, %{start_date: nil})
+      {:error, _, _, _} = Disruption.update(id, %{start_date: nil})
 
       assert Repo.one!(DisruptionRevision)
     end
@@ -257,7 +259,7 @@ defmodule Arrow.DisruptionTest do
         "days_of_week" => [%{"day_name" => "tuesday"}]
       }
 
-      {:error, changeset} = Disruption.update(id, attrs)
+      {:error, :revision, changeset, _} = Disruption.update(id, attrs)
 
       assert "can't be after end date" in errors_on(changeset).start_date
     end
@@ -276,7 +278,7 @@ defmodule Arrow.DisruptionTest do
         "days_of_week" => [%{"day_name" => "sunday"}]
       }
 
-      {:error, changeset} = Disruption.update(id, attrs)
+      {:error, :revision, changeset, _} = Disruption.update(id, attrs)
 
       assert "should fall between start and end dates" in errors_on(changeset).days_of_week
     end
@@ -296,7 +298,7 @@ defmodule Arrow.DisruptionTest do
         "exceptions" => [%{"excluded_date" => "2020-09-01"}]
       }
 
-      {:error, changeset} = Disruption.update(id, attrs)
+      {:error, :revision, changeset, _} = Disruption.update(id, attrs)
 
       assert "should fall between start and end dates" in errors_on(changeset).exceptions
     end
@@ -316,7 +318,7 @@ defmodule Arrow.DisruptionTest do
         "exceptions" => [%{"excluded_date" => "2020-08-18"}, %{"excluded_date" => "2020-08-18"}]
       }
 
-      {:error, changeset} = Disruption.update(id, attrs)
+      {:error, :revision, changeset, _} = Disruption.update(id, attrs)
 
       assert "should be unique" in errors_on(changeset).exceptions
     end
@@ -336,7 +338,7 @@ defmodule Arrow.DisruptionTest do
         "exceptions" => [%{"excluded_date" => "2020-08-19"}]
       }
 
-      {:error, changeset} = Disruption.update(id, attrs)
+      {:error, :revision, changeset, _} = Disruption.update(id, attrs)
 
       assert "should be applicable to days of week" in errors_on(changeset).exceptions
     end
@@ -355,7 +357,7 @@ defmodule Arrow.DisruptionTest do
         "days_of_week" => []
       }
 
-      {:error, changeset} = Disruption.update(id, attrs)
+      {:error, :revision, changeset, _} = Disruption.update(id, attrs)
 
       assert "must be selected" in errors_on(changeset).days_of_week
     end
@@ -364,17 +366,20 @@ defmodule Arrow.DisruptionTest do
       %{disruption_id: kind_id} = insert(:disruption_revision, adjustment_kind: :bus)
       %{disruption_id: adj_id} = insert(:disruption_revision, adjustments: [build(:adjustment)])
 
-      {:error, changeset} = Disruption.update(kind_id, %{"adjustment_kind" => nil})
+      {:error, :revision, changeset, _} = Disruption.update(kind_id, %{"adjustment_kind" => nil})
       assert "is required without adjustments" in errors_on(changeset).adjustment_kind
 
-      {:error, changeset} = Disruption.update(adj_id, %{"adjustments" => []})
+      {:error, :revision, changeset, _} = Disruption.update(adj_id, %{"adjustments" => []})
       assert "is required without adjustments" in errors_on(changeset).adjustment_kind
 
       %{id: id} = insert(:adjustment)
-      {:error, changeset} = Disruption.update(kind_id, %{"adjustments" => [%{"id" => id}]})
+
+      {:error, :revision, changeset, _} =
+        Disruption.update(kind_id, %{"adjustments" => [%{"id" => id}]})
+
       assert "cannot be set with adjustments" in errors_on(changeset).adjustment_kind
 
-      {:error, changeset} = Disruption.update(adj_id, %{"adjustment_kind" => "bus"})
+      {:error, :revision, changeset, _} = Disruption.update(adj_id, %{"adjustment_kind" => "bus"})
       assert "cannot be set with adjustments" in errors_on(changeset).adjustment_kind
     end
   end

--- a/test/arrow_web/controllers/api/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/api/disruption_controller_test.exs
@@ -35,7 +35,7 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
           end_date: ~D[2019-11-01]
         )
 
-      {:ok, _revision} = Disruption.update(d1.id, %{end_date: ~D[2019-12-01]})
+      {:ok, _multi} = Disruption.update(d1.id, "author", %{end_date: ~D[2019-12-01]})
 
       new_d1 =
         Disruption
@@ -46,7 +46,7 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
       |> Changeset.change(%{published_revision_id: Enum.at(new_d1.revisions, -1).id})
       |> Repo.update!()
 
-      {:ok, _revision} = Disruption.update(d1.id, %{end_date: ~D[2020-01-01]})
+      {:ok, _multi} = Disruption.update(d1.id, "author", %{end_date: ~D[2020-01-01]})
 
       res = json_response(get(conn, "/api/disruptions"), 200)
 

--- a/test/arrow_web/controllers/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/disruption_controller_test.exs
@@ -29,6 +29,32 @@ defmodule ArrowWeb.DisruptionControllerTest do
 
       assert resp =~ "#{id}"
     end
+
+    @tag :authenticated
+    test "anyone can see notes, but not create new ones", %{conn: conn} do
+      %{disruption_id: id} = insert_revision_with_everything()
+      insert(:note, disruption_id: id, body: "This is the body")
+
+      resp =
+        conn
+        |> get(Routes.disruption_path(conn, :show, id))
+        |> html_response(200)
+
+      assert resp =~ "This is the body"
+      refute resp =~ "save"
+    end
+
+    @tag :authenticated_admin
+    test "admins see form to save new notes", %{conn: conn} do
+      %{disruption_id: id} = insert_revision_with_everything()
+
+      resp =
+        conn
+        |> get(Routes.disruption_path(conn, :show, id))
+        |> html_response(200)
+
+      assert resp =~ "save"
+    end
   end
 
   describe "new/2" do

--- a/test/arrow_web/controllers/note_controller_test.exs
+++ b/test/arrow_web/controllers/note_controller_test.exs
@@ -1,0 +1,45 @@
+defmodule ArrowWeb.NoteControllerTest do
+  use ArrowWeb.ConnCase, async: true
+
+  alias Arrow.Disruption
+  import Arrow.Factory
+
+  describe "create/2" do
+    @tag :authenticated_admin
+    test "inserts a note when valid", %{conn: conn} do
+      %{disruption_id: id} = insert(:disruption_revision, start_date: ~D[2021-01-01])
+      params = %{"note" => %{"body" => "This is a note."}}
+
+      conn = post(conn, Routes.note_path(conn, :create, id), params)
+
+      assert redirected_to(conn) == Routes.disruption_path(conn, :show, id)
+      disruption = Disruption.get!(id)
+      assert [%{body: "This is a note."}] = disruption.notes
+    end
+
+    @tag :authenticated_admin
+    test "redirects with error when invalid", %{conn: conn} do
+      %{disruption_id: id} = insert(:disruption_revision, start_date: ~D[2021-01-01])
+      params = %{"note" => %{}}
+
+      conn = post(conn, Routes.note_path(conn, :create, id), params)
+
+      assert redirected_to(conn) == Routes.disruption_path(conn, :show, id)
+      assert {_, _} = get_flash(conn, :errors)
+      disruption = Disruption.get!(id)
+      assert disruption.notes == []
+    end
+
+    @tag :authenticated
+    test "non-admin cannot add note", %{conn: conn} do
+      %{disruption_id: id} = insert(:disruption_revision, start_date: ~D[2021-01-01])
+      params = %{"note" => %{"body" => "This is a note."}}
+
+      conn = post(conn, Routes.note_path(conn, :create, id), params)
+
+      assert redirected_to(conn) == "/unauthorized"
+      disruption = Disruption.get!(id)
+      assert disruption.notes == []
+    end
+  end
+end

--- a/test/arrow_web/views/disruption_view/form_test.exs
+++ b/test/arrow_web/views/disruption_view/form_test.exs
@@ -23,6 +23,7 @@ defmodule ArrowWeb.DisruptionView.FormTest do
           end_date: ~D[2021-01-31],
           row_approved: true,
           description: "a disruption for testing",
+          note_body: "some note",
           adjustments: [hd(adjustments)],
           days_of_week: [%DayOfWeek{day_name: "monday", start_time: ~T[21:15:00], end_time: nil}],
           exceptions: [%Exception{excluded_date: ~D[2021-01-11]}],
@@ -55,6 +56,7 @@ defmodule ArrowWeb.DisruptionView.FormTest do
       assert props["allAdjustments"] == expected_adjustments
       assert props["disruptionRevision"] == expected_revision
       assert get_in(props, ["iconPaths", :subway]) =~ ~r(^/images/)
+      assert props["noteBody"] == "some note"
     end
   end
 end

--- a/test/integration/disruptions_test.exs
+++ b/test/integration/disruptions_test.exs
@@ -121,6 +121,35 @@ defmodule Arrow.Integration.DisruptionsTest do
     |> assert_text(adjustment.source_label)
   end
 
+  feature "note is preserved upon disruption validation errors", %{session: session} do
+    insert(:adjustment, route_id: "Green-B", source_label: "KendallPackardsCorner")
+    now = DateTime.now!("America/New_York")
+
+    # start date after end date to trigger validation failure.
+    start_date = now |> DateTime.add(7 * 24 * 60 * 60) |> Calendar.strftime("%m/%d/%Y")
+    end_date = now |> DateTime.add(-7 * 24 * 60 * 60) |> Calendar.strftime("%m/%d/%Y")
+
+    session
+    |> visit("/")
+    |> click(link("create"))
+    |> assert_text("create new disruption")
+    |> click(text("Pending"))
+    |> click(text("Subway"))
+    |> fill_in(css("[aria-label='description']"), with: "a test description")
+    |> click(text("Select..."))
+    |> click(text("Kendall Packards Corner"))
+    |> fill_in(text_field("start"), with: start_date)
+    |> send_keys([:enter])
+    |> fill_in(text_field("end"), with: end_date)
+    |> send_keys([:enter])
+    |> click(css("label", text: "Mon"))
+    |> assert_text("Start of service")
+    |> fill_in(css("[aria-label='note']"), with: "this is a note")
+    |> click(button("save"))
+    |> assert_text("Disruption could not be created")
+    |> assert_text("this is a note")
+  end
+
   defp build_today_revision do
     date = DateTime.now!("America/New_York") |> DateTime.to_date()
     day_name = date |> Calendar.strftime("%A") |> String.downcase()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -51,4 +51,8 @@ defmodule Arrow.Factory do
   def trip_short_name_factory do
     %Arrow.Disruption.TripShortName{trip_short_name: "1234"}
   end
+
+  def note_factory do
+    %Arrow.Disruption.Note{author: "An author", body: "This is the body."}
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Notes can be added to a disruption](https://app.asana.com/0/584764604969369/1201330656931525)

This adds the concept of "notes" to the app. Notes can be added from a form on the show page (if the user is an admin), or while creating or updating a disruption.

This PR can be reviewed commit-by-commit. The commits are:

1. Set up the data model. Notes belong to a disruption (not a revision).
2. Add notes from a form on the show page.
3. A refactor of `Disruption.create` and `Disruption.update` to switch to using `Ecto.Multi` in preparation for the next commit which adds notes. I went back and forth here and tried a few different approaches and liked this one the best. The main consideration is that the Ecto docs and the book *Programming Ecto* (which I bought and read while working on this PR......) recommend *not* including associations in a changeset on the parent, if you're only appending a new one, and not managing the collection as a whole. Given that, that points to either a transaction or a Multi, and I found the Multi pretty ergonomic in juggling the various parts of the transaction.
4. Add notes via disruption creation or update. This uses the Multi set up in the previous commit. I thought it was important to maintain the note contents on the page in the event that there was a validation failure on submit. I'm not entirely happy with the extra stuff I had to do to flow that through. I feel like ideally maybe it would be part of the changeset, but given the above point that children shouldn't be a part of the parent changeset in append-only scenarios I didn't want to do that. *Programming Ecto* gave the example of using an "embedded" schema (not backed by the DB) to be a virtual changeset container, which then handled the multiple underlying changesets, but this felt a little too complicated.

For now, I punted on the JS interaction to expose the note form on the show page. I think this can be cleanly and easily done by upgrading our `phoenix_live_view` to `0.17` which includes a `JS` module for this sort of thing. But the PR was already dragging and large, so I carved it off to another ticket.



#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
