### PR TITLE
fix: Hide notes feature for now

### DIFF
--- a/assets/src/components/DisruptionForm.tsx
+++ b/assets/src/components/DisruptionForm.tsx
@@ -149,7 +149,6 @@ interface DisruptionFormProps {
   allAdjustments: Adjustment[]
   disruptionRevision: DisruptionRevision
   iconPaths: { [icon: string]: string }
-  noteBody: string
 }
 
 /**
@@ -173,14 +172,12 @@ const DisruptionForm = ({
     tripShortNames: initialTripShortNames,
   },
   iconPaths,
-  noteBody: initialNoteBody,
 }: DisruptionFormProps) => {
   const [isRowApproved, setIsRowApproved] = useState(initialRowApproved)
   const [description, setDescription] = useState(initialDescription)
   const [adjustmentKind, setAdjustmentKind] = useState(initialAdjustmentKind)
   const [hasAdjustments, setHasAdjustments] = useState(adjustmentKind === null)
   const [adjustments, setAdjustments] = useState(initialAdjustments)
-  const [noteBody, setNoteBody] = useState(initialNoteBody)
 
   const [mode, setMode] = useState<Mode | null>(
     initialMode(adjustments, adjustmentKind)
@@ -553,20 +550,6 @@ const DisruptionForm = ({
             </button>
           </div>
         )}
-      </fieldset>
-
-      <fieldset>
-        <legend>
-          notes{" "}
-          <span className="m-disruption-form__legend-optional">optional</span>
-        </legend>
-        <textarea
-          className="w-100"
-          name="revision[note_body]"
-          value={noteBody}
-          onChange={(event) => setNoteBody(event.target.value)}
-          aria-label="note"
-        />
       </fieldset>
     </>
   )

--- a/assets/tests/components/DisruptionForm.test.tsx
+++ b/assets/tests/components/DisruptionForm.test.tsx
@@ -48,7 +48,6 @@ describe("DisruptionForm", () => {
             tripShortNames: "trip1,trip2",
           }}
           iconPaths={{}}
-          noteBody=""
         />
       </form>
     )
@@ -99,7 +98,6 @@ describe("DisruptionForm", () => {
         allAdjustments={adjustments}
         disruptionRevision={blankRevision}
         iconPaths={{}}
-        noteBody=""
       />
     )
 
@@ -136,7 +134,6 @@ describe("DisruptionForm", () => {
           allAdjustments={adjustments}
           disruptionRevision={blankRevision}
           iconPaths={{}}
-          noteBody=""
         />
       </form>
     )
@@ -157,7 +154,6 @@ describe("DisruptionForm", () => {
           allAdjustments={adjustments}
           disruptionRevision={blankRevision}
           iconPaths={{}}
-          noteBody=""
         />
       </form>
     )
@@ -178,7 +174,6 @@ describe("DisruptionForm", () => {
         allAdjustments={adjustments}
         disruptionRevision={blankRevision}
         iconPaths={{}}
-        noteBody=""
       />
     )
 

--- a/lib/arrow_web/templates/disruption/show.html.heex
+++ b/lib/arrow_web/templates/disruption/show.html.heex
@@ -80,21 +80,6 @@
 
   <section class="col-lg-5">
     <%= if @revision.is_active do %>
-      <h3>notes</h3>
-
-      <%= if Permissions.authorize?(:create_note, @user) do %>
-        <%= form_tag Routes.note_path(@conn, :create, @id), method: "post", class: "mb-4" do %>
-          <%= textarea(:note, :body, class: "w-100") %>
-          <div>
-            <%= submit "save", class: "btn btn-primary" %>
-          </div>
-        <% end %>
-      <% end %>
-
-      <%= for note <- @notes do %>
-        <%= render "_note.html", note: note %>
-      <% end %>
-    
       <div class="m-disruption-details_flex align-items-center">
         <%= if Permissions.authorize?(:update_disruption, @user) do %>
           <%= form_tag Routes.disruption_path(@conn, :update_row_status, @revision.disruption_id), method: "put" do %>

--- a/test/arrow_web/controllers/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/disruption_controller_test.exs
@@ -29,32 +29,6 @@ defmodule ArrowWeb.DisruptionControllerTest do
 
       assert resp =~ "#{id}"
     end
-
-    @tag :authenticated
-    test "anyone can see notes, but not create new ones", %{conn: conn} do
-      %{disruption_id: id} = insert_revision_with_everything()
-      insert(:note, disruption_id: id, body: "This is the body")
-
-      resp =
-        conn
-        |> get(Routes.disruption_path(conn, :show, id))
-        |> html_response(200)
-
-      assert resp =~ "This is the body"
-      refute resp =~ "save"
-    end
-
-    @tag :authenticated_admin
-    test "admins see form to save new notes", %{conn: conn} do
-      %{disruption_id: id} = insert_revision_with_everything()
-
-      resp =
-        conn
-        |> get(Routes.disruption_path(conn, :show, id))
-        |> html_response(200)
-
-      assert resp =~ "save"
-    end
   end
 
   describe "new/2" do

--- a/test/integration/disruptions_test.exs
+++ b/test/integration/disruptions_test.exs
@@ -121,35 +121,6 @@ defmodule Arrow.Integration.DisruptionsTest do
     |> assert_text(adjustment.source_label)
   end
 
-  feature "note is preserved upon disruption validation errors", %{session: session} do
-    insert(:adjustment, route_id: "Green-B", source_label: "KendallPackardsCorner")
-    now = DateTime.now!("America/New_York")
-
-    # start date after end date to trigger validation failure.
-    start_date = now |> DateTime.add(7 * 24 * 60 * 60) |> Calendar.strftime("%m/%d/%Y")
-    end_date = now |> DateTime.add(-7 * 24 * 60 * 60) |> Calendar.strftime("%m/%d/%Y")
-
-    session
-    |> visit("/")
-    |> click(link("create"))
-    |> assert_text("create new disruption")
-    |> click(text("Pending"))
-    |> click(text("Subway"))
-    |> fill_in(css("[aria-label='description']"), with: "a test description")
-    |> click(text("Select..."))
-    |> click(text("Kendall Packards Corner"))
-    |> fill_in(text_field("start"), with: start_date)
-    |> send_keys([:enter])
-    |> fill_in(text_field("end"), with: end_date)
-    |> send_keys([:enter])
-    |> click(css("label", text: "Mon"))
-    |> assert_text("Start of service")
-    |> fill_in(css("[aria-label='note']"), with: "this is a note")
-    |> click(button("save"))
-    |> assert_text("Disruption could not be created")
-    |> assert_text("this is a note")
-  end
-
   defp build_today_revision do
     date = DateTime.now!("America/New_York") |> DateTime.to_date()
     day_name = date |> Calendar.strftime("%A") |> String.downcase()


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

Per discussion in #829, we decided to just hide the Notes feature altogether for now.

In terms of what "hide" means, I did a fairly minimal approach of removing the form from the page, but the controller and DB side of things are still there. Another approach could have been a complete rip-out or revert of the Notes feature, but I actually kind of liked some of the refactors in that PR. Plus, while we're putting Arrow work on ice for now, I hope that in the future we'll come back to it, and we can enable notes then, along with the infrastructure/AD work. Also, this was quick and I just want to be done with this saga....


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
