### PR TITLE
Shuttle page stop section

### DIFF
--- a/lib/arrow/shuttles.ex
+++ b/lib/arrow/shuttles.ex
@@ -247,7 +247,7 @@ defmodule Arrow.Shuttles do
 
   """
   def list_shuttles do
-    Repo.all(Shuttle) |> Repo.preload(routes: [:shape])
+    Repo.all(Shuttle) |> Repo.preload(routes: [:shape, :route_stops])
   end
 
   @doc """
@@ -265,7 +265,7 @@ defmodule Arrow.Shuttles do
 
   """
   def get_shuttle!(id) do
-    Repo.get!(Shuttle, id) |> Repo.preload(routes: [:shape])
+    Repo.get!(Shuttle, id) |> Repo.preload(routes: [:shape, :route_stops])
   end
 
   @doc """
@@ -287,7 +287,7 @@ defmodule Arrow.Shuttles do
       |> Repo.insert()
 
     case created_shuttle do
-      {:ok, shuttle} -> {:ok, Repo.preload(shuttle, routes: [:shape])}
+      {:ok, shuttle} -> {:ok, Repo.preload(shuttle, routes: [:shape, :route_stops])}
       err -> err
     end
   end
@@ -311,7 +311,7 @@ defmodule Arrow.Shuttles do
       |> Repo.update()
 
     case updated_shuttle do
-      {:ok, shuttle} -> {:ok, Repo.preload(shuttle, routes: [:shape])}
+      {:ok, shuttle} -> {:ok, Repo.preload(shuttle, routes: [:shape, :route_stops])}
       err -> err
     end
   end

--- a/lib/arrow/shuttles.ex
+++ b/lib/arrow/shuttles.ex
@@ -9,10 +9,12 @@ defmodule Arrow.Shuttles do
   alias ArrowWeb.ErrorHelpers
 
   alias Arrow.Gtfs.Route, as: GtfsRoute
+  alias Arrow.Gtfs.Stop, as: GtfsStop
   alias Arrow.Shuttles.KML
   alias Arrow.Shuttles.Shape
   alias Arrow.Shuttles.ShapesUpload
   alias Arrow.Shuttles.ShapeUpload
+  alias Arrow.Shuttles.Stop
 
   @doc """
   Returns the list of shapes.
@@ -330,5 +332,18 @@ defmodule Arrow.Shuttles do
   def list_disruptable_routes do
     query = from(r in GtfsRoute, where: r.type in [:light_rail, :heavy_rail])
     Repo.all(query)
+  end
+
+  @doc """
+  Given a stop ID, returns either an Arrow-created stop, or a
+  stop from GTFS. Prefers the Arrow-created stop if both are
+  present.
+  """
+  @spec stop_or_gtfs_stop_for_stop_id(String.t()) :: Stop.t() | GtfsStop.t() | nil
+  def stop_or_gtfs_stop_for_stop_id(id) do
+    case Repo.get_by(Stop, stop_id: id) do
+      nil -> Repo.get(GtfsStop, id)
+      stop -> stop
+    end
   end
 end

--- a/lib/arrow/shuttles.ex
+++ b/lib/arrow/shuttles.ex
@@ -366,7 +366,9 @@ defmodule Arrow.Shuttles do
   stop from GTFS. Prefers the Arrow-created stop if both are
   present.
   """
-  @spec stop_or_gtfs_stop_for_stop_id(String.t()) :: Stop.t() | GtfsStop.t() | nil
+  @spec stop_or_gtfs_stop_for_stop_id(String.t() | nil) :: Stop.t() | GtfsStop.t() | nil
+  def stop_or_gtfs_stop_for_stop_id(nil), do: nil
+
   def stop_or_gtfs_stop_for_stop_id(id) do
     case Repo.get_by(Stop, stop_id: id) do
       nil -> Repo.get(GtfsStop, id)

--- a/lib/arrow/shuttles/route.ex
+++ b/lib/arrow/shuttles/route.ex
@@ -14,7 +14,8 @@ defmodule Arrow.Shuttles.Route do
 
     has_many :route_stops, Arrow.Shuttles.RouteStop,
       foreign_key: :shuttle_route_id,
