### PR TITLE
fix: edit stop broken after dependency update

### DIFF
--- a/lib/arrow_web/live/stop_live/stop_live.ex
+++ b/lib/arrow_web/live/stop_live/stop_live.ex
@@ -103,14 +103,13 @@ defmodule ArrowWeb.StopViewLive do
   def mount(_params, session, socket) do
     logout_url = session["logout_url"]
     form = to_form(Stops.change_stop(%Stop{}))
-    stops = Stops.list_stops()
 
     socket =
       socket
       |> assign(:form, form)
       |> assign(:form_action, "create")
       |> assign(:http_action, ~p"/stops")
-      |> assign(:stops, stops)
+      |> assign(:stop, %Stop{})
       |> assign(:title, "create shuttle stop")
       |> assign(:stop_map_props, %{})
       |> assign(:logout_url, logout_url)
@@ -130,7 +129,7 @@ defmodule ArrowWeb.StopViewLive do
   end
 
   def handle_event("validate", %{"stop" => stop_params}, socket) do
-    form = Stops.change_stop(%Stop{}, stop_params) |> to_form(action: :validate)
+    form = Stops.change_stop(socket.assigns.stop, stop_params) |> to_form(action: :validate)
 
     {:noreply,
      socket

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -54,7 +54,7 @@ defmodule ArrowWeb.Router do
     live("/stops/new", StopViewLive, :new)
     live("/stops/:id/edit", StopViewLive, :edit)
     get("/stops", StopController, :index)
-    post("/stops/:id", StopController, :update)
+    put("/stops/:id", StopController, :update)
     post("/stops", StopController, :create)
     resources("/shapes", ShapeController, only: [:delete, :index, :show])
     get("/shapes_upload", ShapeController, :new)

--- a/test/arrow_web/live/stop_live/stop_live_test.exs
+++ b/test/arrow_web/live/stop_live/stop_live_test.exs
@@ -122,7 +122,7 @@ defmodule ArrowWeb.StopLiveTest do
       conn = follow_trigger_action(form, conn)
       assert conn.method == "POST"
       params = Enum.map(@update_attrs, fn {k, v} -> {"#{k}", v} end) |> Enum.into(%{})
-      assert conn.params == %{"stop" => params, "id" => "#{stop.id}"}
+      assert conn.params == %{"stop" => params}
     end
 
     @tag :authenticated_admin


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐛🏹 Fix Stop ID Validation in Stop Form](https://app.asana.com/0/1204137169527258/1208671244010889/f)


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
