### PR TITLE
feat: add shuttle route definition to shuttles

### DIFF
--- a/lib/arrow/shuttles.ex
+++ b/lib/arrow/shuttles.ex
@@ -8,6 +8,7 @@ defmodule Arrow.Shuttles do
   alias Arrow.Repo
   alias ArrowWeb.ErrorHelpers
 
+  alias Arrow.Gtfs.Route, as: GtfsRoute
   alias Arrow.Shuttles.KML
   alias Arrow.Shuttles.Shape
   alias Arrow.Shuttles.ShapesUpload
@@ -310,5 +311,10 @@ defmodule Arrow.Shuttles do
   """
   def change_shuttle(%Shuttle{} = shuttle, attrs \\ %{}) do
     Shuttle.changeset(shuttle, attrs)
+  end
+
+  def list_disruptable_routes do
+    query = from(r in GtfsRoute, where: r.type in [:light_rail, :heavy_rail])
+    Repo.all(query)
   end
 end

--- a/lib/arrow/shuttles.ex
+++ b/lib/arrow/shuttles.ex
@@ -262,7 +262,9 @@ defmodule Arrow.Shuttles do
       ** (Ecto.NoResultsError)
 
   """
-  def get_shuttle!(id), do: Repo.get!(Shuttle, id)
+  def get_shuttle!(id) do
+    Repo.get!(Shuttle, id) |> Repo.preload(routes: [:shape])
+  end
 
   @doc """
   Creates a shuttle.

--- a/lib/arrow/shuttles.ex
+++ b/lib/arrow/shuttles.ex
@@ -245,7 +245,7 @@ defmodule Arrow.Shuttles do
 
   """
   def list_shuttles do
-    Repo.all(Shuttle)
+    Repo.all(Shuttle) |> Repo.preload(routes: [:shape])
   end
 
   @doc """

--- a/lib/arrow/shuttles.ex
+++ b/lib/arrow/shuttles.ex
@@ -279,9 +279,15 @@ defmodule Arrow.Shuttles do
 
   """
   def create_shuttle(attrs \\ %{}) do
-    %Shuttle{}
-    |> Shuttle.changeset(attrs)
-    |> Repo.insert()
+    created_shuttle =
+      %Shuttle{}
+      |> Shuttle.changeset(attrs)
+      |> Repo.insert()
+
+    case created_shuttle do
+      {:ok, shuttle} -> {:ok, Repo.preload(shuttle, routes: [:shape])}
+      err -> err
+    end
   end
 
   @doc """
@@ -297,9 +303,15 @@ defmodule Arrow.Shuttles do
 
   """
   def update_shuttle(%Shuttle{} = shuttle, attrs) do
