### PR TITLE
feat: "Create Stop" link button

### DIFF
--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -149,6 +149,12 @@ defmodule ArrowWeb.ShuttleViewLive do
           Add Another Stop
         </button>
       </.inputs_for>
+      <div class="mt-8 flex items-center space-x-4">
+        <span>If you'd like to create a stop:</span>
+        <.link_button class="btn-primary" href={~p"/stops/new"} target="_blank">
+          Create Stop
+        </.link_button>
+      </div>
       <:actions>
         <.button>Save Shuttle</.button>
       </:actions>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Implement "Create/Edit Shuttle Route Definition" - Create Stop Function](https://app.asana.com/0/584764604969369/1208403724207314/f)

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/116f5348-64a8-4b86-bd5f-630be5043402">

The [Miro mockups](https://miro.com/app/board/uXjVKVLTOI0=/?moveToWidget=3458764595370550770&cot=14) included a substantial amount of space between this line and the rest of the "define stops" section of the form.
I added a bit of top margin, but I figure that the look of the neighboring elements will change substantially in upcoming polish work and the correct margin can be set at that time.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
