### PR TITLE
🏹 Implement /shuttle-stops Arrow API

### DIFF
--- a/lib/arrow_web/controllers/api/stops_controller.ex
+++ b/lib/arrow_web/controllers/api/stops_controller.ex
@@ -1,0 +1,11 @@
+defmodule ArrowWeb.API.StopsController do
+  use ArrowWeb, :controller
+  alias Arrow.Stops
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, _params) do
+    data = Stops.list_stops()
+
+    render(conn, "index.json-api", data: data)
+  end
+end

--- a/lib/arrow_web/controllers/api_html/stops_view.ex
+++ b/lib/arrow_web/controllers/api_html/stops_view.ex
@@ -1,0 +1,33 @@
+defmodule ArrowWeb.API.StopsView do
+  use ArrowWeb, :html
+  use JaSerializer.PhoenixView
+
+  @fields [
+    :stop_id,
+    :stop_name,
+    :stop_desc,
+    :platform_code,
+    :platform_name,
+    :stop_lat,
+    :stop_lon,
+    :stop_address,
+    :zone_id,
+    :level_id,
+    :parent_station,
+    :municipality,
+    :on_street,
+    :at_street,
+    :inserted_at,
+    :updated_at
+  ]
+
+  def attributes(stop, _) do
+    stop
+    |> Map.from_struct()
+    |> Enum.reject(fn {_, v} -> is_nil(v) end)
+    |> Enum.into(%{})
+    |> Map.take(@fields)
+  end
+
+  def id(stop, _conn), do: stop.stop_id
+end

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -71,6 +71,7 @@ defmodule ArrowWeb.Router do
 
     resources("/disruptions", DisruptionController, only: [:index])
     resources("/adjustments", AdjustmentController, only: [:index])
+    resources("/shuttle-stops", StopsController, only: [:index])
   end
 
   scope "/api", ArrowWeb.API do

