### PR TITLE
fix: fix naming of Arrow Shuttles context to plural Shuttles

### DIFF
--- a/lib/arrow/shuttle/kml.ex
+++ b/lib/arrow/shuttle/kml.ex
@@ -1,4 +1,4 @@
-defmodule Arrow.Shuttle.KML do
+defmodule Arrow.Shuttles.KML do
   @moduledoc """
   A struct for the full KML representation of a shape to be used with Saxy.Builder
   """
@@ -13,7 +13,7 @@ defmodule Arrow.Shuttle.KML do
     element(
       "Folder",
       [],
-      Saxy.Builder.build(%Arrow.Shuttle.ShapeKML{name: name, coordinates: coordinates})
+      Saxy.Builder.build(%Arrow.Shuttles.ShapeKML{name: name, coordinates: coordinates})
     )
   end
 end

--- a/lib/arrow/shuttle/shape.ex
+++ b/lib/arrow/shuttle/shape.ex
@@ -1,4 +1,4 @@
-defmodule Arrow.Shuttle.Shape do
+defmodule Arrow.Shuttles.Shape do
   @moduledoc "schema for shuttle shapes for the db"
   use Ecto.Schema
   import Ecto.Changeset

--- a/lib/arrow/shuttle/shape_kml.ex
+++ b/lib/arrow/shuttle/shape_kml.ex
@@ -1,11 +1,11 @@
-defmodule Arrow.Shuttle.ShapeKML do
+defmodule Arrow.Shuttles.ShapeKML do
   @moduledoc """
   A struct for a shape representation to be used with Saxy.Builder
   """
   defstruct [:name, :coordinates]
 end
 
-defimpl Saxy.Builder, for: Arrow.Shuttle.ShapeKML do
+defimpl Saxy.Builder, for: Arrow.Shuttles.ShapeKML do
   import Saxy.XML
 
   def build(%{name: name, coordinates: coordinates}) do

--- a/lib/arrow/shuttle/shape_upload.ex
+++ b/lib/arrow/shuttle/shape_upload.ex
@@ -1,4 +1,4 @@
-defmodule Arrow.Shuttle.ShapeUpload do
+defmodule Arrow.Shuttles.ShapeUpload do
   @moduledoc "schema for shuttle shapes as an embedded schema"
   use Ecto.Schema
   import Ecto.Changeset

--- a/lib/arrow/shuttle/shapes_upload.ex
+++ b/lib/arrow/shuttle/shapes_upload.ex
@@ -1,16 +1,16 @@
-defmodule Arrow.Shuttle.ShapesUpload do
+defmodule Arrow.Shuttles.ShapesUpload do
   @moduledoc "schema for shapes upload"
   use Ecto.Schema
   import Ecto.Changeset
 
   @type t :: %__MODULE__{
           filename: String.t(),
-          shapes: list(Arrow.Shuttle.ShapeUpload.t())
+          shapes: list(Arrow.Shuttles.ShapeUpload.t())
         }
 
   embedded_schema do
     field :filename, :string
-    embeds_many :shapes, Arrow.Shuttle.ShapeUpload
+    embeds_many :shapes, Arrow.Shuttles.ShapeUpload
   end
 
   @doc false
@@ -66,7 +66,7 @@ defmodule Arrow.Shuttle.ShapesUpload do
   @doc """
   Parses one or many Shapes from a map of the KML/XML
   """
-  @spec shapes_from_kml(map) :: {:ok, list(Arrow.Shuttle.ShapeUpload.t())} | {:error, any}
+  @spec shapes_from_kml(map) :: {:ok, list(Arrow.Shuttles.ShapeUpload.t())} | {:error, any}
   def shapes_from_kml(saxy_shapes) do
     placemarks = saxy_shapes["kml"]["Folder"]["Placemark"]
 

--- a/lib/arrow/shuttle/stop.ex
+++ b/lib/arrow/shuttle/stop.ex
@@ -1,4 +1,4 @@
-defmodule Arrow.Shuttle.Stop do
+defmodule Arrow.Shuttles.Stop do
   @moduledoc false
 
   use Ecto.Schema

