### PR TITLE
chore: update aws cert bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mix local.hex --force && \
 
 RUN curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
   -o /root/aws-cert-bundle.pem
-RUN echo "d72191eaa5d48fe2b6e044a0ae0b0e9f35e325b34b1ecab6ffe11d490d5cdb8f /root/aws-cert-bundle.pem" | sha256sum -c -
+RUN echo "ed2b625ceeca0ebacf413972c33acbeb65a6c6b94d0c6434f1bb006cd4904ede /root/aws-cert-bundle.pem" | sha256sum -c -
 
 # Instructions from:
 # https://github.com/nodesource/distributions#debian-versions


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket

Deploy to dev is failing on merge to main: https://github.com/mbta/arrow/actions/runs/10832864737/job/30058252111
```
  > [elixir-builder  5/25] RUN echo "d72191eaa5d48fe2b6e044a0ae0b0e9f35e325b34b1ecab6ffe11d490d5cdb8f /root/aws-cert-bundle.pem" | sha256sum -c -:
0.253 /root/aws-cert-bundle.pem: FAILED
0.253 sha256sum: WARNING: 1 computed checksum did NOT match
```

```curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem | shasum -a 256```

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
