### PR TITLE
feat: add login via token for API user for dependabot

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,7 @@ config :arrow,
   },
   ueberauth_provider: :cognito,
   api_login_module: ArrowWeb.TryApiTokenAuth.Cognito,
+  local_token_allowed_domain: "@mbta.com",
   required_roles: %{
     view_disruption: ["read-only", "admin"],
     create_disruption: ["admin"],

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,7 +22,6 @@ config :arrow,
   },
   ueberauth_provider: :cognito,
   api_login_module: ArrowWeb.TryApiTokenAuth.Cognito,
-  local_token_allowed_domain: "@mbta.com",
   required_roles: %{
     view_disruption: ["read-only", "admin"],
     create_disruption: ["admin"],

--- a/lib/arrow_web/try_api_token_auth.ex
+++ b/lib/arrow_web/try_api_token_auth.ex
@@ -40,6 +40,10 @@ defmodule ArrowWeb.TryApiTokenAuth do
     ArrowWeb.TryApiTokenAuth.Cognito
   end
 
+  defp api_login_module_for_token(%Arrow.AuthToken{username: "gtfs_creator_ci@mbta.com"}) do
+    ArrowWeb.TryApiTokenAuth.Local
+  end
+
   defp api_login_module_for_token(_token) do
     Application.get_env(:arrow, :api_login_module)
   end

--- a/lib/arrow_web/try_api_token_auth/local.ex
+++ b/lib/arrow_web/try_api_token_auth/local.ex
@@ -8,23 +8,12 @@ defmodule ArrowWeb.TryApiTokenAuth.Local do
 
   @spec sign_in(Conn.t(), Arrow.AuthToken.t()) :: Conn.t()
   def sign_in(%Conn{} = conn, %Arrow.AuthToken{} = auth_token) do
-    if String.ends_with?(
-         auth_token.username,
-         Application.get_env(:arrow, :local_token_allowed_domain)
-       ) do
-      conn
-      |> Guardian.Plug.sign_in(
-        ArrowWeb.AuthManager,
-        auth_token.username,
-        %{roles: ["read-only"]},
-        ttl: {0, :second}
-      )
-    else
-      Logger.warn(
-        "refusing to login in API client username=#{inspect(auth_token.username)} reason=unexpected username"
-      )
-
-      conn
-    end
+    conn
+    |> Guardian.Plug.sign_in(
+      ArrowWeb.AuthManager,
+      auth_token.username,
+      %{roles: ["read-only"]},
+      ttl: {0, :second}
+    )
   end
 end

--- a/lib/arrow_web/try_api_token_auth/local.ex
+++ b/lib/arrow_web/try_api_token_auth/local.ex
@@ -1,0 +1,30 @@
+defmodule ArrowWeb.TryApiTokenAuth.Local do
+  @moduledoc """
+  Signs in an API client from a database token for read-only access.
+  """
+
+  alias Plug.Conn
+  require Logger
+
+  @spec sign_in(Conn.t(), Arrow.AuthToken.t()) :: Conn.t()
+  def sign_in(%Conn{} = conn, %Arrow.AuthToken{} = auth_token) do
+    if String.ends_with?(
+         auth_token.username,
+         Application.get_env(:arrow, :local_token_allowed_domain)
+       ) do
+      conn
+      |> Guardian.Plug.sign_in(
+        ArrowWeb.AuthManager,
+        auth_token.username,
+        %{roles: ["read-only"]},
+        ttl: {0, :second}
+      )
+    else
+      Logger.warn(
+        "refusing to login in API client username=#{inspect(auth_token.username)} reason=unexpected username"
+      )
+
+      conn
+    end
+  end
+end

--- a/priv/repo/migrations/20240207224211_add_ci_readonly_user_token.exs
+++ b/priv/repo/migrations/20240207224211_add_ci_readonly_user_token.exs
@@ -1,0 +1,7 @@
+defmodule Arrow.Repo.Migrations.AddCiReadonlyUserToken do
+  use Ecto.Migration
+
+  def change do
+    Arrow.AuthToken.get_or_create_token_for_user("gtfs_creator_ci@mbta.com")
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -636,3 +636,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20210922191945);
 INSERT INTO public."schema_migrations" (version) VALUES (20210924180538);
 INSERT INTO public."schema_migrations" (version) VALUES (20211209185029);
 INSERT INTO public."schema_migrations" (version) VALUES (20220105203850);