--- a/lib/arrow/shuttles.ex
+++ b/lib/arrow/shuttles.ex
@@ -1,6 +1,6 @@
-defmodule Arrow.Shuttle do
+defmodule Arrow.Shuttles do
   @moduledoc """
-  The Shuttle context.
+  The Shuttles context.
   """
 
   import Ecto.Query, warn: false
@@ -8,10 +8,10 @@ defmodule Arrow.Shuttle do
   alias Arrow.Repo
   alias ArrowWeb.ErrorHelpers
 
-  alias Arrow.Shuttle.KML
-  alias Arrow.Shuttle.Shape
-  alias Arrow.Shuttle.ShapesUpload
-  alias Arrow.Shuttle.ShapeUpload
+  alias Arrow.Shuttles.KML
+  alias Arrow.Shuttles.Shape
+  alias Arrow.Shuttles.ShapesUpload
+  alias Arrow.Shuttles.ShapeUpload
 
   @doc """
   Returns the list of shapes.

--- a/lib/arrow/stops.ex
+++ b/lib/arrow/stops.ex
@@ -6,7 +6,7 @@ defmodule Arrow.Stops do
   import Ecto.Query, warn: false
   alias Arrow.Repo
 
-  alias Arrow.Shuttle.Stop
+  alias Arrow.Shuttles.Stop
 
   @doc """
   Returns the list of stops.

--- a/lib/arrow_web/controllers/shape_controller.ex
+++ b/lib/arrow_web/controllers/shape_controller.ex
@@ -1,11 +1,11 @@
 defmodule ArrowWeb.ShapeController do
   require Logger
-  alias Arrow.Shuttle.ShapesUpload
+  alias Arrow.Shuttles.ShapesUpload
   alias ArrowWeb.ErrorHelpers
   alias Ecto.Changeset
   use ArrowWeb, :controller
 
-  alias Arrow.Shuttle
+  alias Arrow.Shuttles
   alias ArrowWeb.Plug.Authorize
 
   plug(Authorize, :view_disruption when action in [:index, :show, :download])
@@ -14,7 +14,7 @@ defmodule ArrowWeb.ShapeController do
   plug(Authorize, :delete_disruption when action in [:delete])
 
   def index(conn, _params) do
-    shapes = Shuttle.list_shapes()
+    shapes = Shuttles.list_shapes()
     render(conn, :index, shapes: shapes)
   end
 
@@ -68,7 +68,7 @@ defmodule ArrowWeb.ShapeController do
       |> Enum.filter(fn shape -> shape["save"] == "true" end)
       |> Enum.map(fn shape -> %{name: shape["name"], coordinates: shape["coordinates"]} end)
 
