### PR TITLE
feat: don't require admin privs to fetch API token

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,6 @@ config :arrow,
     update_disruption: [:admin],
     delete_disruption: [:admin],
     create_note: [:admin],
-    use_api: [:admin],
     view_change_feed: [:admin]
   },
   time_zone: "America/New_York",

--- a/lib/arrow/permissions.ex
+++ b/lib/arrow/permissions.ex
@@ -10,7 +10,6 @@ defmodule Arrow.Permissions do
           :create_disruption
           | :update_disruption
           | :delete_disruption
-          | :use_api
           | :view_change_feed
 
   @spec authorize(action(), User.t()) :: :ok | {:error, :unauthorized}

--- a/lib/arrow_web/controllers/my_token_controller.ex
+++ b/lib/arrow_web/controllers/my_token_controller.ex
@@ -2,8 +2,6 @@ defmodule ArrowWeb.MyTokenController do
   use ArrowWeb, :controller
   alias Arrow.AuthToken
 
-  plug(ArrowWeb.Plug.Authorize, :use_api)
-
   @spec show(Plug.Conn.t(), Plug.Conn.params()) :: Plug.Conn.t()
   def show(conn, _params) do
     token = conn |> get_session(:arrow_username) |> AuthToken.get_or_create_token_for_user()

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -36,7 +36,6 @@ defmodule ArrowWeb.Router do
     plug(ArrowWeb.TryApiTokenAuth)
     plug(Guardian.Plug.EnsureAuthenticated)
     plug(ArrowWeb.Plug.AssignUser)
-    plug(ArrowWeb.Plug.Authorize, :use_api)
   end
 
   scope "/", ArrowWeb do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Allow read-only users to access API token](https://app.asana.com/0/584764604969369/1204479614714399/f)

Removes the config that requires admin privileges for viewing the user's API token.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
