### PR TITLE
feat: non-admins can fetch their token and use GET apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 - `mix deps.get`
 - `mix esbuild.install`
 - `npm install --prefix assets`
+- `direnv allow`
 - `cp .envrc.example .envrc`
 - Update `.envrc` with your local Postgres username and password
-- `direnv allow`
 - `mix ecto.setup`
 - `brew install chromedriver`
 - Add your Arrow API key from https://arrow.mbta.com/mytoken to `.envrc`

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -38,8 +38,13 @@
         "typescript": "^3.9.10"
       }
     },
-    "../deps/phoenix": {},
-    "../deps/phoenix_html": {},
+    "../deps/phoenix": {
+      "version": "1.6.16",
+      "license": "MIT"
+    },
+    "../deps/phoenix_html": {
+      "version": "3.2.0"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,7 +28,9 @@ config :arrow,
     update_disruption: ["admin"],
     delete_disruption: ["admin"],
     create_note: ["admin"],
-    view_change_feed: ["admin"]
+    view_change_feed: ["admin"],
+    publish_notice: ["admin"],
+    db_dump: ["admin"]
   },
   time_zone: "America/New_York",
   ex_aws_requester: {Fake.ExAws, :admin_group_request},

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,7 +28,6 @@ config :arrow,
     update_disruption: ["admin"],
     delete_disruption: ["admin"],
     create_note: ["admin"],
-    use_api: ["admin"],
     view_change_feed: ["admin"]
   },
   time_zone: "America/New_York",

--- a/lib/arrow/permissions.ex
+++ b/lib/arrow/permissions.ex
@@ -12,6 +12,8 @@ defmodule Arrow.Permissions do
           | :update_disruption
           | :delete_disruption
           | :view_change_feed
+          | :publish_notice
+          | :db_dump
 
   @spec authorize(action(), User.t()) :: :ok | {:error, :unauthorized}
   def authorize(action, user) do

--- a/lib/arrow/permissions.ex
+++ b/lib/arrow/permissions.ex
@@ -11,7 +11,6 @@ defmodule Arrow.Permissions do
           | :create_disruption
           | :update_disruption
           | :delete_disruption
-          | :use_api
           | :view_change_feed
 
   @spec authorize(action(), User.t()) :: :ok | {:error, :unauthorized}

--- a/lib/arrow_web/controllers/api/db_dump_controller.ex
+++ b/lib/arrow_web/controllers/api/db_dump_controller.ex
@@ -1,5 +1,8 @@
 defmodule ArrowWeb.API.DBDumpController do
+  alias ArrowWeb.Plug.Authorize
   use ArrowWeb, :controller
+
+  plug(Authorize, :db_dump)
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, _params) do

--- a/lib/arrow_web/controllers/api/notice_controller.ex
+++ b/lib/arrow_web/controllers/api/notice_controller.ex
@@ -1,6 +1,9 @@
 defmodule ArrowWeb.API.NoticeController do
+  alias ArrowWeb.Plug.Authorize
   use ArrowWeb, :controller
   require Logger
+
+  plug(Authorize, :publish_notice)
 
   @spec publish(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def publish(conn, params) do

--- a/lib/arrow_web/controllers/my_token_controller.ex
+++ b/lib/arrow_web/controllers/my_token_controller.ex
@@ -2,8 +2,6 @@ defmodule ArrowWeb.MyTokenController do
   use ArrowWeb, :controller
   alias Arrow.AuthToken
 
-  plug(ArrowWeb.Plug.Authorize, :use_api)
-
   @spec show(Plug.Conn.t(), Plug.Conn.params()) :: Plug.Conn.t()
   def show(conn, _params) do
     token = conn |> Guardian.Plug.current_resource() |> AuthToken.get_or_create_token_for_user()

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -35,7 +35,6 @@ defmodule ArrowWeb.Router do
     plug(ArrowWeb.TryApiTokenAuth)
     plug(Guardian.Plug.EnsureAuthenticated)
     plug(ArrowWeb.Plug.AssignUser)
-    plug(ArrowWeb.Plug.Authorize, :use_api)
   end
 
   scope "/", ArrowWeb do

--- a/test/arrow_web/controllers/api/adjustment_controller_test.exs
+++ b/test/arrow_web/controllers/api/adjustment_controller_test.exs
@@ -4,8 +4,8 @@ defmodule ArrowWeb.API.AdjustmentControllerTest do
 
   describe "index/2" do
     @tag :authenticated
-    test "non-admin user can't access the adjustments API", %{conn: conn} do
-      assert conn |> get("/api/adjustments") |> redirected_to() == "/unauthorized"
+    test "non-admin user can access the adjustments API", %{conn: conn} do
+      assert %{status: 200} = get(conn, "/api/adjustments")
     end
 
     @tag :authenticated_admin

--- a/test/arrow_web/controllers/api/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/api/disruption_controller_test.exs
@@ -6,8 +6,8 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
 
   describe "index/2" do
     @tag :authenticated
-    test "non-admin user can't access the disruptions API", %{conn: conn} do
-      assert conn |> get("/api/disruptions") |> redirected_to() == "/unauthorized"
+    test "non-admin user can access the disruptions API", %{conn: conn} do
+      assert %{status: 200} = get(conn, "/api/disruptions")
     end
 
     @tag :authenticated_admin

--- a/test/arrow_web/controllers/my_token_controller_test.exs
+++ b/test/arrow_web/controllers/my_token_controller_test.exs
@@ -3,14 +3,13 @@ defmodule ArrowWeb.MyTokenControllerTest do
 
   @tag :authenticated_admin
   test "GET /mytoken", %{conn: conn} do
-    conn = get(conn, Routes.my_token_path(conn, :show))
-    assert html_response(conn, 200) =~ "Your token is"
+    conn = get(conn, routes.my_token_path(conn, :show))
+    assert html_response(conn, 200) =~ "your token is"
   end
 
   @tag :authenticated
-  test "non-admin user cannot get their API token", %{conn: conn} do
-    assert conn
-           |> get(Routes.my_token_path(conn, :show))
-           |> redirected_to() == "/unauthorized"
+  test "non-admin user can get their API token", %{conn: conn} do
+    conn = get(conn, routes.my_token_path(conn, :show))
+    assert html_response(conn, 200) =~ "your token is"
   end
 end

--- a/test/arrow_web/controllers/my_token_controller_test.exs
+++ b/test/arrow_web/controllers/my_token_controller_test.exs
@@ -3,13 +3,13 @@ defmodule ArrowWeb.MyTokenControllerTest do
 
   @tag :authenticated_admin
   test "GET /mytoken", %{conn: conn} do
-    conn = get(conn, routes.my_token_path(conn, :show))
-    assert html_response(conn, 200) =~ "your token is"
+    conn = get(conn, Routes.my_token_path(conn, :show))
+    assert html_response(conn, 200) =~ "Your token is"
   end
 
   @tag :authenticated
   test "non-admin user can get their API token", %{conn: conn} do
-    conn = get(conn, routes.my_token_path(conn, :show))
-    assert html_response(conn, 200) =~ "your token is"
+    conn = get(conn, Routes.my_token_path(conn, :show))
+    assert html_response(conn, 200) =~ "Your token is"
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [💳 Fix Dependabot CI on gtfs_creator](https://app.asana.com/0/584764604969369/1206364138902694)

Related to https://github.com/mbta/arrow/pull/963 in that we need the GET APIs to support non-admin users for dependabot 

Partly based on https://github.com/mbta/arrow/pull/930 with other updates since then.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