-    case Shuttle.create_shapes(saved_shapes) do
+    case Shuttles.create_shapes(saved_shapes) do
       {:ok, []} ->
         conn
         |> put_flash(
@@ -100,14 +100,14 @@ defmodule ArrowWeb.ShapeController do
   end
 
   def show(conn, %{"id" => id}) do
-    shape = Shuttle.get_shape!(id)
-    shape_upload = Shuttle.get_shapes_upload(shape)
+    shape = Shuttles.get_shape!(id)
+    shape_upload = Shuttles.get_shapes_upload(shape)
     render(conn, :show, shape: shape, shape_upload: shape_upload)
   end
 
   def download(conn, %{"id" => id}) do
     enabled? = Application.get_env(:arrow, :shape_storage_enabled?)
-    shape = Shuttle.get_shape!(id)
+    shape = Shuttles.get_shape!(id)
     basic_url = "https://#{shape.bucket}.s3.amazonaws.com/#{shape.path}"
 
     {:ok, url} =
@@ -124,8 +124,8 @@ defmodule ArrowWeb.ShapeController do
   end
 
   def delete(conn, %{"id" => id}) do
-    shape = Shuttle.get_shape!(id)
-    {:ok, _shape} = Shuttle.delete_shape(shape)
+    shape = Shuttles.get_shape!(id)
+    {:ok, _shape} = Shuttles.delete_shape(shape)
 
     conn
     |> put_flash(:info, "Shape deleted successfully.")

--- a/lib/arrow_web/controllers/shape_html.ex
+++ b/lib/arrow_web/controllers/shape_html.ex
@@ -1,6 +1,6 @@
 defmodule ArrowWeb.ShapeView do
   use ArrowWeb, :html
-  alias Arrow.Shuttle.ShapesUpload
+  alias Arrow.Shuttles.ShapesUpload
 
   embed_templates "shape_html/*"
 

--- a/lib/arrow_web/live/stop_live/stop_live.ex
+++ b/lib/arrow_web/live/stop_live/stop_live.ex
@@ -1,7 +1,7 @@
 defmodule ArrowWeb.StopViewLive do
   use ArrowWeb, :live_view
 
-  alias Arrow.Shuttle.Stop
+  alias Arrow.Shuttles.Stop
   alias Arrow.Stops
   embed_templates "stop_live/*"
 

--- a/test/arrow/shuttle/kml_test.exs
+++ b/test/arrow/shuttle/kml_test.exs
@@ -1,8 +1,8 @@
-defmodule Arrow.Shuttle.KMLTest do
+defmodule Arrow.Shuttles.KMLTest do
   @moduledoc false
   use Arrow.DataCase
 
-  @required_struct %Arrow.Shuttle.ShapeKML{
+  @required_struct %Arrow.Shuttles.ShapeKML{
     name: "some shape",
     coordinates: "-71.14163,42.39551 -71.14163,42.39551 -71.14163,42.39551"
   }
@@ -24,7 +24,7 @@ defmodule Arrow.Shuttle.KMLTest do
                     ]}
                  ]}
               ]} =
