### PR TITLE
fix: update SHA256 for AWS cert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mix local.hex --force && \
 
 RUN curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
   -o /root/aws-cert-bundle.pem
-RUN echo "2c151768edd48e9ef6719de74fdcbdebe290d1e87bc02ce9014ea6eea557d2a0 /root/aws-cert-bundle.pem" | sha256sum -c -
+RUN echo "51b107da46717aed974d97464b63f7357b220fe8737969db1492d1cae74b3947 /root/aws-cert-bundle.pem" | sha256sum -c -
 
 # Instructions from:
 # https://github.com/nodesource/distributions#debian-versions


### PR DESCRIPTION
#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