-    shuttle
-    |> Shuttle.changeset(attrs)
-    |> Repo.update()
+    updated_shuttle =
+      shuttle
+      |> Shuttle.changeset(attrs)
+      |> Repo.update()
+
+    case updated_shuttle do
+      {:ok, shuttle} -> {:ok, Repo.preload(shuttle, routes: [:shape])}
+      err -> err
+    end
   end
 
   @doc """

--- a/lib/arrow/shuttles/route.ex
+++ b/lib/arrow/shuttles/route.ex
@@ -9,8 +9,8 @@ defmodule Arrow.Shuttles.Route do
     field :direction_id, Ecto.Enum, values: [:"0", :"1"]
     field :direction_desc, :string
     field :waypoint, :string
-    field :shuttle_id, :id
-    field :shape_id, :id
+    belongs_to :shuttle, Arrow.Shuttles.Shuttle
+    belongs_to :shape, Arrow.Shuttles.Shape
 
     timestamps(type: :utc_datetime)
   end
@@ -19,6 +19,7 @@ defmodule Arrow.Shuttles.Route do
   def changeset(route, attrs) do
     route
     |> cast(attrs, [:direction_id, :direction_desc, :destination, :waypoint, :suffix])
+    |> cast_assoc(:shape)
     |> validate_required([:direction_id, :direction_desc, :destination])
   end
 end

--- a/lib/arrow/shuttles/route.ex
+++ b/lib/arrow/shuttles/route.ex
@@ -18,8 +18,8 @@ defmodule Arrow.Shuttles.Route do
   @doc false
   def changeset(route, attrs) do
     route
-    |> cast(attrs, [:direction_id, :direction_desc, :destination, :waypoint, :suffix])
-    |> cast_assoc(:shape)
+    |> cast(attrs, [:direction_id, :direction_desc, :destination, :waypoint, :suffix, :shape_id])
+    |> foreign_key_constraint(:shape_id)
     |> validate_required([:direction_id, :direction_desc, :destination])
   end
 end

--- a/lib/arrow/shuttles/route_stop.ex
+++ b/lib/arrow/shuttles/route_stop.ex
@@ -8,7 +8,7 @@ defmodule Arrow.Shuttles.RouteStop do
     field :stop_id, :string
     field :stop_sequence, :integer
     field :time_to_next_stop, :decimal
-    field :shuttle_route_id, :id
+    belongs_to :route, Arrow.Shuttles.Route
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -16,6 +16,7 @@ defmodule Arrow.Shuttles.Shuttle do
     shuttle
     |> cast(attrs, [:shuttle_name, :disrupted_route_id, :status])
     |> validate_required([:shuttle_name, :status])
+    |> foreign_key_constraint(:disrupted_route_id)
     |> unique_constraint(:shuttle_name)
   end
 end

--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -7,7 +7,7 @@ defmodule Arrow.Shuttles.Shuttle do
     field :status, Ecto.Enum, values: [:draft, :active, :inactive]
     field :shuttle_name, :string
     field :disrupted_route_id, :string
-    has_many :routes, Arrow.Shuttles.Route
+    has_many :routes, Arrow.Shuttles.Route, preload_order: [asc: :direction_id]
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -16,7 +16,7 @@ defmodule Arrow.Shuttles.Shuttle do
   def changeset(shuttle, attrs) do
     shuttle
     |> cast(attrs, [:shuttle_name, :disrupted_route_id, :status])
-    |> cast_assoc(:routes)
+    |> cast_assoc(:routes, with: &Arrow.Shuttles.Route.changeset/2)
     |> validate_required([:shuttle_name, :status])
     |> validate_required_for(:status)
     |> foreign_key_constraint(:disrupted_route_id)

--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -7,6 +7,7 @@ defmodule Arrow.Shuttles.Shuttle do
     field :status, Ecto.Enum, values: [:draft, :active, :inactive]
     field :shuttle_name, :string
     field :disrupted_route_id, :string
+    has_many :routes, Arrow.Shuttles.Route
 
     timestamps(type: :utc_datetime)
   end
@@ -15,6 +16,7 @@ defmodule Arrow.Shuttles.Shuttle do
   def changeset(shuttle, attrs) do
     shuttle
     |> cast(attrs, [:shuttle_name, :disrupted_route_id, :status])
+    |> cast_assoc(:routes)
     |> validate_required([:shuttle_name, :status])
     |> validate_required_for(:status)
     |> foreign_key_constraint(:disrupted_route_id)

--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -16,7 +16,33 @@ defmodule Arrow.Shuttles.Shuttle do
     shuttle
     |> cast(attrs, [:shuttle_name, :disrupted_route_id, :status])
     |> validate_required([:shuttle_name, :status])
+    |> validate_required_for(:status)
     |> foreign_key_constraint(:disrupted_route_id)
     |> unique_constraint(:shuttle_name)
+  end
+
+  def validate_required_for(changeset, :status) do
+    # Placeholder validation until form is complete
+    status = get_field(changeset, :status)
+    # Set error on status field for now
+    fields = [:status]
+
+    case status do
+      :active ->
+        message = "can't be set to active when required fields are missing"
+
+        %{
+          changeset
+          | errors:
+              Enum.map(
+                fields,
+                &{&1, {message, [validation: :required]}}
+              ),
+            valid?: false
+        }
+
+      _ ->
+        changeset
+    end
   end
 end

--- a/lib/arrow_web/components/core_components.ex
+++ b/lib/arrow_web/components/core_components.ex
@@ -408,7 +408,7 @@ defmodule ArrowWeb.CoreComponents do
 
   def label(assigns) do
     ~H"""