-               Saxy.Builder.build(%Arrow.Shuttle.KML{
+               Saxy.Builder.build(%Arrow.Shuttles.KML{
                  xmlns: "http://www.opengis.net/kml/2.2",
                  Folder: @required_struct
                })

--- a/test/arrow/shuttle/shape_kml_test.exs
+++ b/test/arrow/shuttle/shape_kml_test.exs
@@ -1,8 +1,8 @@
-defmodule Arrow.Shuttle.ShapeKMLTest do
+defmodule Arrow.Shuttles.ShapeKMLTest do
   @moduledoc false
   use Arrow.DataCase
 
-  @required_struct %Arrow.Shuttle.ShapeKML{
+  @required_struct %Arrow.Shuttles.ShapeKML{
     name: "some shape",
     coordinates: "-71.14163,42.39551 -71.14163,42.39551 -71.14163,42.39551"
   }

--- a/test/arrow/shuttle/shape_test.exs
+++ b/test/arrow/shuttle/shape_test.exs
@@ -1,7 +1,7 @@
-defmodule Arrow.Shuttle.ShapeTest do
+defmodule Arrow.Shuttles.ShapeTest do
   use Arrow.DataCase
 
-  alias Arrow.Shuttle.Shape
+  alias Arrow.Shuttles.Shape
 
   describe "changeset/2" do
     test "validates shape name ends with -S" do

--- a/test/arrow/shuttle/stop_test.exs
+++ b/test/arrow/shuttle/stop_test.exs
@@ -1,7 +1,7 @@
-defmodule Arrow.Shuttle.StopTest do
+defmodule Arrow.Shuttles.StopTest do
   use Arrow.DataCase
 
-  alias Arrow.Shuttle.Stop
+  alias Arrow.Shuttles.Stop
 
   @required_stop_params %{
     stop_id: "stop_id",

--- a/test/arrow/shuttle_test.exs
+++ b/test/arrow/shuttle_test.exs
@@ -1,9 +1,9 @@
-defmodule Arrow.ShuttleTest do
+defmodule Arrow.ShuttlesTest do
   use Arrow.DataCase
 
-  alias Arrow.Shuttle
-  alias Arrow.Shuttle.Shape
-  import Arrow.ShuttleFixtures
+  alias Arrow.Shuttles
+  alias Arrow.Shuttles.Shape
+  import Arrow.ShuttlesFixtures
   import Test.Support.Helpers
 
   describe "shapes with s3 functionality enabled (mocked)" do
@@ -16,7 +16,7 @@ defmodule Arrow.ShuttleTest do
       reassign_env(:shape_storage_enabled?, true)
       reassign_env(:shape_storage_prefix, "prefix/#{Ecto.UUID.generate()}/")
 
-      assert {:ok, %Shape{} = shape} = Shuttle.create_shape(@valid_shape)
+      assert {:ok, %Shape{} = shape} = Shuttles.create_shape(@valid_shape)
       assert shape.name == "some name-S"
       Application.put_env(:arrow, :shape_storage_enabled?, false)
     end
@@ -26,7 +26,7 @@ defmodule Arrow.ShuttleTest do
       Application.put_env(:arrow, :shape_storage_prefix, "prefix/#{Ecto.UUID.generate()}/")
 
       assert {:ok, %Shape{} = shape} =
-               Shuttle.create_shape(%{name: "some name", coordinates: coords()})
+               Shuttles.create_shape(%{name: "some name", coordinates: coords()})
 
       assert shape.name == "some name-S"
     end
@@ -34,17 +34,17 @@ defmodule Arrow.ShuttleTest do
     test "delete_shape/1 deletes the shape" do
       reassign_env(:shape_storage_enabled?, true)
 
-      assert {:ok, %Shape{} = shape} = Shuttle.create_shape(@valid_shape)
-      assert {:ok, %Shape{}} = Shuttle.delete_shape(shape)
-      assert_raise Ecto.NoResultsError, fn -> Shuttle.get_shape!(shape.id) end
+      assert {:ok, %Shape{} = shape} = Shuttles.create_shape(@valid_shape)
+      assert {:ok, %Shape{}} = Shuttles.delete_shape(shape)
+      assert_raise Ecto.NoResultsError, fn -> Shuttles.get_shape!(shape.id) end
     end
 
     test "get_shapes_upload/1 returns a ShapesUpload changeset" do
       reassign_env(:shape_storage_enabled?, true)
 
       new_shape = s3_mocked_shape_fixture()
-      shape = Shuttle.get_shape!(new_shape.id)
-      assert %Ecto.Changeset{valid?: true} = Shuttle.get_shapes_upload(shape)
+      shape = Shuttles.get_shape!(new_shape.id)
+      assert %Ecto.Changeset{valid?: true} = Shuttles.get_shapes_upload(shape)
     end
   end
 
@@ -54,57 +54,57 @@ defmodule Arrow.ShuttleTest do
 
     test "list_shapes/0 returns all shapes" do
       shape = shape_fixture()
-      assert Shuttle.list_shapes() == [shape]
+      assert Shuttles.list_shapes() == [shape]
     end
 
     test "get_shape!/1 returns the shape with given id" do
       shape = shape_fixture()
-      assert Shuttle.get_shape!(shape.id) == shape
+      assert Shuttles.get_shape!(shape.id) == shape
     end
 
     test "create_shapes/1 with valid data creates a shape" do
-      assert {:ok, [{:ok, %Shape{} = shape}]} = Shuttle.create_shapes([@valid_attrs])
+      assert {:ok, [{:ok, %Shape{} = shape}]} = Shuttles.create_shapes([@valid_attrs])
       assert shape.name == "some name-S"
     end
 
     test "create_shapes/1 with invalid data returns error changeset" do
       assert {:error, {"Failed to upload some shapes", changeset}} =
-               Shuttle.create_shapes([@invalid_attrs])
+               Shuttles.create_shapes([@invalid_attrs])
 
       assert ["Name can't be blank "] = changeset
     end
 
     test "create_shapes/1 creates valid and returns errors for invalid" do
       name = @valid_attrs.name
-      refute Repo.get_by(Arrow.Shuttle.Shape, name: name)
+      refute Repo.get_by(Arrow.Shuttles.Shape, name: name)
 
       assert {:error, {"Failed to upload some shapes", changeset}} =
-               Shuttle.create_shapes([@valid_attrs, @invalid_attrs])
+               Shuttles.create_shapes([@valid_attrs, @invalid_attrs])
 
       assert ["Name can't be blank "] = changeset
-      assert %Shape{name: ^name} = Repo.get_by(Arrow.Shuttle.Shape, name: name)
+      assert %Shape{name: ^name} = Repo.get_by(Arrow.Shuttles.Shape, name: name)
     end
 
     test "create_shape/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Shuttle.create_shape(@invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Shuttles.create_shape(@invalid_attrs)
     end
 
     test "create_shape/1 with existing name returns an error" do
-      assert {:ok, %Shape{}} = Shuttle.create_shape(@valid_attrs)
+      assert {:ok, %Shape{}} = Shuttles.create_shape(@valid_attrs)
       # Trying to create a second time throws an error
-      assert {:error, message} = Shuttle.create_shape(@valid_attrs)
+      assert {:error, message} = Shuttles.create_shape(@valid_attrs)
       assert message =~ "already exists"
     end
 
     test "delete_shape/1 deletes the shape" do
       shape = shape_fixture()
-      assert {:ok, %Shape{}} = Shuttle.delete_shape(shape)
-      assert_raise Ecto.NoResultsError, fn -> Shuttle.get_shape!(shape.id) end
+      assert {:ok, %Shape{}} = Shuttles.delete_shape(shape)
+      assert_raise Ecto.NoResultsError, fn -> Shuttles.get_shape!(shape.id) end
     end
 
     test "change_shape/1 returns a shape changeset" do
       shape = shape_fixture()
-      assert %Ecto.Changeset{} = Shuttle.change_shape(shape)
+      assert %Ecto.Changeset{} = Shuttles.change_shape(shape)
     end
   end
 end

--- a/test/arrow/stops_test.exs
+++ b/test/arrow/stops_test.exs
@@ -5,7 +5,7 @@ defmodule Arrow.StopsTest do
   alias Arrow.Stops
 
   describe "stops" do
-    alias Arrow.Shuttle.Stop
+    alias Arrow.Shuttles.Stop
 
     import Arrow.StopsFixtures
 

--- a/test/arrow_web/controllers/shape_controller_test.exs
+++ b/test/arrow_web/controllers/shape_controller_test.exs
@@ -1,9 +1,9 @@
 defmodule ArrowWeb.ShapeControllerTest do
   use ArrowWeb.ConnCase, async: true
   alias Arrow.Repo
-  alias Arrow.Shuttle.Shape
+  alias Arrow.Shuttles.Shape
 
-  import Arrow.ShuttleFixtures
+  import Arrow.ShuttlesFixtures
   import Test.Support.Helpers
 
   @upload_attrs %{

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -58,7 +58,7 @@ defmodule Arrow.Factory do
   end
 
   def stop_factory do
-    %Arrow.Shuttle.Stop{
+    %Arrow.Shuttles.Stop{
       stop_id: sequence(:source_label, &"stop-#{&1}"),
       stop_name: sequence(:source_label, &"Stop #{&1}"),
       stop_desc: sequence(:source_label, &"Stop Description #{&1}"),

--- a/test/support/fixtures/shuttles_fixtures.ex
+++ b/test/support/fixtures/shuttles_fixtures.ex
@@ -1,11 +1,11 @@
-defmodule Arrow.ShuttleFixtures do
+defmodule Arrow.ShuttlesFixtures do
   @moduledoc """
   This module defines test helpers for creating
-  entities via the `Arrow.Shuttle` context.
+  entities via the `Arrow.Shuttles` context.
   """
 
   alias Arrow.Repo
-  alias Arrow.Shuttle.Shape
+  alias Arrow.Shuttles.Shape
 
   @doc """
   Generate valid coords
@@ -31,7 +31,7 @@ defmodule Arrow.ShuttleFixtures do
         prefix: "some/prefix/",
         coordinates: coords()
       })
-      |> Arrow.Shuttle.create_shape()
+      |> Arrow.Shuttles.create_shape()
 
     shape
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket, pre-work to shuttles implementation

Rename the Shuttle context to be Shuttles, this should have been pluralized originally. 

Phoenix documentation gives the example of "Catalog" and states:

> If you're stuck when trying to come up with a context name when the grouped functionality in your system isn't yet clear, you can simply use the plural form of the resource you're creating. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
