### PR TITLE
fix: don't clear stop ID when adding multiple stops

### DIFF
--- a/lib/arrow/shuttles/route_stop.ex
+++ b/lib/arrow/shuttles/route_stop.ex
@@ -32,7 +32,14 @@ defmodule Arrow.Shuttles.RouteStop do
 
     change =
       route_stop
-      |> cast(attrs, [:direction_id, :stop_id, :gtfs_stop_id, :stop_sequence, :time_to_next_stop])
+      |> cast(attrs, [
+        :direction_id,
+        :stop_id,
+        :gtfs_stop_id,
+        :stop_sequence,
+        :time_to_next_stop,
+        :display_stop_id
+      ])
       |> change(stop_id: stop_id)
       |> change(gtfs_stop_id: gtfs_stop_id)
       |> validate_required([:direction_id, :stop_sequence])


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** followup on [🏹 Implement "Create/Edit Shuttle Route Definition" - Stop Selection Section](https://app.asana.com/0/584764604969369/1208185020019710/f)

@Whoops noticed that if you try adding multiple stops in a row without saving first, the stop IDs from the previously filled out (but non-persisted) stops get cleared out. I noticed when inspecting the changeset that the `add_stop` event was updating had a nil `display_stop_id` because previous events like `validate` that were generating and updating a changeset based on the form were correctly filling in the other stop-related fields but not casting `display_stop_id`. I added it to the array passed into `cast` and it seems to work now.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