-    <label for={@for}>
+    <label for={@for} class="col-form-label">
       <%= render_slot(@inner_block) %>
     </label>
     """

--- a/lib/arrow_web/controllers/shuttle_controller.ex
+++ b/lib/arrow_web/controllers/shuttle_controller.ex
@@ -12,6 +12,7 @@ defmodule ArrowWeb.ShuttleController do
   def new(conn, _params) do
     changeset =
       Shuttles.change_shuttle(%Shuttle{
+        status: :draft,
         routes: [%Shuttles.Route{direction_id: :"0"}, %Shuttles.Route{direction_id: :"1"}]
       })
 

--- a/lib/arrow_web/controllers/shuttle_controller.ex
+++ b/lib/arrow_web/controllers/shuttle_controller.ex
@@ -10,7 +10,11 @@ defmodule ArrowWeb.ShuttleController do
   end
 
   def new(conn, _params) do
-    changeset = Shuttles.change_shuttle(%Shuttle{})
+    changeset =
+      Shuttles.change_shuttle(%Shuttle{
+        routes: [%Shuttles.Route{direction_id: :"0"}, %Shuttles.Route{direction_id: :"1"}]
+      })
+
     gtfs_disruptable_routes = Shuttles.list_disruptable_routes()
     render(conn, :new, changeset: changeset, gtfs_disruptable_routes: gtfs_disruptable_routes)
   end

--- a/lib/arrow_web/controllers/shuttle_controller.ex
+++ b/lib/arrow_web/controllers/shuttle_controller.ex
@@ -11,7 +11,8 @@ defmodule ArrowWeb.ShuttleController do
 
   def new(conn, _params) do
     changeset = Shuttles.change_shuttle(%Shuttle{})
-    render(conn, :new, changeset: changeset)
+    gtfs_disruptable_routes = Shuttles.list_disruptable_routes()
+    render(conn, :new, changeset: changeset, gtfs_disruptable_routes: gtfs_disruptable_routes)
   end
 
   def create(conn, %{"shuttle" => shuttle_params}) do
@@ -22,7 +23,8 @@ defmodule ArrowWeb.ShuttleController do
         |> redirect(to: ~p"/shuttles/#{shuttle}")
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        render(conn, :new, changeset: changeset)
+        gtfs_disruptable_routes = Shuttles.list_disruptable_routes()
+        render(conn, :new, changeset: changeset, gtfs_disruptable_routes: gtfs_disruptable_routes)
     end
   end
 
@@ -34,7 +36,13 @@ defmodule ArrowWeb.ShuttleController do
   def edit(conn, %{"id" => id}) do
     shuttle = Shuttles.get_shuttle!(id)
     changeset = Shuttles.change_shuttle(shuttle)
-    render(conn, :edit, shuttle: shuttle, changeset: changeset)
+    gtfs_disruptable_routes = Shuttles.list_disruptable_routes()
+
+    render(conn, :edit,
+      shuttle: shuttle,
+      changeset: changeset,
+      gtfs_disruptable_routes: gtfs_disruptable_routes
+    )
   end
 
   def update(conn, %{"id" => id, "shuttle" => shuttle_params}) do
@@ -47,7 +55,13 @@ defmodule ArrowWeb.ShuttleController do
         |> redirect(to: ~p"/shuttles/#{shuttle}")
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        render(conn, :edit, shuttle: shuttle, changeset: changeset)
+        gtfs_disruptable_routes = Shuttles.list_disruptable_routes()
+
+        render(conn, :edit,
+          shuttle: shuttle,
+          changeset: changeset,
+          gtfs_disruptable_routes: gtfs_disruptable_routes
+        )
     end
   end
 end

--- a/lib/arrow_web/controllers/shuttle_controller.ex
+++ b/lib/arrow_web/controllers/shuttle_controller.ex
@@ -16,7 +16,13 @@ defmodule ArrowWeb.ShuttleController do
       })
 
     gtfs_disruptable_routes = Shuttles.list_disruptable_routes()
-    render(conn, :new, changeset: changeset, gtfs_disruptable_routes: gtfs_disruptable_routes)
+    shapes = Shuttles.list_shapes()
+
+    render(conn, :new,
+      changeset: changeset,
+      gtfs_disruptable_routes: gtfs_disruptable_routes,
+      shapes: shapes
+    )
   end
 
   def create(conn, %{"shuttle" => shuttle_params}) do
@@ -28,7 +34,13 @@ defmodule ArrowWeb.ShuttleController do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         gtfs_disruptable_routes = Shuttles.list_disruptable_routes()
-        render(conn, :new, changeset: changeset, gtfs_disruptable_routes: gtfs_disruptable_routes)
+        shapes = Shuttles.list_shapes()
+
+        render(conn, :new,
+          changeset: changeset,
+          gtfs_disruptable_routes: gtfs_disruptable_routes,
+          shapes: shapes
+        )
     end
   end
 
@@ -41,11 +53,13 @@ defmodule ArrowWeb.ShuttleController do
     shuttle = Shuttles.get_shuttle!(id)
     changeset = Shuttles.change_shuttle(shuttle)
     gtfs_disruptable_routes = Shuttles.list_disruptable_routes()
+    shapes = Shuttles.list_shapes()
 
     render(conn, :edit,
       shuttle: shuttle,
       changeset: changeset,
-      gtfs_disruptable_routes: gtfs_disruptable_routes
+      gtfs_disruptable_routes: gtfs_disruptable_routes,
+      shapes: shapes
     )
   end
 
@@ -60,11 +74,13 @@ defmodule ArrowWeb.ShuttleController do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         gtfs_disruptable_routes = Shuttles.list_disruptable_routes()
+        shapes = Shuttles.list_shapes()
 
         render(conn, :edit,
           shuttle: shuttle,
           changeset: changeset,
-          gtfs_disruptable_routes: gtfs_disruptable_routes
+          gtfs_disruptable_routes: gtfs_disruptable_routes,
+          shapes: shapes
         )
     end
   end

--- a/lib/arrow_web/controllers/shuttle_html.ex
+++ b/lib/arrow_web/controllers/shuttle_html.ex
@@ -9,6 +9,7 @@ defmodule ArrowWeb.ShuttleView do
   attr :changeset, Ecto.Changeset, required: true
   attr :action, :string, required: true
   attr :gtfs_disruptable_routes, :list, required: true
+  attr :shapes, :list, required: true
 
   def shuttle_form(assigns)
 end

--- a/lib/arrow_web/controllers/shuttle_html.ex
+++ b/lib/arrow_web/controllers/shuttle_html.ex
@@ -8,6 +8,7 @@ defmodule ArrowWeb.ShuttleView do
   """
   attr :changeset, Ecto.Changeset, required: true
   attr :action, :string, required: true
+  attr :gtfs_disruptable_routes, :list, required: true
 
   def shuttle_form(assigns)
 end

--- a/lib/arrow_web/controllers/shuttle_html/edit.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/edit.html.heex
@@ -2,6 +2,6 @@
   Edit Shuttle <%= @shuttle.id %>
 </.header>
 
-<.shuttle_form changeset={@changeset} action={~p"/shuttles/#{@shuttle}"} />
+<.shuttle_form changeset={@changeset} action={~p"/shuttles/#{@shuttle}"} gtfs_disruptable_routes={@gtfs_disruptable_routes} />
 
 <.back navigate={~p"/shuttles"}>Back to shuttles</.back>

