### PR TITLE
fix: fix parameter parsing after plug update

### DIFF
--- a/assets/src/components/DisruptionForm.tsx
+++ b/assets/src/components/DisruptionForm.tsx
@@ -316,7 +316,7 @@ const DisruptionForm = ({
             <Select
               className="ml-4 mb-4"
               classNamePrefix="adjustment-select"
-              name="revision[adjustments][][id]"
+              name="revision[adjustments][id][]"
               isMulti={true}
               options={adjustmentSelectOptions}
               value={adjustmentSelectValues}
@@ -403,7 +403,7 @@ const DisruptionForm = ({
                 <input
                   key={index}
                   type="hidden"
-                  name="revision[trip_short_names][][trip_short_name]"
+                  name={`revision[trip_short_names][${index}][trip_short_name]`}
                   value={name}
                 />
               ))}
@@ -517,7 +517,7 @@ const DisruptionForm = ({
         {exceptions.map((exception, index) => (
           <div key={index} className="row mb-2 ml-0">
             <DatePicker
-              name="revision[exceptions][][excluded_date]"
+              name={`revision[exceptions][${index}][excluded_date]`}
               required={true}
               selected={exception}
               excludeDates={exceptions.filter((e) => e !== null) as string[]}

--- a/assets/tests/components/DisruptionForm.test.tsx
+++ b/assets/tests/components/DisruptionForm.test.tsx
@@ -76,7 +76,7 @@ describe("DisruptionForm", () => {
     pickDate(exceptions[exceptions.length - 1], "01/13/2021")
 
     expect(screen.getByRole("form")).toHaveFormValues({
-      "revision[adjustments][][id]": ["3", "4"],
+      "revision[adjustments][id]": ["3", "4"],
       "revision[start_date]": "2021-01-04",
       "revision[end_date]": "2021-01-29",
       "revision[description]": "Worcester test disruption",
@@ -87,8 +87,10 @@ describe("DisruptionForm", () => {
       "revision[days_of_week][1][day_name]": "wednesday",
       "revision[days_of_week][1][start_time]": "16:30:00",
       "revision[days_of_week][1][end_time]": "",
-      "revision[exceptions][][excluded_date]": ["2021-01-12", "2021-01-13"],
-      "revision[trip_short_names][][trip_short_name]": ["trip1", "trip3"],
+      "revision[exceptions][0][excluded_date]": "2021-01-12",
+      "revision[exceptions][1][excluded_date]": "2021-01-13",
+      "revision[trip_short_names][0][trip_short_name]": "trip1",
+      "revision[trip_short_names][1][trip_short_name]": "trip3",
     })
   })
 

--- a/lib/arrow/disruption_revision.ex
+++ b/lib/arrow/disruption_revision.ex
@@ -147,7 +147,7 @@ defmodule Arrow.DisruptionRevision do
   # records in the target table (adjustments), not the records in the join table, so we have to
   # implement this cast ourselves
   defp cast_adjustments(data, %{"adjustments" => attrs}) do
-    ids = attrs |> Enum.map(& &1["id"]) |> Enum.reject(&(&1 in [nil, ""]))
+    ids = attrs |> Map.get("id", []) |> Enum.reject(&(&1 in [nil, ""]))
     adjustments = Repo.all(from a in Adjustment, where: a.id in ^ids)
     Changeset.put_assoc(data, :adjustments, adjustments)
   end

--- a/lib/arrow_web/controllers/disruption_controller.ex
+++ b/lib/arrow_web/controllers/disruption_controller.ex
@@ -103,7 +103,7 @@ defmodule ArrowWeb.DisruptionController do
     # Ensure a form submission with no instances of an association is interpreted as "delete all
     # existing records" rather than "leave existing records alone"
     attrs
-    |> Map.put_new("adjustments", [])
+    |> Map.put_new("adjustments", %{})
     |> Map.put_new("days_of_week", [])
     |> Map.put_new("exceptions", [])
     |> Map.put_new("trip_short_names", [])

--- a/test/arrow/disruption_test.exs
+++ b/test/arrow/disruption_test.exs
@@ -73,7 +73,7 @@ defmodule Arrow.DisruptionTest do
         "start_date" => "2021-01-01",
         "end_date" => "2021-12-31",
         "row_approved" => "true",
-        "adjustments" => [%{"id" => insert(:adjustment).id}],
+        "adjustments" => %{"id" => [insert(:adjustment).id]},
         "days_of_week" => [%{"day_name" => "monday", "start_time" => "20:00:00"}],
         "exceptions" => [%{"excluded_date" => "2021-01-11"}],
         "trip_short_names" => [%{"trip_short_name" => "777"}],
@@ -175,14 +175,14 @@ defmodule Arrow.DisruptionTest do
 
     test "requires exactly one of adjustment kind or non-empty adjustments" do
       {:error, :revision, changeset, _} =
-        Disruption.create("author", %{"adjustment_kind" => nil, "adjustments" => []})
+        Disruption.create("author", %{"adjustment_kind" => nil, "adjustments" => %{}})
 
       assert "is required without adjustments" in errors_on(changeset).adjustment_kind
 
       {:error, :revision, changeset, _} =
         Disruption.create("author", %{
           "adjustment_kind" => "red_line",
-          "adjustments" => [%{"id" => insert(:adjustment).id}]
+          "adjustments" => %{"id" => [insert(:adjustment).id]}
         })
 
       assert "cannot be set with adjustments" in errors_on(changeset).adjustment_kind
@@ -193,7 +193,7 @@ defmodule Arrow.DisruptionTest do
         "start_date" => "2021-01-01",
         "end_date" => "2021-12-31",
         "row_approved" => "true",
-        "adjustments" => [%{"id" => insert(:adjustment).id}],
+        "adjustments" => %{"id" => [insert(:adjustment).id]},
         "days_of_week" => [%{"day_name" => "monday", "start_time" => "20:00:00"}],
         "exceptions" => [%{"excluded_date" => "2021-01-11"}],
         "trip_short_names" => [%{"trip_short_name" => "777"}],
@@ -392,14 +392,14 @@ defmodule Arrow.DisruptionTest do
       assert "is required without adjustments" in errors_on(changeset).adjustment_kind
 
       {:error, :revision, changeset, _} =
-        Disruption.update(adj_id, "author", %{"adjustments" => []})
+        Disruption.update(adj_id, "author", %{"adjustments" => %{}})
 
       assert "is required without adjustments" in errors_on(changeset).adjustment_kind
 
       %{id: id} = insert(:adjustment)
 
       {:error, :revision, changeset, _} =
-        Disruption.update(kind_id, "author", %{"adjustments" => [%{"id" => id}]})
+        Disruption.update(kind_id, "author", %{"adjustments" => %{"id" => [id]}})
 
       assert "cannot be set with adjustments" in errors_on(changeset).adjustment_kind
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No Ticket

In https://github.com/mbta/arrow/commit/a639ec8d25e94c04cd05c2e3c951143c77e56896, `plug` was updated to `1.15.2`, where [version 1.5.0](https://github.com/elixir-plug/plug/blob/main/CHANGELOG.md#v1150-2023-10-01) changed how URL encoded parameters in the form of `param[][field]` are handled. The solution is either to use parameters in the form of `param[field][]` or `param[index][field]`. This PR updates all such usages to be compatible with the new parser.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
