### PR TITLE
fix: Use email address for Cognito ID

### DIFF
--- a/lib/arrow_web/controllers/auth_controller.ex
+++ b/lib/arrow_web/controllers/auth_controller.ex
@@ -4,7 +4,7 @@ defmodule ArrowWeb.AuthController do
 
   @spec callback(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
-    username = auth.uid
+    username = auth.info.email
     expiration = auth.credentials.expires_at
     credentials = conn.assigns.ueberauth_auth.credentials
 

--- a/test/arrow_web/controllers/auth_controller_test.exs
+++ b/test/arrow_web/controllers/auth_controller_test.exs
@@ -6,10 +6,13 @@ defmodule ArrowWeb.Controllers.AuthControllerTest do
       current_time = System.system_time(:second)
 
       auth = %Ueberauth.Auth{
-        uid: "foo@mbta.com",
+        uid: "ActiveDirectory_MBTA\\foo",
         credentials: %Ueberauth.Auth.Credentials{
           expires_at: current_time + 1_000,
           other: %{groups: ["test1"]}
+        },
+        info: %Ueberauth.Auth.Info{
+          email: "foo@mbta.com"
         }
       }
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

When testing out the Notes feature on arrow-dev and finally exercising the real Cognito flow, it turns out that the "user ID" was the Cognito internal ID, which for ActiveDirectory currently has the form `ActiveDirectory_MBTA\[username]`. In the mock-ups and generally throughout the app, we'll want to tag actions with the email address.

I opted to change the username to the email address rather than keeping it with the cognito pool user ID and adding email as a field for simplicity. Since we're just annotating a field, rather than maintaining a full users table (with all the pros & cons that would entail), the ID itself is fairly meaningless while the email address is useful if you want to know how to contact someone who left a comment or (in the future) made a change to the disruption. While you can generally infer the email from the cognito ID currently, that ID format itself has changed 3 times since we've used Cognito, and may in the future as well. And non-Active Directory cognito accounts, like in Alerts-UI, just have a UUID in that field.

This branch is on dev now.

<img width="1049" alt="Screen Shot 2022-01-26 at 8 42 54 AM" src="https://user-images.githubusercontent.com/384428/151184136-0898abfb-5d98-45fb-bebc-491707bb5788.png">


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