--- a/lib/arrow_web/controllers/shuttle_html/edit.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/edit.html.heex
@@ -6,6 +6,7 @@
   changeset={@changeset}
   action={~p"/shuttles/#{@shuttle}"}
   gtfs_disruptable_routes={@gtfs_disruptable_routes}
+  shapes={@shapes}
 />
 
 <.back navigate={~p"/shuttles"}>Back to shuttles</.back>

--- a/lib/arrow_web/controllers/shuttle_html/edit.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/edit.html.heex
@@ -2,6 +2,10 @@
   edit shuttle <%= @shuttle.id %>
 </.header>
 
-<.shuttle_form changeset={@changeset} action={~p"/shuttles/#{@shuttle}"} gtfs_disruptable_routes={@gtfs_disruptable_routes} />
+<.shuttle_form
+  changeset={@changeset}
+  action={~p"/shuttles/#{@shuttle}"}
+  gtfs_disruptable_routes={@gtfs_disruptable_routes}
+/>
 
 <.back navigate={~p"/shuttles"}>Back to shuttles</.back>

--- a/lib/arrow_web/controllers/shuttle_html/edit.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/edit.html.heex
@@ -1,5 +1,5 @@
 <.header>
-  Edit Shuttle <%= @shuttle.id %>
+  edit shuttle <%= @shuttle.id %>
 </.header>
 
 <.shuttle_form changeset={@changeset} action={~p"/shuttles/#{@shuttle}"} gtfs_disruptable_routes={@gtfs_disruptable_routes} />

--- a/lib/arrow_web/controllers/shuttle_html/index.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/index.html.heex
@@ -9,6 +9,7 @@
 
 <.table id="shuttles" rows={@shuttles} row_click={&JS.navigate(~p"/shuttles/#{&1}")}>
   <:col :let={shuttle} label="Shuttle name"><%= shuttle.shuttle_name %></:col>
+  <:col :let={shuttle} label="Disrupted route"><%= shuttle.disrupted_route_id %></:col>
   <:col :let={shuttle} label="Status"><%= shuttle.status %></:col>
   <:action :let={shuttle}>
     <div class="sr-only">

--- a/lib/arrow_web/controllers/shuttle_html/index.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/index.html.heex
@@ -1,5 +1,5 @@
 <.header>
-  Listing Shuttles
+  shuttles
   <:actions>
     <.link href={~p"/shuttles/new"}>
       <.button>New Shuttle</.button>

--- a/lib/arrow_web/controllers/shuttle_html/new.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/new.html.heex
@@ -6,6 +6,7 @@
   changeset={@changeset}
   action={~p"/shuttles"}
   gtfs_disruptable_routes={@gtfs_disruptable_routes}
+  shapes={@shapes}
 />
 
 <.back navigate={~p"/shuttles"}>Back to shuttles</.back>

--- a/lib/arrow_web/controllers/shuttle_html/new.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/new.html.heex
@@ -2,6 +2,10 @@
   new shuttle
 </.header>
 
-<.shuttle_form changeset={@changeset} action={~p"/shuttles"} gtfs_disruptable_routes={@gtfs_disruptable_routes} />
+<.shuttle_form
+  changeset={@changeset}
+  action={~p"/shuttles"}
+  gtfs_disruptable_routes={@gtfs_disruptable_routes}
+/>
 
 <.back navigate={~p"/shuttles"}>Back to shuttles</.back>

--- a/lib/arrow_web/controllers/shuttle_html/new.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/new.html.heex
@@ -2,6 +2,6 @@
   New Shuttle
 </.header>
 
-<.shuttle_form changeset={@changeset} action={~p"/shuttles"} />
+<.shuttle_form changeset={@changeset} action={~p"/shuttles"} gtfs_disruptable_routes={@gtfs_disruptable_routes} />
 
 <.back navigate={~p"/shuttles"}>Back to shuttles</.back>

--- a/lib/arrow_web/controllers/shuttle_html/new.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/new.html.heex
@@ -1,5 +1,5 @@
 <.header>
-  New Shuttle
+  new shuttle
 </.header>
 
 <.shuttle_form changeset={@changeset} action={~p"/shuttles"} gtfs_disruptable_routes={@gtfs_disruptable_routes} />

--- a/lib/arrow_web/controllers/shuttle_html/show.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/show.html.heex
@@ -1,5 +1,5 @@
 <.header>
-  Shuttle <%= @shuttle.id %>
+  shuttle <%= @shuttle.id %>
   <:actions>
     <.link href={~p"/shuttles/#{@shuttle}/edit"}>
       <.button>Edit shuttle</.button>

--- a/lib/arrow_web/controllers/shuttle_html/show.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/show.html.heex
@@ -9,6 +9,7 @@
 
 <.list>
   <:item title="Shuttle name"><%= @shuttle.shuttle_name %></:item>
+  <:item title="Disrupted route"><%= @shuttle.disrupted_route_id %></:item>
   <:item title="Status"><%= @shuttle.status %></:item>
 </.list>
 

--- a/lib/arrow_web/controllers/shuttle_html/shuttle_form.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/shuttle_form.html.heex
@@ -1,34 +1,71 @@
 <.simple_form :let={f} for={@changeset} action={@action}>
