### PR TITLE
feat: add http post for stops and use with liveview form

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > cover/PR_SHA
         if: github.event.pull_request
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: elixir-lcov
           path: cover/

--- a/lib/arrow/shuttle/stop.ex
+++ b/lib/arrow/shuttle/stop.ex
@@ -64,6 +64,7 @@ defmodule Arrow.Shuttle.Stop do
     stop
     |> cast(attrs, @permitted_fields)
     |> validate_required(@required_fields)
+    |> unsafe_validate_unique([:stop_id], Arrow.Repo)
     |> unique_constraint(:stop_id)
   end
 end

--- a/lib/arrow_web/controllers/stop_controller.ex
+++ b/lib/arrow_web/controllers/stop_controller.ex
@@ -9,4 +9,19 @@ defmodule ArrowWeb.StopController do
     stops = Stops.list_stops(params)
     render(conn, :index, stops: stops, order_by: Map.get(params, "order_by"))
   end
+
+  @spec create(Conn.t(), Conn.params()) :: Conn.t()
+  def create(conn, %{"stop" => stop_params}) do
+    case Stops.create_stop(stop_params) do
+      {:ok, _stop} ->
+        conn
+        |> put_flash(:info, "Stop created successfully.")
+        |> redirect(to: ~p"/stops")
+
+      {:error, %Ecto.Changeset{} = _changeset} ->
+        conn
+        |> put_flash(:error, "Unable to create stop, please try again")
+        |> redirect(to: ~p"/stops/new")
+    end
+  end
 end

--- a/lib/arrow_web/controllers/stop_controller.ex
+++ b/lib/arrow_web/controllers/stop_controller.ex
@@ -2,6 +2,7 @@ defmodule ArrowWeb.StopController do
   use ArrowWeb, :controller
 
   alias Arrow.Stops
+  alias ArrowWeb.ErrorHelpers
   alias Plug.Conn
 
   @spec index(Conn.t(), Conn.params()) :: Conn.t()
@@ -18,9 +19,13 @@ defmodule ArrowWeb.StopController do
         |> put_flash(:info, "Stop created successfully.")
         |> redirect(to: ~p"/stops")
 
-      {:error, %Ecto.Changeset{} = _changeset} ->
+      {:error, %Ecto.Changeset{} = changeset} ->
         conn
-        |> put_flash(:error, "Unable to create stop, please try again")
+        |> put_flash(
+          :errors,
+          {"Error creating stop, please try again",
+           ErrorHelpers.changeset_error_messages(changeset)}
+        )
         |> redirect(to: ~p"/stops/new")
     end
   end

--- a/lib/arrow_web/live/stop_live/stop_live.ex
+++ b/lib/arrow_web/live/stop_live/stop_live.ex
@@ -10,6 +10,8 @@ defmodule ArrowWeb.StopViewLive do
   """
   attr :form, :any, required: true
   attr :action, :string, required: true
+  attr :trigger_submit, :boolean, required: true
+  attr :http_action, :string
 
   def stop_form(assigns) do
     ~H"""
@@ -20,7 +22,7 @@ defmodule ArrowWeb.StopViewLive do
       <br>
       <a class="text-sm" href="https://www.notion.so/mbta-downtown-crossing/Conventions-for-shuttle-bus-information-fc5a788409b24eb088dbfe3a43abf67e?pvs=4#7f7211396f6c46e59c26e63373cdb4ac">View Shuttle Stop Conventions</a>
     </p>
-    <.simple_form :let={f} for={@form} as={:stop} phx-change="validate" phx-submit={@action} id="stop-form">
+    <.simple_form :let={f} for={@form} as={:stop} action={@http_action} phx-change="validate" phx-submit={@action} phx-trigger-action={@trigger_submit} id="stop-form">
       <.error :if={@form.action}>
         Oops, something went wrong! Please check the errors below.
       </.error>
@@ -68,10 +70,12 @@ defmodule ArrowWeb.StopViewLive do
       socket
       |> assign(:form, form)
       |> assign(:form_action, "edit")
+      |> assign(:http_action, nil)
       |> assign(:stop, stop)
       |> assign(:title, "edit shuttle stop")
       |> assign(:stop_map_props, stop)
       |> assign(:logout_url, logout_url)
+      |> assign(:trigger_submit, false)
 
     {:ok, socket}
   end
@@ -85,16 +89,22 @@ defmodule ArrowWeb.StopViewLive do
       socket
       |> assign(:form, form)
       |> assign(:form_action, "create")
+      |> assign(:http_action, ~p"/stops")
       |> assign(:stops, stops)
       |> assign(:title, "create shuttle stop")
       |> assign(:stop_map_props, %{})
       |> assign(:logout_url, logout_url)
+      |> assign(:trigger_submit, false)
 
     {:ok, socket}
   end
 
   def handle_event("validate", %{"stop" => stop_params}, socket) do
-    {:noreply, assign(socket, :stop_map_props, stop_params)}
+    form = Stops.change_stop(%Stop{}, stop_params) |> to_form(action: :validate)
+
+    {:noreply,
+     socket
+     |> assign(stop_map_props: stop_params, form: form)}
   end
 
   def handle_event("edit", %{"stop" => stop_params}, socket) do
