### PR TITLE
fix: fix error display of bootstrap styling for core_components select

### DIFF
--- a/lib/arrow_web/components/core_components.ex
+++ b/lib/arrow_web/components/core_components.ex
@@ -344,6 +344,7 @@ defmodule ArrowWeb.CoreComponents do
         name={@name}
         class={[
           "mt-2 block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm",
+          @errors != [] && "is-invalid",
           @class
         ]}
         multiple={@multiple}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket

I noticed the select input within the core components file was missing the "@errors" check that was added when the bootstrap styling was incorporated into `core_components`. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