-      preload_order: [asc: :stop_sequence]
+      preload_order: [asc: :stop_sequence],
+      on_replace: :delete
 
     timestamps(type: :utc_datetime)
   end
@@ -23,7 +24,11 @@ defmodule Arrow.Shuttles.Route do
   def changeset(route, attrs) do
     route
     |> cast(attrs, [:direction_id, :direction_desc, :destination, :waypoint, :suffix, :shape_id])
-    |> cast_assoc(:route_stops, with: &Arrow.Shuttles.RouteStop.changeset/2)
+    |> cast_assoc(:route_stops,
+      with: &Arrow.Shuttles.RouteStop.changeset/2,
+      sort_param: :route_stops_sort,
+      drop_param: :route_stops_drop
+    )
     |> validate_required([:direction_id, :direction_desc, :destination])
     |> assoc_constraint(:shape)
   end

--- a/lib/arrow/shuttles/route.ex
+++ b/lib/arrow/shuttles/route.ex
@@ -11,7 +11,7 @@ defmodule Arrow.Shuttles.Route do
     field :waypoint, :string
     belongs_to :shuttle, Arrow.Shuttles.Shuttle
     belongs_to :shape, Arrow.Shuttles.Shape
-    has_many :route_stop, Arrow.Shuttles.RouteStop, foreign_key: :shuttle_route_id
+    has_many :route_stops, Arrow.Shuttles.RouteStop, foreign_key: :shuttle_route_id
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/arrow/shuttles/route.ex
+++ b/lib/arrow/shuttles/route.ex
@@ -11,7 +11,10 @@ defmodule Arrow.Shuttles.Route do
     field :waypoint, :string
     belongs_to :shuttle, Arrow.Shuttles.Shuttle
     belongs_to :shape, Arrow.Shuttles.Shape
-    has_many :route_stops, Arrow.Shuttles.RouteStop, foreign_key: :shuttle_route_id
+
+    has_many :route_stops, Arrow.Shuttles.RouteStop,
+      foreign_key: :shuttle_route_id,
+      preload_order: [asc: :stop_sequence]
 
     timestamps(type: :utc_datetime)
   end
@@ -20,6 +23,7 @@ defmodule Arrow.Shuttles.Route do
   def changeset(route, attrs) do
     route
     |> cast(attrs, [:direction_id, :direction_desc, :destination, :waypoint, :suffix, :shape_id])
+    |> cast_assoc(:route_stops, with: &Arrow.Shuttles.RouteStop.changeset/2)
     |> validate_required([:direction_id, :direction_desc, :destination])
     |> assoc_constraint(:shape)
   end

--- a/lib/arrow/shuttles/route_stop.ex
+++ b/lib/arrow/shuttles/route_stop.ex
@@ -3,10 +3,15 @@ defmodule Arrow.Shuttles.RouteStop do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Arrow.Gtfs.Stop, as: GtfsStop
+  alias Arrow.Shuttles
+  alias Arrow.Shuttles.Stop
+
   schema "shuttle_route_stops" do
     field :direction_id, Ecto.Enum, values: [:"0", :"1"]
     field :stop_sequence, :integer
     field :time_to_next_stop, :decimal
+    field :display_stop_id, :string, virtual: true
     belongs_to :shuttle_route, Arrow.Shuttles.Route
     belongs_to :stop, Arrow.Shuttles.Stop
     belongs_to :gtfs_stop, Arrow.Gtfs.Stop, type: :string
@@ -16,11 +21,29 @@ defmodule Arrow.Shuttles.RouteStop do
 
   @doc false
   def changeset(route_stop, attrs) do
