### PR TITLE
feat: Create tables for GTFS-static archive import

### DIFF
--- a/priv/repo/migrations/20240826153959_create_gtfs_tables_part1.exs
+++ b/priv/repo/migrations/20240826153959_create_gtfs_tables_part1.exs
@@ -34,9 +34,7 @@ defmodule Arrow.Repo.Migrations.CreateGtfsTablesPart1 do
       add :long_name, :string, null: false
       add :desc, :string, null: false
       add :url, :string
-      # Maybe integer
       add :color, :string, null: false
-      # Maybe integer
       add :text_color, :string, null: false
       add :sort_order, :integer, null: false
     end

--- a/priv/repo/migrations/20240826153959_create_gtfs_tables_part1.exs
+++ b/priv/repo/migrations/20240826153959_create_gtfs_tables_part1.exs
@@ -1,0 +1,44 @@
+defmodule Arrow.Repo.Migrations.CreateGtfsTablesPart1 do
+  @moduledoc """
+  Creates auxiliary tables referenced by fields in the more frequently-used
+  GTFS-static tables.
+
+  Column names omit the `${table_name}_` prefix of their CSV counterparts.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    create table("gtfs_agencies", primary_key: [name: :id, type: :integer]) do
+      add :name, :string, null: false
+      add :url, :string, null: false
+      add :timezone, :string, null: false
+      add :lang, :string
+      add :phone, :string
+    end
+
+    create table("gtfs_checkpoints", primary_key: [name: :id, type: :string]) do
+      add :name, :string, null: false
+    end
+
+    create table("gtfs_levels", primary_key: [name: :id, type: :string]) do
+      add :index, :float, null: false
+      add :name, :string
+      # `level_elevation` column is included but empty in the CSV and not
+      # mentioned in either the official spec or our reference.
+      # add :elevation, :string
+    end
+
+    create table("gtfs_lines", primary_key: [name: :id, type: :string]) do
+      add :short_name, :string, null: false
+      add :long_name, :string, null: false
+      add :desc, :string, null: false
+      add :url, :string
+      # Maybe integer
+      add :color, :string, null: false
+      # Maybe integer
+      add :text_color, :string, null: false
+      add :sort_order, :integer, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20240826154124_create_gtfs_tables_part2.exs
+++ b/priv/repo/migrations/20240826154124_create_gtfs_tables_part2.exs
@@ -39,7 +39,7 @@ defmodule Arrow.Repo.Migrations.CreateGtfsTablesPart2 do
       add :address, :string
       add :url, :string
       add :level_id, references("gtfs_levels", type: :string)
-      # Really an enum type like route_type
+      # Really an integer-code type like route_type
       add :location_type, :integer, null: false
       add :parent_station, references("gtfs_stops", type: :string)
       add :wheelchair_boarding, :integer, null: false

--- a/priv/repo/migrations/20240826154124_create_gtfs_tables_part2.exs
+++ b/priv/repo/migrations/20240826154124_create_gtfs_tables_part2.exs
@@ -1,0 +1,80 @@
+defmodule Arrow.Repo.Migrations.CreateGtfsTablesPart2 do
+  use Ecto.Migration
+
+  def change do
+    create table("gtfs_route_types", primary_key: [name: :id, type: :integer]) do
+      add :name, :string, null: false
+    end
+
+    execute(&route_types_up/0, &route_types_down/0)
+
+    create table("gtfs_calendar", primary_key: [name: :service_id, type: :string]) do
+      for day <- ~w[monday tuesday wednesday thursday friday saturday sunday]a do
+        add day, :boolean, null: false
+      end
+
+      add :start_date, :integer, null: false
+      add :end_date, :integer, null: false
+    end
+
+    create table("gtfs_calendar_dates", primary_key: false) do
+      add :service_id, references("gtfs_calendar", column: :service_id, type: :string),
+        primary_key: true
+
+      # Dates are formatted like YearMonthDay, e.g. 20240829
+      add :date, :integer, primary_key: true
+      add :exception_type, :integer, null: false
+      add :holiday_name, :string
+    end
+
+    create table("gtfs_stops", primary_key: [name: :id, type: :string]) do
+      add :code, :string
+      add :name, :string, null: false
+      add :desc, :string
+      add :platform_code, :string
+      add :platform_name, :string
+      add :lat, :float
+      add :lon, :float
+      add :zone_id, :string
+      add :address, :string
+      add :url, :string
+      add :level_id, references("gtfs_levels", type: :string)
+      # Really an enum type like route_type
+      add :location_type, :integer, null: false
+      add :parent_station, references("gtfs_stops", type: :string)
+      add :wheelchair_boarding, :integer, null: false
+      add :municipality, :string
+      add :on_street, :string
+      add :at_street, :string
+      add :vehicle_type, references("gtfs_route_types", type: :integer)
+    end
+
+    create table("gtfs_shapes", primary_key: [name: :id, type: :integer])
+
+    # Individual points are separated into another table to properly
+    # form the 1:* relationship and allow FK relations to gtfs_shapes.
+    create table("gtfs_shape_points", primary_key: false) do
+      add :shaped_id, references("gtfs_shapes", type: :integer), primary_key: true
+      add :sequence, :integer, primary_key: true
+      add :lat, :float, null: false
+      add :lon, :float, null: false
+      # Column is empty, maybe should omit it?
+      add :dist_traveled, :float
+    end
+  end
+
+  # 1. Does this seem useful to define at the DB level
+  # 2. If yes, should I do this for other enum-ish columns like stops.location_type
+  defp route_types_up do
+    repo().query!("""
+    INSERT INTO "gtfs_route_types" ("id", "name") VALUES
+        (0, 'Light Rail'),
+        (1, 'Heavy Rail'),
+        (2, 'Commuter Rail'),
+        (3, 'Bus'),
+        (4, 'Ferry')
+    """)
+  end
+
+  defp route_types_down, do: nil
+end

--- a/priv/repo/migrations/20240826154204_create_gtfs_tables_part3.exs
+++ b/priv/repo/migrations/20240826154204_create_gtfs_tables_part3.exs
@@ -1,0 +1,22 @@
+defmodule Arrow.Repo.Migrations.CreateGtfsTablesPart3 do
+  use Ecto.Migration
+
+  def change do
+    create table("gtfs_routes", primary_key: [name: :id, type: :string]) do
+      add :agency_id, references("gtfs_agencies", type: :integer), null: false
+      add :short_name, :string
+      add :long_name, :string
+      # One of a finite list of strings - make an enum?
+      add :desc, :string, null: false
+      add :type, references("gtfs_route_types", type: :integer), null: false
+      add :url, :string
+      add :color, :string
+      add :text_color, :string
+      add :sort_order, :integer, null: false
+      add :fare_class, :string, null: false
+      add :line_id, references("gtfs_lines", type: :string)
+      add :listed_route, :integer
+      add :network_id, :string, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20240826154208_create_gtfs_tables_part4.exs
+++ b/priv/repo/migrations/20240826154208_create_gtfs_tables_part4.exs
@@ -1,0 +1,38 @@
+defmodule Arrow.Repo.Migrations.CreateGtfsTablesPart4 do
+  use Ecto.Migration
+
+  def change do
+    create table("gtfs_directions", primary_key: false) do
+      add :route_id, references("gtfs_routes", type: :string), primary_key: true
+      add :direction_id, :integer, primary_key: true
+      # Make an enum type for this?
+      add :direction, :string, null: false
+      add :direction_destination, :string, null: false
+    end
+
+    create table("gtfs_route_patterns", primary_key: [name: :id, type: :string]) do
+      add :route_id, references("gtfs_routes", type: :string), null: false
+
+      add :direction_id,
+          references("gtfs_directions",
+            column: :direction_id,
+            type: :integer,
+            with: [route_id: :route_id]
+          ),
+          null: false
+
+      add :name, :string, null: false
+      add :time_desc, :string
+      # May want to define an enum for this
+      add :typicality, :integer, null: false
+      add :sort_order, :integer, null: false
+      # References gtfs_trips, but we haven't created that yet. (gtfs_trips
+      # references this table, so we'll need to add a DEFERRED FK constraint to
+      # this column later.)
+      add :representative_trip_id, :string, null: false
+
+      # Make an enum type for this?
+      add :canonical, :integer, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20240826154208_create_gtfs_tables_part4.exs
+++ b/priv/repo/migrations/20240826154208_create_gtfs_tables_part4.exs
@@ -23,7 +23,7 @@ defmodule Arrow.Repo.Migrations.CreateGtfsTablesPart4 do
 
       add :name, :string, null: false
       add :time_desc, :string
-      # May want to define an enum for this
+      # May want to define an integer-code table for this
       add :typicality, :integer, null: false
       add :sort_order, :integer, null: false
       # References gtfs_trips, but we haven't created that yet. (gtfs_trips
@@ -31,7 +31,7 @@ defmodule Arrow.Repo.Migrations.CreateGtfsTablesPart4 do
       # this column later.)
       add :representative_trip_id, :string, null: false
 
-      # Make an enum type for this?
+      # Make an integer-code table for this?
       add :canonical, :integer, null: false
     end
   end

--- a/priv/repo/migrations/20240826154213_create_gtfs_tables_part5.exs
+++ b/priv/repo/migrations/20240826154213_create_gtfs_tables_part5.exs
@@ -1,0 +1,48 @@
+defmodule Arrow.Repo.Migrations.CreateGtfsTablesPart5 do
+  use Ecto.Migration
+
+  def change do
+    create table("gtfs_trips", primary_key: [name: :id, type: :string]) do
+      add :route_id, references("gtfs_routes", type: :string), null: false
+
+      add :service_id, references("gtfs_calendar", column: :service_id, type: :string),
+        null: false
+
+      add :headsign, :string, null: false
+      add :short_name, :string
+
+      add :direction_id,
+          references("gtfs_directions",
+            column: :direction_id,
+            type: :integer,
+            with: [route_id: :route_id]
+          ),
+          null: false
+
+      add :block_id, :string
+      add :shape_id, references("gtfs_shapes", type: :integer)
+      add :wheelchair_accessible, :integer, null: false
+      add :trip_route_type, references("gtfs_route_types", type: :integer)
+      add :route_pattern_id, references("gtfs_route_patterns", type: :string), null: false
+      add :bikes_allowed, :integer, null: false
+    end
+
+    execute(&route_patterns_deferred_pk_up/0, &route_patterns_deferred_pk_down/0)
+  end
+
+  defp route_patterns_deferred_pk_up do
+    repo().query!("""
+    ALTER TABLE "gtfs_route_patterns"
+    ADD CONSTRAINT "gtfs_route_patterns_representative_trip_id_fkey"
+      FOREIGN KEY ("representative_trip_id") REFERENCES "gtfs_trips"("id")
+      DEFERRABLE INITIALLY DEFERRED
+    """)
+  end
+
+  defp route_patterns_deferred_pk_down do
+    repo().query!("""
+    ALTER TABLE "gtfs_route_patterns"
+    DROP CONSTRAINT "gtfs_route_patterns_representative_trip_id_fkey"
+    """)
+  end
+end

--- a/priv/repo/migrations/20240826154218_create_gtfs_tables_part6.exs
+++ b/priv/repo/migrations/20240826154218_create_gtfs_tables_part6.exs
@@ -10,13 +10,13 @@ defmodule Arrow.Repo.Migrations.CreateGtfsTablesPart6 do
       add :departure_time, :string, null: false
       add :stop_id, references("gtfs_stops", type: :string), null: false
       add :stop_headsign, :string
-      # pickup_type and drop_off_type are enum-ish
+      # pickup_type and drop_off_type are integer-codes
       add :pickup_type, :integer, null: false
       add :drop_off_type, :integer, null: false
-      # enum-ish
+      # integer-code
       add :timepoint, :integer
       add :checkpoint_id, references("gtfs_checkpoints", type: :string)
-      # continuous_pickup and continuous_drop_off are enum-ish
+      # continuous_pickup and continuous_drop_off are integer-codes
       add :continuous_pickup, :integer
       add :continuous_drop_off, :integer
     end

--- a/priv/repo/migrations/20240826154218_create_gtfs_tables_part6.exs
+++ b/priv/repo/migrations/20240826154218_create_gtfs_tables_part6.exs
@@ -1,0 +1,24 @@
+defmodule Arrow.Repo.Migrations.CreateGtfsTablesPart6 do
+  use Ecto.Migration
+
+  def change do
+    create table("gtfs_stop_times", primary_key: false) do
+      add :trip_id, references("gtfs_trips", type: :string), primary_key: true
+      add :stop_sequence, :integer, primary_key: true
+      # Maybe type can be :time?
+      add :arrival_time, :string, null: false
+      add :departure_time, :string, null: false
+      add :stop_id, references("gtfs_stops", type: :string), null: false
+      add :stop_headsign, :string
+      # pickup_type and drop_off_type are enum-ish
+      add :pickup_type, :integer, null: false
+      add :drop_off_type, :integer, null: false
+      # enum-ish
+      add :timepoint, :integer
+      add :checkpoint_id, references("gtfs_checkpoints", type: :string)
+      # continuous_pickup and continuous_drop_off are enum-ish
+      add :continuous_pickup, :integer
+      add :continuous_drop_off, :integer
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Define DB table schemata for GTFS data](https://app.asana.com/0/584764604969369/1208141467238946/f)
(first subtask of [[extra] 🏹 Implement /import-GTFS Arrow endpoint](https://app.asana.com/0/584764604969369/1207472819136817/f))

This is split into several migrations, partly to keep file lengths reasonable and partly to make it clear which tables reference/depend on the existence of other tables.

<details>
<summary><h4>Output of <code>mix ecto.migrate --log-migrations-sql</code></h4></summary>

```sql
11:27:58.114 [info] == Running 20240826153959 Arrow.Repo.Migrations.CreateGtfsTablesPart1.change/0 forward

11:27:58.117 [info] create table gtfs_agencies

11:27:58.137 [debug] QUERY OK db=18.8ms
CREATE TABLE "gtfs_agencies" ("id" integer, "name" varchar(255) NOT NULL, "url" varchar(255) NOT NULL, "timezone" varchar(255) NOT NULL, "lang" varchar(255), "phone" varchar(255), PRIMARY KEY ("id")) []

11:27:58.137 [info] create table gtfs_checkpoints

11:27:58.140 [debug] QUERY OK db=3.3ms
CREATE TABLE "gtfs_checkpoints" ("id" varchar(255), "name" varchar(255) NOT NULL, PRIMARY KEY ("id")) []

11:27:58.140 [info] create table gtfs_levels

11:27:58.142 [debug] QUERY OK db=2.1ms
CREATE TABLE "gtfs_levels" ("id" varchar(255), "index" float NOT NULL, "name" varchar(255), PRIMARY KEY ("id")) []

11:27:58.142 [info] create table gtfs_lines

11:27:58.146 [debug] QUERY OK db=3.5ms
CREATE TABLE "gtfs_lines" ("id" varchar(255), "short_name" varchar(255) NOT NULL, "long_name" varchar(255) NOT NULL, "desc" varchar(255) NOT NULL, "url" varchar(255), "color" varchar(255) NOT NULL, "text_color" varchar(255) NOT NULL, "sort_order" integer NOT NULL, PRIMARY KEY ("id")) []

11:27:58.147 [info] == Migrated 20240826153959 in 0.0s

11:27:58.167 [info] == Running 20240826154124 Arrow.Repo.Migrations.CreateGtfsTablesPart2.change/0 forward

11:27:58.167 [info] create table gtfs_route_types

11:27:58.175 [debug] QUERY OK db=7.7ms
CREATE TABLE "gtfs_route_types" ("id" integer, "name" varchar(255) NOT NULL, PRIMARY KEY ("id")) []

11:27:58.176 [debug] QUERY OK db=0.5ms
INSERT INTO "gtfs_route_types" ("id", "name") VALUES
    (0, 'Light Rail'),
    (1, 'Heavy Rail'),
    (2, 'Commuter Rail'),
    (3, 'Bus'),
    (4, 'Ferry')
 []

11:27:58.176 [info] create table gtfs_calendar

11:27:58.177 [debug] QUERY OK db=1.5ms
CREATE TABLE "gtfs_calendar" ("service_id" varchar(255), "monday" boolean NOT NULL, "tuesday" boolean NOT NULL, "wednesday" boolean NOT NULL, "thursday" boolean NOT NULL, "friday" boolean NOT NULL, "saturday" boolean NOT NULL, "sunday" boolean NOT NULL, "start_date" integer NOT NULL, "end_date" integer NOT NULL, PRIMARY KEY ("service_id")) []

11:27:58.177 [info] create table gtfs_calendar_dates

11:27:58.184 [debug] QUERY OK db=6.0ms
CREATE TABLE "gtfs_calendar_dates" ("service_id" varchar(255), CONSTRAINT "gtfs_calendar_dates_service_id_fkey" FOREIGN KEY ("service_id") REFERENCES "gtfs_calendar"("service_id"), "date" integer, "exception_type" integer NOT NULL, "holiday_name" varchar(255), PRIMARY KEY ("service_id","date")) []

11:27:58.184 [info] create table gtfs_stops

11:27:58.188 [debug] QUERY OK db=4.5ms
CREATE TABLE "gtfs_stops" ("id" varchar(255), "code" varchar(255), "name" varchar(255) NOT NULL, "desc" varchar(255), "platform_code" varchar(255), "platform_name" varchar(255), "lat" float, "lon" float, "zone_id" varchar(255), "address" varchar(255), "url" varchar(255), "level_id" varchar(255), CONSTRAINT "gtfs_stops_level_id_fkey" FOREIGN KEY ("level_id") REFERENCES "gtfs_levels"("id"), "location_type" integer NOT NULL, "parent_station" varchar(255), CONSTRAINT "gtfs_stops_parent_station_fkey" FOREIGN KEY ("parent_station") REFERENCES "gtfs_stops"("id"), "wheelchair_boarding" integer NOT NULL, "municipality" varchar(255), "on_street" varchar(255), "at_street" varchar(255), "vehicle_type" integer, CONSTRAINT "gtfs_stops_vehicle_type_fkey" FOREIGN KEY ("vehicle_type") REFERENCES "gtfs_route_types"("id"), PRIMARY KEY ("id")) []

11:27:58.188 [info] create table gtfs_shapes

11:27:58.190 [debug] QUERY OK db=1.4ms
CREATE TABLE "gtfs_shapes" ("id" integer, PRIMARY KEY ("id")) []

11:27:58.190 [info] create table gtfs_shape_points

11:27:58.192 [debug] QUERY OK db=1.8ms
CREATE TABLE "gtfs_shape_points" ("shaped_id" integer, CONSTRAINT "gtfs_shape_points_shaped_id_fkey" FOREIGN KEY ("shaped_id") REFERENCES "gtfs_shapes"("id"), "sequence" integer, "lat" float NOT NULL, "lon" float NOT NULL, "dist_traveled" float, PRIMARY KEY ("shaped_id","sequence")) []

11:27:58.192 [info] == Migrated 20240826154124 in 0.0s

11:27:58.194 [info] == Running 20240826154204 Arrow.Repo.Migrations.CreateGtfsTablesPart3.change/0 forward

11:27:58.194 [info] create table gtfs_routes

11:27:58.198 [debug] QUERY OK db=4.1ms
CREATE TABLE "gtfs_routes" ("id" varchar(255), "agency_id" integer NOT NULL, CONSTRAINT "gtfs_routes_agency_id_fkey" FOREIGN KEY ("agency_id") REFERENCES "gtfs_agencies"("id"), "short_name" varchar(255), "long_name" varchar(255), "desc" varchar(255) NOT NULL, "type" integer NOT NULL, CONSTRAINT "gtfs_routes_type_fkey" FOREIGN KEY ("type") REFERENCES "gtfs_route_types"("id"), "url" varchar(255), "color" varchar(255), "text_color" varchar(255), "sort_order" integer NOT NULL, "fare_class" varchar(255) NOT NULL, "line_id" varchar(255), CONSTRAINT "gtfs_routes_line_id_fkey" FOREIGN KEY ("line_id") REFERENCES "gtfs_lines"("id"), "listed_route" integer, "network_id" varchar(255) NOT NULL, PRIMARY KEY ("id")) []

11:27:58.198 [info] == Migrated 20240826154204 in 0.0s

11:27:58.199 [info] == Running 20240826154208 Arrow.Repo.Migrations.CreateGtfsTablesPart4.change/0 forward

11:27:58.199 [info] create table gtfs_directions

11:27:58.201 [debug] QUERY OK db=2.2ms
CREATE TABLE "gtfs_directions" ("route_id" varchar(255), CONSTRAINT "gtfs_directions_route_id_fkey" FOREIGN KEY ("route_id") REFERENCES "gtfs_routes"("id"), "direction_id" integer, "direction" varchar(255) NOT NULL, "direction_destination" varchar(255) NOT NULL, PRIMARY KEY ("route_id","direction_id")) []

11:27:58.201 [info] create table gtfs_route_patterns

11:27:58.202 [debug] QUERY OK db=1.2ms
CREATE TABLE "gtfs_route_patterns" ("id" varchar(255), "route_id" varchar(255) NOT NULL, CONSTRAINT "gtfs_route_patterns_route_id_fkey" FOREIGN KEY ("route_id") REFERENCES "gtfs_routes"("id"), "direction_id" integer NOT NULL, CONSTRAINT "gtfs_route_patterns_direction_id_fkey" FOREIGN KEY ("direction_id","route_id") REFERENCES "gtfs_directions"("direction_id","route_id"), "name" varchar(255) NOT NULL, "time_desc" varchar(255), "typicality" integer NOT NULL, "sort_order" integer NOT NULL, "representative_trip_id" varchar(255) NOT NULL, "canonical" integer NOT NULL, PRIMARY KEY ("id")) []

11:27:58.202 [info] == Migrated 20240826154208 in 0.0s

11:27:58.204 [info] == Running 20240826154213 Arrow.Repo.Migrations.CreateGtfsTablesPart5.change/0 forward

11:27:58.204 [info] create table gtfs_trips

11:27:58.205 [debug] QUERY OK db=1.4ms
CREATE TABLE "gtfs_trips" ("id" varchar(255), "route_id" varchar(255) NOT NULL, CONSTRAINT "gtfs_trips_route_id_fkey" FOREIGN KEY ("route_id") REFERENCES "gtfs_routes"("id"), "service_id" varchar(255) NOT NULL, CONSTRAINT "gtfs_trips_service_id_fkey" FOREIGN KEY ("service_id") REFERENCES "gtfs_calendar"("service_id"), "headsign" varchar(255) NOT NULL, "short_name" varchar(255), "direction_id" integer NOT NULL, CONSTRAINT "gtfs_trips_direction_id_fkey" FOREIGN KEY ("direction_id","route_id") REFERENCES "gtfs_directions"("direction_id","route_id"), "block_id" varchar(255), "shape_id" integer, CONSTRAINT "gtfs_trips_shape_id_fkey" FOREIGN KEY ("shape_id") REFERENCES "gtfs_shapes"("id"), "wheelchair_accessible" integer NOT NULL, "trip_route_type" integer, CONSTRAINT "gtfs_trips_trip_route_type_fkey" FOREIGN KEY ("trip_route_type") REFERENCES "gtfs_route_types"("id"), "route_pattern_id" varchar(255) NOT NULL, CONSTRAINT "gtfs_trips_route_pattern_id_fkey" FOREIGN KEY ("route_pattern_id") REFERENCES "gtfs_route_patterns"("id"), "bikes_allowed" integer NOT NULL, PRIMARY KEY ("id")) []

11:27:58.206 [debug] QUERY OK db=0.5ms
ALTER TABLE "gtfs_route_patterns"
ADD CONSTRAINT "gtfs_route_patterns_representative_trip_id_fkey"
  FOREIGN KEY ("representative_trip_id") REFERENCES "gtfs_trips"("id")
  DEFERRABLE INITIALLY DEFERRED
 []

11:27:58.206 [info] == Migrated 20240826154213 in 0.0s

11:27:58.207 [info] == Running 20240826154218 Arrow.Repo.Migrations.CreateGtfsTablesPart6.change/0 forward

11:27:58.207 [info] create table gtfs_stop_times

11:27:58.208 [debug] QUERY OK db=1.2ms
CREATE TABLE "gtfs_stop_times" ("trip_id" varchar(255), CONSTRAINT "gtfs_stop_times_trip_id_fkey" FOREIGN KEY ("trip_id") REFERENCES "gtfs_trips"("id"), "stop_sequence" integer, "arrival_time" varchar(255) NOT NULL, "departure_time" varchar(255) NOT NULL, "stop_id" varchar(255) NOT NULL, CONSTRAINT "gtfs_stop_times_stop_id_fkey" FOREIGN KEY ("stop_id") REFERENCES "gtfs_stops"("id"), "stop_headsign" varchar(255), "pickup_type" integer NOT NULL, "drop_off_type" integer NOT NULL, "timepoint" integer, "checkpoint_id" varchar(255), CONSTRAINT "gtfs_stop_times_checkpoint_id_fkey" FOREIGN KEY ("checkpoint_id") REFERENCES "gtfs_checkpoints"("id"), "continuous_pickup" integer, "continuous_drop_off" integer, PRIMARY KEY ("trip_id","stop_sequence")) []

11:27:58.208 [info] == Migrated 20240826154218 in 0.0s
```
</details>

🫷 Some overall design choices that I'm open to push-back on:
- Remove the `${table_name}_` prefix on most column names, e.g. `trip_headsign` -> `headsign`.
- Use foreign key constraints.
- Create tables only for the archive files mentioned in [[extra] 🏹 Implement /import-GTFS Arrow endpoint](https://app.asana.com/0/584764604969369/1207472819136817/f), and any files that those files depend on directly or indirectly.

❓ I left a few comments on things I'm unsure of. Mainly:
- Should I define and use simple (id, name) tables for all of the integer-code fields, in the same way that I did for `route_type`? E.g. `location_type`, `wheelchair_boarding`, `typicality`...
- Should I define enum types for all of the string fields that have a finite list of allowed values? E.g. `route_desc`

I'm thinking some of these changes can be made in the follow-up PR where I create the Ecto schema modules for these tables. I'm still getting familiar with `cast` and what you can achieve with it, but I'm guessing I can convert the numeric date fields in the CSV to proper dates before they get inserted into the DB, as well as other similar transformations.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