+  <div class="form-group">
+    <a
+      target="_blank"
+      rel="noreferrer noopener"
+      href="https://www.notion.so/native/mbta-downtown-crossing/Conventions-for-shuttle-bus-information-fc5a788409b24eb088dbfe3a43abf67e?pvs=4&deepLinkOpenNewTab=true#2b8886089b25403991f1ed69144d8fd8"
+    >
+      View Shuttle Definition Conventions
+    </a>
+  </div>
   <.error :if={@changeset.action}>
     Oops, something went wrong! Please check the errors below.
   </.error>
-  <.input field={f[:shuttle_name]} type="text" label="Shuttle name" />
-  <.input 
-    field={f[:disrupted_route_id]} 
-    type="select" 
-    label="Disrupted route"
-    prompt="Choose a route"
-    options={Enum.map(@gtfs_disruptable_routes, fn route -> route.id end)}
-   />
-  <.input
-    field={f[:status]}
-    type="select"
-    label="Status"
-    prompt="Choose a value"
-    options={Ecto.Enum.values(Arrow.Shuttles.Shuttle, :status)}
-  />
+  <div class="row">
+    <div class="col">
+      <.input field={f[:shuttle_name]} type="text" label="Shuttle Name" />
+    </div>
+    <div class="col">
+      <.input 
+        field={f[:disrupted_route_id]} 
+        type="select" 
+        label="Disrupted Route"
+        prompt="Choose a route"
+        options={Enum.map(@gtfs_disruptable_routes, fn route -> route.id end)}
+      />
+    </div>
+    <div class="col">
+      <.input
+        field={f[:status]}
+        type="select"
+        label="Status"
+        prompt="Choose a value"
+        options={Ecto.Enum.values(Arrow.Shuttles.Shuttle, :status)}
+      />
+    </div>
+  </div>
+  <hr>
+  <h2> define route </h2>
   <.inputs_for :let={f_route} field={f[:routes]}> 
-    <hr>
-    <div class="form-group">
-      <h3>direction <%= input_value(f_route, :direction_id) %> </h3>
+    <h4>direction <%= input_value(f_route, :direction_id) %> </h4>
+    <div class="row">
       <div class="hidden">
         <.input field={f_route[:direction_id]} type="text" label="Direction id" />
       </div>
-      <.input field={f_route[:direction_desc]} type="text" label="Direction desc" />
-      <.input field={f_route[:destination]} type="text" label="Destination" />
-      <.input field={f_route[:waypoint]} type="text" label="Waypoint" />
-      <.input field={f_route[:suffix]} type="text" label="Suffix" />
-      <.input field={f_route[:shape_id]} type="text" label="Shape id" />
+      <div class="col">
+        <.input field={f_route[:direction_desc]} type="text" label="Direction desc" />
+      </div>
+      <div class="col offset-md-1">
+        <.input field={f_route[:shape_id]} type="text" label="Shape id" />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <.input field={f_route[:destination]} type="text" label="Destination" />
+      </div>
+      <div class="col-1 align-self-end italic">
+        <div class="form-group">
+        via
+        </div>
+      </div>
+      <div class="col">
+        <.input field={f_route[:waypoint]} type="text" label="Waypoint" />
+      </div>
+    </div>
+    <div class="row">
+        <div class="col">
+        <.input field={f_route[:suffix]} type="text" label="Suffix" />
+        </div>
     </div>
   </.inputs_for>
   <:actions>

--- a/lib/arrow_web/controllers/shuttle_html/shuttle_form.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/shuttle_form.html.heex
@@ -21,7 +21,7 @@
         type="select"
         label="Disrupted Route"
         prompt="Choose a route"
-        options={Enum.map(@gtfs_disruptable_routes, fn route -> route.id end)}
+        options={Enum.map(@gtfs_disruptable_routes, &{&1.long_name, &1.id})}
       />
     </div>
     <div class="col">
@@ -46,7 +46,13 @@
         <.input field={f_route[:direction_desc]} type="text" label="Direction desc" />
       </div>
       <div class="col offset-md-1">
-        <.input field={f_route[:shape_id]} type="text" label="Shape id" />
+        <.input
+          field={f_route[:shape_id]}
+          type="select"
+          label="Shape"
+          prompt="Choose a shape"
+          options={Enum.map(@shapes, &{&1.name, &1.id})}
+        />
       </div>
     </div>
     <div class="row">

--- a/lib/arrow_web/controllers/shuttle_html/shuttle_form.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/shuttle_form.html.heex
@@ -3,6 +3,7 @@
     Oops, something went wrong! Please check the errors below.
   </.error>
   <.input field={f[:shuttle_name]} type="text" label="Shuttle name" />
+  <.input field={f[:disrupted_route_id]} type="text" label="Disrupted route" />
   <.input
     field={f[:status]}
     type="select"

--- a/lib/arrow_web/controllers/shuttle_html/shuttle_form.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/shuttle_form.html.heex
@@ -16,9 +16,9 @@
       <.input field={f[:shuttle_name]} type="text" label="Shuttle Name" />
     </div>
     <div class="col">
-      <.input 
-        field={f[:disrupted_route_id]} 
-        type="select" 
+      <.input
+        field={f[:disrupted_route_id]}
+        type="select"
         label="Disrupted Route"
         prompt="Choose a route"
         options={Enum.map(@gtfs_disruptable_routes, fn route -> route.id end)}