-    route_stop
-    |> cast(attrs, [:direction_id, :stop_id, :gtfs_stop_id, :stop_sequence, :time_to_next_stop])
-    |> validate_required([:direction_id, :stop_sequence, :time_to_next_stop])
-    |> assoc_constraint(:shuttle_route)
-    |> assoc_constraint(:stop)
-    |> assoc_constraint(:gtfs_stop)
+    {stop_id, gtfs_stop_id, error} =
+      case Shuttles.stop_or_gtfs_stop_for_stop_id(
+             attrs["display_stop_id"] || route_stop.display_stop_id
+           ) do
+        %Stop{id: id} -> {id, nil, nil}
+        %GtfsStop{id: id} -> {nil, id, nil}
+        nil -> {nil, nil, "not a valid stop ID"}
+      end
+
+    change =
+      route_stop
+      |> cast(attrs, [:direction_id, :stop_id, :gtfs_stop_id, :stop_sequence, :time_to_next_stop])
+      |> change(stop_id: stop_id)
+      |> change(gtfs_stop_id: gtfs_stop_id)
+      |> validate_required([:direction_id, :stop_sequence])
+      |> assoc_constraint(:shuttle_route)
+      |> assoc_constraint(:stop)
+      |> assoc_constraint(:gtfs_stop)
+
+    if is_nil(error) do
+      change
+    else
+      add_error(change, :display_stop_id, error)
+    end
   end
 end

--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -28,21 +28,19 @@ defmodule Arrow.Shuttles.Shuttle do
     # Placeholder validation until form is complete
     status = get_field(changeset, :status)
     # Set error on status field for now
-    fields = [:status]
 
     case status do
       :active ->
-        message = "can't be set to active when required fields are missing"
+        routes = get_assoc(changeset, :routes)
 
-        %{
+        enough_stops? =
+          routes |> Enum.map(&get_assoc(&1, :route_stops)) |> Enum.all?(&(length(&1) >= 2))
+
+        if enough_stops? do
           changeset
-          | errors:
-              Enum.map(
-                fields,
-                &{&1, {message, [validation: :required]}}
-              ),
-            valid?: false
-        }
+        else
+          add_error(changeset, :status, "must have at least two stops in each direction")
+        end
 
       _ ->
         changeset

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -106,6 +106,19 @@ defmodule ArrowWeb.ShuttleViewLive do
         <.inputs_for :let={f_route_stop} field={f_route[:route_stops]}>
           <.input field={f_route_stop[:display_stop_id]} label="Stop ID" />
           <.input field={f_route_stop[:time_to_next_stop]} type="number" label="Time to next stop" />
+          <button
+            type="button"
+            name={input_name(f_route, :route_stops_drop) <> "[]"}
+            value={f_route_stop.index}
+            phx-click={JS.dispatch("change")}
+          >
+            Delete stop
+          </button>
+          <input
+            value={f_route_stop.index}
+            type="hidden"
+            name={input_name(f_route, :route_stops_sort) <> "[]"}
+          />
           <input
             value={input_value(f_route_stop, :direction_id)}
             type="hidden"
@@ -117,6 +130,15 @@ defmodule ArrowWeb.ShuttleViewLive do
             name={input_name(f_route_stop, :stop_sequence)}
           />
         </.inputs_for>
+        <input type="hidden" name={input_name(f_route, :route_stops_drop) <> "[]"} />
+        <button
+          type="button"
+          name={input_name(f_route, :route_stops_sort) <> "[]"}
+          value="new"
+          phx-click={JS.dispatch("change")}
+        >
+          Add Another Stop
+        </button>
       </.inputs_for>
       <:actions>
         <.button>Save Shuttle</.button>
@@ -226,12 +248,14 @@ defmodule ArrowWeb.ShuttleViewLive do
           shuttle_params
           |> Map.get("routes")
           |> Map.new(fn {route_index, route} ->
-            {route_index,
-             Map.put(
-               route,
-               "route_stops",
-               routes_with_stops_params[route_index]["route_stops"] || []
-             )}
+            route_stop_fields =
+              Map.take(routes_with_stops_params[route_index], [
+                "route_stops",
+                "route_stops_drop",
+                "route_stops_sort"
+              ])
+
+            {route_index, Map.merge(route, route_stop_fields)}
           end)
     }
   end

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -103,33 +103,43 @@ defmodule ArrowWeb.ShuttleViewLive do
       <h2>define stops</h2>
       <.inputs_for :let={f_route} field={f[:routes]} as={:routes_with_stops}>
         <h4>direction <%= input_value(f_route, :direction_id) %></h4>
