### PR TITLE
tweak: Register atoms earlier in execution of `mix copy_db`

### DIFF
--- a/lib/mix/tasks/copy_db.ex
+++ b/lib/mix/tasks/copy_db.ex
@@ -9,6 +9,10 @@ defmodule Mix.Tasks.CopyDb do
   @shortdoc "Copies database"
   @impl Mix.Task
   def run(_args) do
+    # Load the DBStructure module now, so that relevant atoms like :route_id are
+    # registered ahead of the call to `String.to_existing_atom/1` further down
+    # in this function.
+    Code.ensure_loaded!(Arrow.DBStructure)
     api_key = System.get_env("ARROW_API_KEY")
     domain = System.get_env("ARROW_DOMAIN", "https://arrow.mbta.com")
     fetch_module = Application.get_env(:arrow, :http_client)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** ad hoc

https://mbta.slack.com/archives/C07639BHFKR/p1724686373999939

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