@@ -113,15 +123,14 @@ defmodule ArrowWeb.StopViewLive do
   end
 
   def handle_event("create", %{"stop" => stop_params}, socket) do
-    case Stops.create_stop(stop_params) do
-      {:ok, _stop} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Stop created successfully.")
-         |> redirect(to: ~p"/stops/")}
+    changeset = Stops.change_stop(%Stop{}, stop_params)
 
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:noreply, assign(socket, form: to_form(changeset))}
+    case Ecto.Changeset.apply_action(changeset, :validate) do
+      {:ok, _} ->
+        {:noreply, assign(socket, form: to_form(changeset), trigger_submit: true)}
+
+      {:error, applied_changeset} ->
+        {:noreply, assign(socket, form: to_form(applied_changeset), trigger_submit: false)}
     end
   end
 end

--- a/lib/arrow_web/live/stop_live/stop_view_live.html.heex
+++ b/lib/arrow_web/live/stop_live/stop_view_live.html.heex
@@ -3,4 +3,4 @@
 </.header>
 
 <%= live_react_component("Components.StopViewMap", [stop: @stop_map_props], id: "stop-view-map") %>
-<.stop_form form={@form} action={@form_action} />
+<.stop_form form={@form} action={@form_action} http_action={@http_action} trigger_submit={@trigger_submit} />

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -52,6 +52,7 @@ defmodule ArrowWeb.Router do
     live("/stops/new", StopViewLive, :new)
     live("/stops/:id/edit", StopViewLive, :edit)
     get("/stops", StopController, :index)
+    post("/stops", StopController, :create)
     resources("/shapes", ShapeController, only: [:delete, :index, :show])
     get("/shapes_upload", ShapeController, :new)
     post("/shapes_upload", ShapeController, :create)

--- a/test/arrow/stops_test.exs
+++ b/test/arrow/stops_test.exs
@@ -100,7 +100,7 @@ defmodule Arrow.StopsTest do
                })
 
       assert {_, error} = change.errors[:stop_id]
-      assert error[:constraint] == :unique
+      assert error == [validation: :unsafe_unique, fields: [:stop_id]]
     end
 
     test "create_stop/1 with invalid data returns error changeset" do
@@ -158,7 +158,7 @@ defmodule Arrow.StopsTest do
                Stops.update_stop(stop1, %{stop_id: stop2.stop_id})
 
       assert {_, error} = change.errors[:stop_id]
-      assert error[:constraint] == :unique
+      assert error == [validation: :unsafe_unique, fields: [:stop_id]]
     end
 
     test "delete_stop/1 deletes the stop" do

--- a/test/arrow_web/controllers/stop_controller_test.exs
+++ b/test/arrow_web/controllers/stop_controller_test.exs
@@ -1,11 +1,47 @@
 defmodule ArrowWeb.StopControllerTest do
   use ArrowWeb.ConnCase, async: true
 
+  @create_attrs %{
+    stop_id: "some stop_id",
+    stop_name: "some stop_name",
+    stop_desc: "some stop_desc",
+    platform_code: "some platform_code",
+    platform_name: "some platform_name",
+    stop_lat: 120.5,
+    stop_lon: 120.5,
+    stop_address: "some stop_address",
+    zone_id: "some zone_id",
+    level_id: "some level_id",
+    parent_station: "some parent_station",
+    municipality: "some municipality",
+    on_street: "some on_street",
+    at_street: "some at_street"
+  }
+
   describe "index" do
     @tag :authenticated
     test "lists all stops", %{conn: conn} do
       conn = get(conn, ~p"/stops")
       assert html_response(conn, 200) =~ "Listing Stops"
+    end
+  end
+
+  describe "create stop" do
+    @tag :authenticated_admin
+    test "redirects to index when data is valid", %{conn: conn} do
+      conn = post(conn, ~p"/stops", stop: @create_attrs)
+
+      assert redirected_to(conn) == ~p"/stops"
+    end
+
+    @tag :authenticated_admin
+    test "renders errors when data is invalid", %{conn: conn} do
+      invalid_attrs = Enum.reject(@create_attrs, fn {k, _v} -> k == :stop_id end)
+      conn = post(conn, ~p"/stops", stop: invalid_attrs)
+      assert redirected_to(conn) == ~p"/stops/new"
+
+      assert get_flash(conn, :errors) ==
+               {"Error creating stop, please try again", ["Stop id can\'t be blank"]}
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Import gtfs_creator shuttle stops into Arrow](https://app.asana.com/0/584764604969369/1207472819136798/f)

* Adds back a REST post endpoint for this work
* Adds Ecto validation to the stop form on phx-change
* Adds Ecto [unsafe_unique validation](https://hexdocs.pm/ecto/Ecto.Changeset.html#unsafe_validate_unique/4) to the stop form for stop_id (runs at changeset creation, unique constraint still runs on Repo.insert)

I considered whether we could write a SQL script to INSERT the stop records from gtfs_creator replacement bus into the arrow database but these changes seem worthwhile anyway.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