-        <.inputs_for :let={f_route_stop} field={f_route[:route_stops]}>
-          <.input field={f_route_stop[:display_stop_id]} label="Stop ID" />
-          <.input field={f_route_stop[:time_to_next_stop]} type="number" label="Time to next stop" />
-          <button
-            type="button"
-            name={input_name(f_route, :route_stops_drop) <> "[]"}
-            value={f_route_stop.index}
-            phx-click={JS.dispatch("change")}
-          >
-            Delete stop
-          </button>
-          <input
-            value={f_route_stop.index}
-            type="hidden"
-            name={input_name(f_route, :route_stops_sort) <> "[]"}
-          />
-          <input
-            value={input_value(f_route_stop, :direction_id)}
-            type="hidden"
-            name={input_name(f_route_stop, :direction_id)}
-          />
-          <input
-            value={input_value(f_route_stop, :stop_sequence)}
-            type="hidden"
-            name={input_name(f_route_stop, :stop_sequence)}
-          />
-        </.inputs_for>
+        <div class="container">
+          <.inputs_for :let={f_route_stop} field={f_route[:route_stops]}>
+            <div class="row">
+              <.input field={f_route_stop[:display_stop_id]} label="Stop ID" class="col-lg-7" />
+              <.input
+                field={f_route_stop[:time_to_next_stop]}
+                type="number"
+                label="Time to next stop"
+                class="col-lg-4"
+              />
+              <button
+                type="button"
+                name={input_name(f_route, :route_stops_drop) <> "[]"}
+                value={f_route_stop.index}
+                phx-click={JS.dispatch("change")}
+                class="col-lg-1"
+              >
+                <.icon name="hero-x-mark-solid" class="h-4 w-4" />
+              </button>
+              <input
+                value={f_route_stop.index}
+                type="hidden"
+                name={input_name(f_route, :route_stops_sort) <> "[]"}
+              />
+              <input
+                value={input_value(f_route_stop, :direction_id)}
+                type="hidden"
+                name={input_name(f_route_stop, :direction_id)}
+              />
+              <input
+                value={input_value(f_route_stop, :stop_sequence)}
+                type="hidden"
+                name={input_name(f_route_stop, :stop_sequence)}
+              />
+            </div>
+          </.inputs_for>
+        </div>
         <input type="hidden" name={input_name(f_route, :route_stops_drop) <> "[]"} />
         <button type="button" value={input_value(f_route, :direction_id)} phx-click="add_stop">
           Add Another Stop

--- a/test/arrow/shuttle/shuttle_test.exs
+++ b/test/arrow/shuttle/shuttle_test.exs
@@ -1,0 +1,68 @@
+defmodule Arrow.Shuttles.ShuttleTest do
+  use Arrow.DataCase
+
+  alias Arrow.Shuttles.Shuttle
+
+  import Arrow.Factory
+  import Arrow.ShuttlesFixtures
+
+  describe "changeset/2" do
+    test "cannot mark a shuttle as active without at least two shuttle_stops per shuttle_route" do
+      shuttle = shuttle_fixture()
+
+      changeset = Shuttle.changeset(shuttle, %{status: :active})
+
+      assert %Ecto.Changeset{
+               valid?: false,
+               errors: [status: {"must have at least two stops in each direction", []}]
+             } = changeset
+    end
+
+    test "can mark a shuttle as active with at least two shuttle_stops per shuttle_route" do
+      shuttle = shuttle_fixture()
+      [route0, route1] = shuttle.routes
+
+      [stop1, stop2, stop3, stop4] = insert_list(4, :gtfs_stop)
+
+      route0
+      |> Arrow.Shuttles.Route.changeset(%{
+        "route_stops" => [
+          %{
+            "direction_id" => "0",
+            "stop_sequence" => "1",
+            "display_stop_id" => stop1.id
+          },
+          %{
+            "direction_id" => "0",
+            "stop_sequence" => "2",
+            "display_stop_id" => stop2.id
+          }
+        ]
+      })
+      |> Arrow.Repo.update()
+
+      route1
+      |> Arrow.Shuttles.Route.changeset(%{
+        "route_stops" => [
+          %{
+            "direction_id" => "1",
+            "stop_sequence" => "1",
+            "display_stop_id" => stop3.id
+          },
+          %{
+            "direction_id" => "0",
+            "stop_sequence" => "1",
+            "display_stop_id" => stop4.id
+          }
+        ]
+      })
+      |> Arrow.Repo.update()
+
+      shuttle = Arrow.Shuttles.get_shuttle!(shuttle.id)
+
+      changeset = Shuttle.changeset(shuttle, %{status: :active})
+
+      assert %Ecto.Changeset{valid?: true} = changeset
+    end
+  end
+end

