### PR TITLE
fix: use ueberauth_provider: :cognito on dev

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -77,6 +77,7 @@ config :arrow, dev_routes: true
 # Set prefix env for s3 uploads
 config :arrow,
   ueberauth_provider: :cognito,
+  api_login_module: ArrowWeb.TryApiTokenAuth.Cognito,
   shape_storage_enabled?: true,
   shape_storage_prefix_env: "dev/local/",
   gtfs_archive_storage_enabled?: true,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -76,6 +76,7 @@ config :arrow, dev_routes: true
 
 # Set prefix env for s3 uploads
 config :arrow,
+  ueberauth_provider: :cognito,
   shape_storage_enabled?: true,
   shape_storage_prefix_env: "dev/local/",
   gtfs_archive_storage_enabled?: true,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** no ticket, just a quick fix

I noticed that with #1028 you can use real Keycloak just fine, but because `ueberauth_provider: :keycloak` is now the default in `config.exs`, that's applied to dev as well and it will either use the real Keycloak flow if the environment variables are available, or just break otherwise. This changes it so that dev defaults to `:cognito`, causing it to still use the old fake Cognito login flow successfully, but if the environment variables are provided, `runtime.exs` will still overwrite it and use the real Keycloak service for authentication.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
