### PR TITLE
fix: expose arrow id for shuttle stops view

### DIFF
--- a/lib/arrow_web/controllers/api_html/stops_view.ex
+++ b/lib/arrow_web/controllers/api_html/stops_view.ex
@@ -29,5 +29,5 @@ defmodule ArrowWeb.API.StopsView do
     |> Map.take(@fields)
   end
 
-  def id(stop, _conn), do: stop.stop_id
+  def id(stop, _conn), do: stop.id
 end

--- a/test/arrow_web/controllers/api/stops_controller_test.exs
+++ b/test/arrow_web/controllers/api/stops_controller_test.exs
@@ -40,7 +40,7 @@ defmodule ArrowWeb.API.StopsControllerTest do
                    "stop_name" => stop1.stop_name,
                    "updated_at" => DateTime.to_iso8601(stop1.updated_at)
                  },
-                 "id" => stop1.stop_id,
+                 "id" => "#{stop1.id}",
                  "type" => "stops"
                },
                %{
@@ -54,7 +54,7 @@ defmodule ArrowWeb.API.StopsControllerTest do
                    "stop_name" => stop2.stop_name,
                    "updated_at" => DateTime.to_iso8601(stop2.updated_at)
                  },
-                 "id" => stop2.stop_id,
+                 "id" => "#{stop2.id}",
                  "type" => "stops"
                },
                %{
@@ -68,7 +68,7 @@ defmodule ArrowWeb.API.StopsControllerTest do
                    "stop_name" => stop3.stop_name,
                    "updated_at" => DateTime.to_iso8601(stop3.updated_at)
                  },
-                 "id" => stop3.stop_id,
+                 "id" => "#{stop3.id}",
                  "type" => "stops"
                }
              ] == data
@@ -103,7 +103,7 @@ defmodule ArrowWeb.API.StopsControllerTest do
                    "at_street" => "At Avenue",
                    "on_street" => "On Street"
                  },
-                 "id" => stop1.stop_id,
+                 "id" => "#{stop1.id}",
                  "type" => "stops"
                },
                %{
@@ -118,7 +118,7 @@ defmodule ArrowWeb.API.StopsControllerTest do
                    "updated_at" => DateTime.to_iso8601(stop2.updated_at),
                    "at_street" => "At Avenue"
                  },
-                 "id" => stop2.stop_id,
+                 "id" => "#{stop2.id}",
                  "type" => "stops"
                },
                %{
@@ -133,7 +133,7 @@ defmodule ArrowWeb.API.StopsControllerTest do
                    "updated_at" => DateTime.to_iso8601(stop3.updated_at),
                    "on_street" => "On Street"
                  },
-                 "id" => stop3.stop_id,
+                 "id" => "#{stop3.id}",
                  "type" => "stops"
                }
              ] == data


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Relates to [importing shuttles](https://app.asana.com/0/584764604969369/1207472819136798/f)

Expose arrow id field so that we can use it to bulk update Arrow shuttle stops. In other situations, we can use `stop_id` under the stop's `attributes`

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