--- a/test/arrow/shuttles_test.exs
+++ b/test/arrow/shuttles_test.exs
@@ -1,9 +1,11 @@
 defmodule Arrow.ShuttlesTest do
   use Arrow.DataCase
 
+  import Arrow.Factory
   alias Arrow.Shuttles
   alias Arrow.Shuttles.Shape
   import Arrow.ShuttlesFixtures
+  import Arrow.StopsFixtures
   import Test.Support.Helpers
 
   describe "shapes with s3 functionality enabled (mocked)" do
@@ -212,6 +214,36 @@ defmodule Arrow.ShuttlesTest do
     test "change_shuttle/1 returns a shuttle changeset" do
       shuttle = shuttle_fixture()
       assert %Ecto.Changeset{} = Shuttles.change_shuttle(shuttle)
+    end
+  end
+
+  describe "stop_or_gtfs_stop_for_stop_id/1" do
+    test "fetches Arrow stop" do
+      stop = stop_fixture()
+      stop_id = stop.stop_id
+
+      assert %Arrow.Shuttles.Stop{stop_id: ^stop_id} =
+               Shuttles.stop_or_gtfs_stop_for_stop_id(stop_id)
+    end
+
+    test "fetches GTFS stop" do
+      gtfs_stop = insert(:gtfs_stop)
+      stop_id = gtfs_stop.id
+
+      assert %Arrow.Gtfs.Stop{id: ^stop_id} = Shuttles.stop_or_gtfs_stop_for_stop_id(stop_id)
+    end
+
+    test "prefers the Arrow stop if there are both Arrow and Gtfs stops" do
+      stop = stop_fixture()
+      _gtfs_stop = insert(:gtfs_stop)
+      stop_id = stop.stop_id
+
+      assert %Arrow.Shuttles.Stop{stop_id: ^stop_id} =
+               Shuttles.stop_or_gtfs_stop_for_stop_id(stop_id)
+    end
+
+    test "returns nil if no stops are found" do
+      assert is_nil(Shuttles.stop_or_gtfs_stop_for_stop_id("nonexistent-stop"))
     end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -67,4 +67,28 @@ defmodule Arrow.Factory do
       municipality: "Boston"
     }
   end
+
+  def gtfs_stop_factory do
+    %Arrow.Gtfs.Stop{
+      id: sequence(:source_label, &"gtfs-stop-#{&1}"),
+      code: nil,
+      name: "Test Stop",
+      desc: nil,
+      platform_code: nil,
+      platform_name: nil,
+      lat: 72.0,
+      lon: 43.0,
+      zone_id: nil,
+      address: nil,
+      url: nil,
+      level: nil,
+      location_type: :stop_platform,
+      parent_station: nil,
+      wheelchair_boarding: :accessible,
+      municipality: "Boston",
+      on_street: nil,
+      at_street: nil,
+      vehicle_type: :bus
+    }
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Implement "Create/Edit Shuttle Route Definition" - Stop Selection Section](https://app.asana.com/0/584764604969369/1208185020019710/f)

This should be the main PR implementing the functionality from the ticket. I think there are a couple of small subtleties I want to address related to the acceptance criteria (for instance, it sounds like we want to display a placeholder stop if there aren't any in a direction, but still allow saving in that case without persisting the placeholder), but I think this takes care of most of it.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