--- a/test/arrow_web/controllers/api/stops_controller_test.exs
+++ b/test/arrow_web/controllers/api/stops_controller_test.exs
@@ -1,0 +1,142 @@
+defmodule ArrowWeb.API.StopsControllerTest do
+  use ArrowWeb.ConnCase
+  import Arrow.Factory
+
+  describe "index/2" do
+    @tag :authenticated
+    test "non-admin user can access the stops API", %{conn: conn} do
+      assert %{status: 200} = get(conn, "/api/shuttle-stops")
+    end
+
+    @tag :authenticated_admin
+    test "returns 200", %{conn: conn} do
+      assert %{status: 200} = get(conn, "/api/shuttle-stops")
+    end
+
+    @tag :authenticated_admin
+    test "includes all stops", %{conn: conn} do
+      stop1 = insert(:stop)
+      stop2 = insert(:stop)
+      stop3 = insert(:stop)
+
+      res = json_response(get(conn, "/api/shuttle-stops"), 200)
+
+      assert %{
+               "data" => data,
+               "jsonapi" => %{"version" => "1.0"}
+             } = res
+
+      assert Enum.count(data) == 3
+
+      assert [
+               %{
+                 "attributes" => %{
+                   "inserted_at" => DateTime.to_iso8601(stop1.inserted_at),
+                   "municipality" => "Boston",
+                   "stop_desc" => stop1.stop_desc,
+                   "stop_id" => stop1.stop_id,
+                   "stop_lat" => 72.0,
+                   "stop_lon" => 43.0,
+                   "stop_name" => stop1.stop_name,
+                   "updated_at" => DateTime.to_iso8601(stop1.updated_at)
+                 },
+                 "id" => stop1.stop_id,
+                 "type" => "stops"
+               },
+               %{
+                 "attributes" => %{
+                   "inserted_at" => DateTime.to_iso8601(stop2.inserted_at),
+                   "municipality" => "Boston",
+                   "stop_desc" => stop2.stop_desc,
+                   "stop_id" => stop2.stop_id,
+                   "stop_lat" => 72.0,
+                   "stop_lon" => 43.0,
+                   "stop_name" => stop2.stop_name,
+                   "updated_at" => DateTime.to_iso8601(stop2.updated_at)
+                 },
+                 "id" => stop2.stop_id,
+                 "type" => "stops"
+               },
+               %{
+                 "attributes" => %{
+                   "inserted_at" => DateTime.to_iso8601(stop3.inserted_at),
+                   "municipality" => "Boston",
+                   "stop_desc" => stop3.stop_desc,
+                   "stop_id" => stop3.stop_id,
+                   "stop_lat" => 72.0,
+                   "stop_lon" => 43.0,
+                   "stop_name" => stop3.stop_name,
+                   "updated_at" => DateTime.to_iso8601(stop3.updated_at)
+                 },
+                 "id" => stop3.stop_id,
+                 "type" => "stops"
+               }
+             ] == data
+    end
+
+    @tag :authenticated_admin
+    test "removes nil fields entirely", %{conn: conn} do
+      stop1 = insert(:stop, %{on_street: "On Street", at_street: "At Avenue"})
+      stop2 = insert(:stop, %{at_street: "At Avenue"})
+      stop3 = insert(:stop, %{on_street: "On Street"})
+
+      res = json_response(get(conn, "/api/shuttle-stops"), 200)
+
+      assert %{
+               "data" => data,
+               "jsonapi" => %{"version" => "1.0"}
+             } = res
+
+      assert Enum.count(data) == 3
+
+      assert [
+               %{
+                 "attributes" => %{
+                   "inserted_at" => DateTime.to_iso8601(stop1.inserted_at),
+                   "municipality" => "Boston",
+                   "stop_desc" => stop1.stop_desc,
+                   "stop_id" => stop1.stop_id,
+                   "stop_lat" => 72.0,
+                   "stop_lon" => 43.0,
+                   "stop_name" => stop1.stop_name,
+                   "updated_at" => DateTime.to_iso8601(stop1.updated_at),
+                   "at_street" => "At Avenue",
+                   "on_street" => "On Street"
+                 },
+                 "id" => stop1.stop_id,
+                 "type" => "stops"
+               },
+               %{
+                 "attributes" => %{
+                   "inserted_at" => DateTime.to_iso8601(stop2.inserted_at),
+                   "municipality" => "Boston",
+                   "stop_desc" => stop2.stop_desc,
+                   "stop_id" => stop2.stop_id,
+                   "stop_lat" => 72.0,
+                   "stop_lon" => 43.0,
+                   "stop_name" => stop2.stop_name,
+                   "updated_at" => DateTime.to_iso8601(stop2.updated_at),
+                   "at_street" => "At Avenue"
+                 },
+                 "id" => stop2.stop_id,
+                 "type" => "stops"
+               },
+               %{
+                 "attributes" => %{
+                   "inserted_at" => DateTime.to_iso8601(stop3.inserted_at),
+                   "municipality" => "Boston",
+                   "stop_desc" => stop3.stop_desc,
+                   "stop_id" => stop3.stop_id,
+                   "stop_lat" => 72.0,
+                   "stop_lon" => 43.0,
+                   "stop_name" => stop3.stop_name,
+                   "updated_at" => DateTime.to_iso8601(stop3.updated_at),
+                   "on_street" => "On Street"
+                 },
+                 "id" => stop3.stop_id,
+                 "type" => "stops"
+               }
+             ] == data
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -56,4 +56,15 @@ defmodule Arrow.Factory do
   def note_factory do
     %Arrow.Disruption.Note{author: "An author", body: "This is the body."}
   end
+
+  def stop_factory do
+    %Arrow.Shuttle.Stop{
+      stop_id: sequence(:source_label, &"stop-#{&1}"),
+      stop_name: sequence(:source_label, &"Stop #{&1}"),
+      stop_desc: sequence(:source_label, &"Stop Description #{&1}"),
+      stop_lat: 72.0,
+      stop_lon: 43.0,
+      municipality: "Boston"
+    }
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Implement /shuttle-stops Arrow API](https://app.asana.com/0/584764604969369/1207472819136796/f)

* Add `api/shuttle-stops` endpoint that returns all stops currently saved in db
* Reject all fields that are nil
* use `Stop.stop_id` as top level key rather than arbitrary db id

`curl -H "x-api-key: <YOURTOKENHERE>" https://arrow-dev.mbtace.com/api/shuttle-stops`

note: will need to deploy to dev again after auto-deploy runs at night