+INSERT INTO public."schema_migrations" (version) VALUES (20240207224211);

--- a/test/arrow_web/try_api_token_auth/local_test.exs
+++ b/test/arrow_web/try_api_token_auth/local_test.exs
@@ -29,18 +29,6 @@ defmodule ArrowWeb.TryApiTokenAuth.LocalTest do
 
       refute Guardian.Plug.authenticated?(conn)
     end
-
-    test "does not sign in a token user who does not have an @mbta.com email", %{conn: conn} do
-      unknown_domain = "arrow-missing@unknown.com"
-      Arrow.AuthToken.get_or_create_token_for_user(unknown_domain)
-      auth_token = auth_token_for(unknown_domain)
-
-      {conn, log} = with_log(fn -> Local.sign_in(conn, auth_token) end)
-
-      refute Guardian.Plug.authenticated?(conn)
-
-      assert log =~ "refusing to login"
-    end
   end
 
   defp auth_token_for(username) do

--- a/test/arrow_web/try_api_token_auth/local_test.exs
+++ b/test/arrow_web/try_api_token_auth/local_test.exs
@@ -1,0 +1,49 @@
+defmodule ArrowWeb.TryApiTokenAuth.LocalTest do
+  use ArrowWeb.ConnCase
+  import ExUnit.CaptureLog
+
+  alias ArrowWeb.TryApiTokenAuth.Local
+
+  describe "sign_in/2" do
+    test "signs in a read-only token user", %{conn: conn} do
+      local_token_email = "gtfs_creator_ci@mbta.com"
+      auth_token = auth_token_for(local_token_email)
+
+      conn = Local.sign_in(conn, auth_token)
+
+      assert Guardian.Plug.authenticated?(conn)
+      claims = Guardian.Plug.current_claims(conn)
+
+      assert claims["sub"] == local_token_email
+      assert claims["typ"] == "access"
+      assert claims["roles"] == ["read-only"]
+      assert Guardian.Plug.current_resource(conn) == local_token_email
+    end
+
+    test "does not sign in a token user who does not exist", %{conn: conn} do
+      auth_token = auth_token_for("arrow-missing@mbta.com")
+
+      assert_raise FunctionClauseError, fn ->
+        Local.sign_in(conn, auth_token)
+      end
+
+      refute Guardian.Plug.authenticated?(conn)
+    end
+
+    test "does not sign in a token user who does not have an @mbta.com email", %{conn: conn} do
+      unknown_domain = "arrow-missing@unknown.com"
+      Arrow.AuthToken.get_or_create_token_for_user(unknown_domain)
+      auth_token = auth_token_for(unknown_domain)
+
+      {conn, log} = with_log(fn -> Local.sign_in(conn, auth_token) end)
+
+      refute Guardian.Plug.authenticated?(conn)
+
+      assert log =~ "refusing to login"
+    end
+  end
+
+  defp auth_token_for(username) do
+    Arrow.Repo.get_by(Arrow.AuthToken, username: username)
+  end
+end

--- a/test/arrow_web/try_api_token_auth_test.exs
+++ b/test/arrow_web/try_api_token_auth_test.exs
@@ -55,6 +55,20 @@ defmodule ArrowWeb.TryApiTokenAuthTest do
       assert Guardian.Plug.current_resource(conn) == "foo@mbta.com"
     end
 
+    test "handles API token with local database token from gtfs_creator user", %{conn: conn} do
+      token = Arrow.AuthToken.get_or_create_token_for_user("gtfs_creator_ci@mbta.com")
+
+      conn =
+        conn
+        |> put_req_header("x-api-key", token)
+        |> ArrowWeb.TryApiTokenAuth.call([])
+
+      claims = Guardian.Plug.current_claims(conn)
+
+      assert claims["roles"] == ["read-only"]
+      assert Guardian.Plug.current_resource(conn) == "gtfs_creator_ci@mbta.com"
+    end
+
     test "handles unexpected response from Cognito API", %{conn: conn} do
       reassign_env(:ex_aws_requester, {Fake.ExAws, :unexpected_response})
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [💳 Fix Dependabot CI on gtfs_creator](https://app.asana.com/0/584764604969369/1206364138902694)

* Adds a new api login module for a token-only read-only user (username/token database entry)
* Adds a migration to add a token-only read-only user for dependabot

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
