### PR TITLE
feat: move `logout_url` to the session

### DIFF
--- a/lib/arrow_web/controllers/auth_controller.ex
+++ b/lib/arrow_web/controllers/auth_controller.ex
@@ -6,7 +6,7 @@ defmodule ArrowWeb.AuthController do
 
   @spec logout(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def logout(conn, _params) do
-    logout_url = Map.get(Guardian.Plug.current_claims(conn), "logout_url")
+    logout_url = get_session(conn, :logout_url)
     conn = configure_session(conn, drop: true)
 
     if logout_url do
@@ -66,12 +66,12 @@ defmodule ArrowWeb.AuthController do
       end
 
     conn
+    |> put_session(:logout_url, logout_url)
     |> Guardian.Plug.sign_in(
       ArrowWeb.AuthManager,
       username,
       %{
-        roles: roles,
-        logout_url: logout_url
+        roles: roles
       },
       ttl: {expiration - current_time, :seconds}
     )

--- a/lib/arrow_web/templates/layout/app.html.heex
+++ b/lib/arrow_web/templates/layout/app.html.heex
@@ -27,7 +27,7 @@
 
         <div class="m-header__long-name navbar-text justify-content-end navbar-collapse collapse">
           Adjustments to the Regular Right of Way
-          <%= if Map.has_key?(Guardian.Plug.current_claims(@conn), "logout_url"), do:
+          <%= if Plug.Conn.get_session(@conn, :logout_url), do:
             link("logout",
               to: Routes.auth_path(@conn, :logout),
               class: "ml-2 btn btn-outline-danger"


### PR DESCRIPTION
Meets our best practices of not putting the URL in the Guardian claim, as we can run into errors where the cookie gets too large.

s/o to @firestack who pointed this out.