@@ -34,10 +34,10 @@
       />
     </div>
   </div>
-  <hr>
-  <h2> define route </h2>
-  <.inputs_for :let={f_route} field={f[:routes]}> 
-    <h4>direction <%= input_value(f_route, :direction_id) %> </h4>
+  <hr />
+  <h2>define route</h2>
+  <.inputs_for :let={f_route} field={f[:routes]}>
+    <h4>direction <%= input_value(f_route, :direction_id) %></h4>
     <div class="row">
       <div class="hidden">
         <.input field={f_route[:direction_id]} type="text" label="Direction id" />
@@ -55,7 +55,7 @@
       </div>
       <div class="col-1 align-self-end italic">
         <div class="form-group">
-        via
+          via
         </div>
       </div>
       <div class="col">
@@ -63,9 +63,9 @@
       </div>
     </div>
     <div class="row">
-        <div class="col">
+      <div class="col">
         <.input field={f_route[:suffix]} type="text" label="Suffix" />
-        </div>
+      </div>
     </div>
   </.inputs_for>
   <:actions>

--- a/lib/arrow_web/controllers/shuttle_html/shuttle_form.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/shuttle_form.html.heex
@@ -17,6 +17,20 @@
     prompt="Choose a value"
     options={Ecto.Enum.values(Arrow.Shuttles.Shuttle, :status)}
   />
+  <.inputs_for :let={f_route} field={f[:routes]}> 
+    <hr>
+    <div class="form-group">
+      <h3>direction <%= input_value(f_route, :direction_id) %> </h3>
+      <div class="hidden">
+        <.input field={f_route[:direction_id]} type="text" label="Direction id" />
+      </div>
+      <.input field={f_route[:direction_desc]} type="text" label="Direction desc" />
+      <.input field={f_route[:destination]} type="text" label="Destination" />
+      <.input field={f_route[:waypoint]} type="text" label="Waypoint" />
+      <.input field={f_route[:suffix]} type="text" label="Suffix" />
+      <.input field={f_route[:shape_id]} type="text" label="Shape id" />
+    </div>
+  </.inputs_for>
   <:actions>
     <.button>Save Shuttle</.button>
   </:actions>

--- a/lib/arrow_web/controllers/shuttle_html/shuttle_form.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/shuttle_form.html.heex
@@ -3,7 +3,13 @@
     Oops, something went wrong! Please check the errors below.
   </.error>
   <.input field={f[:shuttle_name]} type="text" label="Shuttle name" />
-  <.input field={f[:disrupted_route_id]} type="text" label="Disrupted route" />
+  <.input 
+    field={f[:disrupted_route_id]} 
+    type="select" 
+    label="Disrupted route"
+    prompt="Choose a route"
+    options={Enum.map(@gtfs_disruptable_routes, fn route -> route.id end)}
+   />
   <.input
     field={f[:status]}
     type="select"

--- a/priv/repo/migrations/20241018202407_add_fk_gtfs_route_shuttles.exs
+++ b/priv/repo/migrations/20241018202407_add_fk_gtfs_route_shuttles.exs
@@ -1,0 +1,10 @@
+defmodule Arrow.Repo.Migrations.AddFkGtfsRouteShuttles do
+  use Ecto.Migration
+
+  def change do
+    alter table(:shuttles) do
+      modify :disrupted_route_id, references(:gtfs_routes, type: :varchar, on_delete: :nothing),
+        from: :string
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,27 +11,34 @@
 # and so on) as they will fail if something goes wrong.
 
 alias Arrow.Repo
-# alias Arrow.Gtfs.Route
+alias Arrow.Gtfs
 alias Arrow.Shuttles.{Shape, Stop, Shuttle, Route, RouteStop}
 
 # For testing locally with dependency on /import-gtfs
