### PR TITLE
feat: add runtime configuration of S3_PREFIX from app environment

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -36,7 +36,6 @@ config :arrow,
   ex_aws_requester: {Fake.ExAws, :admin_group_request},
   http_client: HTTPoison,
   shape_storage_enabled?: false,
-  shape_storage_prefix_env: "dev/local/",
   shape_storage_bucket: "mbta-arrow",
   shape_storage_prefix: "shape-uploads/",
   shape_storage_request_fn: {ExAws, :request}

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -74,10 +74,10 @@ config :arrow, :redirect_http?, false
 # Enable dev routes for dashboard and mailbox
 config :arrow, dev_routes: true
 
-# Set prefix env for s3 uploads in dev
+# Set prefix env for s3 uploads
 config :arrow,
   shape_storage_enabled?: true,
-  shape_storage_prefix_env: "dev/"
+  shape_storage_prefix_env: "local/"
 
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,8 +11,7 @@ import Config
 # before starting your production server.
 
 config :arrow,
-  shape_storage_enabled?: true,
-  shape_storage_prefix_env: "prod/"
+  shape_storage_enabled?: true
 
 config :arrow, ArrowWeb.Endpoint,
   http: [:inet6, port: 4000],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -88,4 +88,7 @@ if config_env() == :prod do
     pool_size: pool_size,
     # password set by `configure` callback below
     configure: {Arrow.Repo, :before_connect, []}
+
+  config :arrow,
+    shape_storage_prefix_env: System.get_env("S3_PREFIX")
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹  Implement Shuttle Route KML Save to S3](https://app.asana.com/0/584764604969369/1207423464713208/f)

Depends on infra PR
* Use a dedicated s3 prefix environment variable from the app env to match s3 permissioning in [🏹 Create Arrow S3 bucket](https://app.asana.com/0/584764604969369/1207404453434865)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