-# Repo.insert %Route{
-#   id: "Red-dev",
-#   agency_id: "1",
-#   short_name: nil,
-#   long_name: "Red Line",
-#   desc: "Rapid Transit",
-#   type: :heavy_rail,
-#   url: "https://www.mbta.com/schedules/Red",
-#   color: "DA291C",
-#   text_color: "FFFFFF",
-#   sort_order: 10010,
-#   fare_class: "Rapid Transit",
-#   line_id: "line-Red",
-#   listed_route: nil,
-#   network_id: "rapid_transit"
-# }
-#
+Repo.insert(%Gtfs.Route{
+  id: "Red-dev",
+  agency: %Gtfs.Agency{id: "1", name: "MBTA", url: "https://www.mbta.com", timezone: "ETC"},
+  short_name: nil,
+  long_name: "Red Line",
+  desc: "Rapid Transit",
+  type: :heavy_rail,
+  url: "https://www.mbta.com/schedules/Red",
+  color: "DA291C",
+  text_color: "FFFFFF",
+  sort_order: 10010,
+  fare_class: "Rapid Transit",
+  line: %Gtfs.Line{
+    id: "line-Red",
+    short_name: "Red",
+    long_name: "Red line",
+    desc: "Red line subway",
+    color: "Red",
+    text_color: "Red",
+    sort_order: 0
+  },
+  listed_route: nil,
+  network_id: "rapid_transit"
+})
 
 Repo.insert!(%Shape{
   id: 1,

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -17,6 +17,13 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+--
 -- Name: day_name; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -854,7 +861,7 @@ ALTER SEQUENCE public.shuttle_routes_id_seq OWNED BY public.shuttle_routes.id;
 CREATE TABLE public.shuttles (
     id bigint NOT NULL,
     shuttle_name character varying(255),
-    disrupted_route_id character varying(255),
+    disrupted_route_id character varying,
     status character varying(255),
     inserted_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL
@@ -1675,6 +1682,14 @@ ALTER TABLE ONLY public.shuttle_routes
 
 
 --
+-- Name: shuttles shuttles_disrupted_route_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.shuttles
+    ADD CONSTRAINT shuttles_disrupted_route_id_fkey FOREIGN KEY (disrupted_route_id) REFERENCES public.gtfs_routes(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -1715,3 +1730,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20241003182524);
 INSERT INTO public."schema_migrations" (version) VALUES (20241010164333);
 INSERT INTO public."schema_migrations" (version) VALUES (20241010164455);
 INSERT INTO public."schema_migrations" (version) VALUES (20241010164555);
+INSERT INTO public."schema_migrations" (version) VALUES (20241018202407);

--- a/test/arrow/shuttles_test.exs
+++ b/test/arrow/shuttles_test.exs
@@ -141,11 +141,20 @@ defmodule Arrow.ShuttlesTest do
 
     test "update_shuttle/2 with valid data updates the shuttle" do
       shuttle = shuttle_fixture()
-      update_attrs = %{status: :active, shuttle_name: "some updated shuttle_name"}
+      update_attrs = %{status: :draft, shuttle_name: "some updated shuttle_name"}
 
       assert {:ok, %Shuttle{} = shuttle} = Shuttles.update_shuttle(shuttle, update_attrs)
-      assert shuttle.status == :active
+      assert shuttle.status == :draft
       assert shuttle.shuttle_name == "some updated shuttle_name"
+    end
+
+    test "update_shuttle/2 with invalid data updates for status active returns error changeset" do
+      shuttle = shuttle_fixture()
+      update_attrs = %{status: :active, shuttle_name: "some updated shuttle_name"}
+
+      assert {:error, %Ecto.Changeset{}} = Shuttles.update_shuttle(shuttle, update_attrs)
+      assert shuttle == Shuttles.get_shuttle!(shuttle.id)
+      refute shuttle.status == :active
     end
 
     test "update_shuttle/2 with invalid data returns error changeset" do

--- a/test/arrow/shuttles_test.exs
+++ b/test/arrow/shuttles_test.exs
@@ -148,6 +148,52 @@ defmodule Arrow.ShuttlesTest do
       assert shuttle.shuttle_name == "some updated shuttle_name"
     end
 
+    test "update_shuttle/2 with valid route data updates the shuttle route" do
+      shuttle = shuttle_fixture()
+      [route1, route2] = shuttle.routes
+      destination = unique_shuttle_route_destination()
+      updated_route1 = Map.merge(route1, %{destination: destination})
+
+      update_attrs =
+        Map.from_struct(%Shuttle{
+          shuttle
+          | routes: [Map.from_struct(updated_route1), Map.from_struct(route2)]
+        })
+
+      assert {:ok, %Shuttle{} = shuttle} = Shuttles.update_shuttle(shuttle, update_attrs)
+      assert List.first(shuttle.routes).id == route1.id
+      assert List.first(shuttle.routes).destination == destination
+    end
+
+    test "update_shuttle/2 with valid shape_id updates the shuttle route shape" do
+      shuttle = shuttle_fixture()
+      routes = shuttle.routes
+      first_route = List.first(routes)
+      new_shape = shape_fixture()
+      # Updated shape is set by shape_id param
+      updated_route1 = Map.merge(List.first(routes), %{shape_id: new_shape.id})
+      existing_route2 = Enum.at(routes, 1)
+
+      update_attrs =
+        Map.from_struct(%Shuttle{
+          shuttle
+          | routes: [Map.from_struct(updated_route1), Map.from_struct(existing_route2)]
+        })
+
+      assert {:ok, %Shuttle{} = updated_shuttle} = Shuttles.update_shuttle(shuttle, update_attrs)
+      # Shuttle id is the same
+      assert updated_shuttle.id == shuttle.id
+      # Existing route is unchanged
+      assert Enum.at(updated_shuttle.routes, 1) == existing_route2
+      # Route definition id is the same
+      updated_shuttle_route = List.first(updated_shuttle.routes)
+      assert updated_shuttle_route.id == first_route.id
+      # Shape reference is updated
+      refute updated_shuttle_route.shape == first_route.shape
+      assert updated_shuttle_route.shape.id == updated_route1.shape_id
+      assert updated_shuttle_route.shape == new_shape
+    end
+
     test "update_shuttle/2 with invalid data updates for status active returns error changeset" do
       shuttle = shuttle_fixture()
       update_attrs = %{status: :active, shuttle_name: "some updated shuttle_name"}

--- a/test/arrow_web/controllers/shuttle_controller_test.exs
+++ b/test/arrow_web/controllers/shuttle_controller_test.exs
@@ -4,7 +4,7 @@ defmodule ArrowWeb.ShuttleControllerTest do
   import Arrow.ShuttlesFixtures
 
   @create_attrs %{status: :draft, shuttle_name: "some shuttle_name"}
-  @update_attrs %{status: :active, shuttle_name: "some updated shuttle_name"}
+  @update_attrs %{status: :inactive, shuttle_name: "some updated shuttle_name"}
   @invalid_attrs %{status: nil, shuttle_name: nil}
 
   describe "index" do

--- a/test/arrow_web/controllers/shuttle_controller_test.exs
+++ b/test/arrow_web/controllers/shuttle_controller_test.exs
@@ -11,7 +11,7 @@ defmodule ArrowWeb.ShuttleControllerTest do
     @tag :authenticated
     test "lists all shuttles", %{conn: conn} do
       conn = get(conn, ~p"/shuttles")
-      assert html_response(conn, 200) =~ "Listing Shuttles"
+      assert html_response(conn, 200) =~ "shuttles"
     end
   end
 
@@ -19,7 +19,7 @@ defmodule ArrowWeb.ShuttleControllerTest do
     @tag :authenticated_admin
     test "renders form", %{conn: conn} do
       conn = get(conn, ~p"/shuttles/new")
-      assert html_response(conn, 200) =~ "New Shuttle"
+      assert html_response(conn, 200) =~ "new shuttle"
     end
   end
 
@@ -35,7 +35,7 @@ defmodule ArrowWeb.ShuttleControllerTest do
     @tag :authenticated_admin
     test "renders errors when data is invalid", %{conn: conn} do
       conn = post(conn, ~p"/shuttles", shuttle: @invalid_attrs)
-      assert html_response(conn, 200) =~ "New Shuttle"
+      assert html_response(conn, 200) =~ "new shuttle"
     end
   end
 
@@ -45,7 +45,7 @@ defmodule ArrowWeb.ShuttleControllerTest do
     @tag :authenticated_admin
     test "renders form for editing chosen shuttle", %{conn: conn, shuttle: shuttle} do
       conn = get(conn, ~p"/shuttles/#{shuttle}/edit")
-      assert html_response(conn, 200) =~ "Edit Shuttle"
+      assert html_response(conn, 200) =~ "edit shuttle"
     end
   end
 
@@ -64,7 +64,7 @@ defmodule ArrowWeb.ShuttleControllerTest do
     @tag :authenticated_admin
     test "renders errors when data is invalid", %{conn: conn, shuttle: shuttle} do
       conn = put(conn, ~p"/shuttles/#{shuttle}", shuttle: @invalid_attrs)
-      assert html_response(conn, 200) =~ "Edit Shuttle"
+      assert html_response(conn, 200) =~ "edit shuttle"
     end
   end
 

--- a/test/support/fixtures/shuttles_fixtures.ex
+++ b/test/support/fixtures/shuttles_fixtures.ex
@@ -69,7 +69,8 @@ defmodule Arrow.ShuttlesFixtures do
       attrs
       |> Enum.into(%{
         shuttle_name: unique_shuttle_shuttle_name(),
-        status: :draft
+        status: :draft,
+        routes: []
       })
       |> Arrow.Shuttles.create_shuttle()
 

--- a/test/support/fixtures/shuttles_fixtures.ex
+++ b/test/support/fixtures/shuttles_fixtures.ex
@@ -62,6 +62,38 @@ defmodule Arrow.ShuttlesFixtures do
   def unique_shuttle_shuttle_name, do: "some shuttle_name#{System.unique_integer([:positive])}"
 
   @doc """
+  Generate a unique shuttle route destination.
+  """
+  def unique_shuttle_route_destination,
+    do: "some shuttle_route_destination#{System.unique_integer([:positive])}"
+
+  defp shuttle_routes do
+    shape1 = shape_fixture()
+    shape2 = shape_fixture()
+
+    [
+      %{
+        shape_id: shape1.id,
+        shape: shape1,
+        destination: "Harvard",
+        direction_id: :"0",
+        direction_desc: "Southbound",
+        suffix: nil,
+        waypoint: "Brattle"
+      },
+      %{
+        shape_id: shape2.id,
+        shape: shape2,
+        destination: "Alewife",
+        direction_id: :"1",
+        direction_desc: "Northbound",
+        suffix: nil,
+        waypoint: "Brattle"
+      }
+    ]
+  end
+
+  @doc """
   Generate a shuttle.
   """
   def shuttle_fixture(attrs \\ %{}) do
@@ -70,7 +102,7 @@ defmodule Arrow.ShuttlesFixtures do
       |> Enum.into(%{
         shuttle_name: unique_shuttle_shuttle_name(),
         status: :draft,
-        routes: []
+        routes: shuttle_routes()
       })
       |> Arrow.Shuttles.create_shuttle()
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Implement "Create/Edit Shuttle Route Definition" Basic View + Route Definition Section](https://app.asana.com/0/584764604969369/1208185020019706/f)

The main bit to review in this PR is the shuttle form page on `/shuttles/new`, `/shuttles/1/edit`

You can populate your local database with example data for relations like Gtfs.Route, Shuttle.Shape with:
`mix run priv/repo/seeds.exs`
If you run into any issues with that, you may already have conflicting data in your local database; for fastest resolution, I'd recommend commenting out the conflicting parts of that script or completely resetting the data in your database via `mix db.reset` and re-running `mix run priv/repo/seeds.exs`

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
