### PR TITLE
Drag and drop stops list

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -20,7 +20,8 @@
         "react-dom": "^18.3.0",
         "react-leaflet": "^4.2.1",
         "react-phoenix": "file:../deps/react_phoenix",
-        "react-select": "^5.8.0"
+        "react-select": "^5.8.0",
+        "sortablejs": "^1.15.4"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -35,6 +36,7 @@
         "@types/react": "^18.3.0",
         "@types/react-datepicker": "^6.2.0",
         "@types/react-select": "^5.0.1",
+        "@types/sortablejs": "^1.15.8",
         "@typescript-eslint/eslint-plugin": "^7.13.0",
         "@typescript-eslint/parser": "^7.13.0",
         "eslint": "^8.56.0",
@@ -52,7 +54,7 @@
       }
     },
     "../deps/live_select": {
-      "version": "1.3.1",
+      "version": "1.4.3",
       "license": "Apache License 2.0"
     },
     "../deps/phoenix": {
@@ -60,7 +62,7 @@
       "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "3.3.4"
+      "version": "4.1.0"
     },
     "../deps/phoenix_live_react": {
       "version": "0.4.2",
@@ -2320,6 +2322,12 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/sortablejs": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.8.tgz",
+      "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -8500,6 +8508,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.4.tgz",
+      "integrity": "sha512-wr7G5Id/WNllca5yF9I2vsz/2wDKJebX5FJBtfUFBGGpaaIVjW4kziAnNMEcigaTZAaPLB92NYBGqWenGDH++g=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -47,7 +47,8 @@
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.3.1",
         "ts-jest": "^29.1.4",
-        "typescript": "^5.4.5"
+        "typescript": "^5.4.5",
+        "typescript-language-server": "^4.3.3"
       }
     },
     "../deps/live_select": {
@@ -8899,6 +8900,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-language-server": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-4.3.3.tgz",
+      "integrity": "sha512-3QLj57Ru9S6zv10sa4z1pA3TIR1Rdkd04Ke0EszbO4fx5PLdlYhlC/PMxwlyxls9wrZs7wPCME1Ru0s1Gabz4Q==",
+      "dev": true,
+      "bin": {
+        "typescript-language-server": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/unbox-primitive": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -24,7 +24,8 @@
     "react-dom": "^18.3.0",
     "react-leaflet": "^4.2.1",
     "react-phoenix": "file:../deps/react_phoenix",
-    "react-select": "^5.8.0"
+    "react-select": "^5.8.0",
+    "sortablejs": "^1.15.4"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
@@ -39,6 +40,7 @@
     "@types/react": "^18.3.0",
     "@types/react-datepicker": "^6.2.0",
     "@types/react-select": "^5.0.1",
+    "@types/sortablejs": "^1.15.8",
     "@typescript-eslint/eslint-plugin": "^7.13.0",
     "@typescript-eslint/parser": "^7.13.0",
     "eslint": "^8.56.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -14,11 +14,11 @@
     "@fullcalendar/daygrid": "^6.1.0",
     "@fullcalendar/react": "^6.1.0",
     "leaflet": "^1.9.4",
+    "live_select": "file:../deps/live_select",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
     "phoenix_live_react": "file:../deps/phoenix_live_react",
     "phoenix_live_view": "file:../deps/phoenix_live_view",
-    "live_select": "file:../deps/live_select",
     "react": "^18.3.0",
     "react-datepicker": "^6.2.0",
     "react-dom": "^18.3.0",
@@ -51,7 +51,8 @@
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.3.1",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "typescript-language-server": "^4.3.3"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -4,7 +4,8 @@ import LiveReact from "./LiveReactPhoenix"
 import live_select from "live_select"
 // Establish Phoenix Socket and LiveView configuration.
 import { Socket } from "phoenix"
-import { LiveSocket } from "phoenix_live_view"
+import { LiveSocket, ViewHook } from "phoenix_live_view"
+import Sortable from "sortablejs"
 
 import ReactPhoenix from "./ReactPhoenix"
 import DisruptionCalendar from "./components/DisruptionCalendar"
@@ -21,8 +22,34 @@ declare global {
   }
 }
 
+const sortable = {
+  mounted() {
+    new Sortable(this.el, {
+      animation: 150,
+      handle: ".drag-handle",
+      draggable: ".item",
+      dragClass: "drag-item",
+      ghostClass: "drag-ghost",
+      forceFallback: true,
+      onEnd: (e) => {
+        const params = {
+          old: e.oldDraggableIndex,
+          new: e.newDraggableIndex,
+          ...e.item.dataset,
+          ...this.el.dataset,
+        }
+        this.pushEventTo(this.el, "reorder_stops", params)
+      },
+    })
+  },
+} as ViewHook
+
 // https://github.com/fidr/phoenix_live_react
-const hooks = { LiveReact, ...live_select }
+const hooks = {
+  LiveReact,
+  sortable,
+  ...live_select,
+}
 
 const csrfToken = document
   .querySelector("meta[name='csrf-token']")!

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -112,60 +112,68 @@ defmodule ArrowWeb.ShuttleViewLive do
       </div>
       <hr />
       <h2>define stops</h2>
-      <.inputs_for :let={f_route} field={f[:routes]} as={:routes_with_stops}>
-        <h4>direction <%= input_value(f_route, :direction_id) %></h4>
-        <div class="container">
-          <.inputs_for :let={f_route_stop} field={f_route[:route_stops]}>
-            <div class="row">
-              <.input field={f_route_stop[:display_stop_id]} label="Stop ID" class="col-lg-7" />
-              <.input
-                field={f_route_stop[:time_to_next_stop]}
-                type="number"
-                label="Time to next stop"
-                class="col-lg-4"
-              />
-              <button
-                type="button"
-                name={input_name(f_route, :route_stops_drop) <> "[]"}
-                value={f_route_stop.index}
-                phx-click={JS.dispatch("change")}
-                class="col-lg-1"
-              >
-                <.icon name="hero-x-mark-solid" class="h-4 w-4" />
-              </button>
-              <input
-                value={f_route_stop.index}
-                type="hidden"
-                name={input_name(f_route, :route_stops_sort) <> "[]"}
-              />
-              <input
-                value={input_value(f_route_stop, :direction_id)}
-                type="hidden"
-                name={input_name(f_route_stop, :direction_id)}
-              />
-              <input
-                value={input_value(f_route_stop, :stop_sequence)}
-                type="hidden"
-                name={input_name(f_route_stop, :stop_sequence)}
-              />
-            </div>
-          </.inputs_for>
-        </div>
-        <input type="hidden" name={input_name(f_route, :route_stops_drop) <> "[]"} />
-        <button type="button" value={input_value(f_route, :direction_id)} phx-click="add_stop">
-          Add Another Stop
-        </button>
-      </.inputs_for>
-      <div class="mt-8 flex items-center space-x-4">
-        <span>If you'd like to create a stop:</span>
-        <.link_button class="btn-primary" href={~p"/stops/new"} target="_blank">
-          Create Stop
-        </.link_button>
-      </div>
+      <.shuttle_form_stops_section f={f} />
       <:actions>
         <.button>Save Shuttle</.button>
       </:actions>
     </.simple_form>
+    """
+  end
+
+  attr :f, :any, required: true
+
+  defp shuttle_form_stops_section(assigns) do
+    ~H"""
+    <.inputs_for :let={f_route} field={@f[:routes]} as={:routes_with_stops}>
+      <h4>direction <%= input_value(f_route, :direction_id) %></h4>
+      <div class="container" id={"stops-dir-#{input_value(f_route, :direction_id)}"}>
+        <.inputs_for :let={f_route_stop} field={f_route[:route_stops]}>
+          <div class="row">
+            <.input field={f_route_stop[:display_stop_id]} label="Stop ID" class="col-lg-7" />
+            <.input
+              field={f_route_stop[:time_to_next_stop]}
+              type="number"
+              label="Time to next stop"
+              class="col-lg-4"
+            />
+            <button
+              type="button"
+              name={input_name(f_route, :route_stops_drop) <> "[]"}
+              value={f_route_stop.index}
+              phx-click={JS.dispatch("change")}
+              class="col-lg-1"
+            >
+              <.icon name="hero-x-mark-solid" class="h-4 w-4" />
+            </button>
+            <input
+              value={f_route_stop.index}
+              type="hidden"
+              name={input_name(f_route, :route_stops_sort) <> "[]"}
+            />
+            <input
+              value={input_value(f_route_stop, :direction_id)}
+              type="hidden"
+              name={input_name(f_route_stop, :direction_id)}
+            />
+            <input
+              value={input_value(f_route_stop, :stop_sequence)}
+              type="hidden"
+              name={input_name(f_route_stop, :stop_sequence)}
+            />
+          </div>
+        </.inputs_for>
+      </div>
+      <input type="hidden" name={input_name(f_route, :route_stops_drop) <> "[]"} />
+      <button type="button" value={input_value(f_route, :direction_id)} phx-click="add_stop">
+        Add Another Stop
+      </button>
+    </.inputs_for>
+    <div class="mt-8 flex items-center space-x-4">
+      <span>If you'd like to create a stop:</span>
+      <.link_button class="btn-primary" href={~p"/stops/new"} target="_blank">
+        Create Stop
+      </.link_button>
+    </div>
     """
   end
 

--- a/test/arrow/shuttle/route_stop_test.exs
+++ b/test/arrow/shuttle/route_stop_test.exs
@@ -1,0 +1,64 @@
+defmodule Arrow.Shuttles.RouteStopTest do
+  use Arrow.DataCase
+
+  alias Arrow.Shuttles.RouteStop
+
+  import Arrow.Factory
+
+  describe "changeset/2" do
+    test "handles GTFS stop" do
+      gtfs_stop = insert(:gtfs_stop)
+
+      gtfs_stop_id = gtfs_stop.id
+
+      route_stop = insert(:route_stop)
+
+      changeset = RouteStop.changeset(route_stop, %{"display_stop_id" => gtfs_stop_id})
+
+      assert %Ecto.Changeset{
+               valid?: true,
+               changes: %{display_stop_id: ^gtfs_stop_id, gtfs_stop_id: ^gtfs_stop_id}
+             } = changeset
+    end
+
+    test "handles Arrow stop" do
+      stop = insert(:stop)
+
+      display_stop_id = stop.stop_id
+      stop_id = stop.id
+
+      route_stop = insert(:route_stop)
+
+      changeset = RouteStop.changeset(route_stop, %{"display_stop_id" => display_stop_id})
+
+      assert %Ecto.Changeset{
+               valid?: true,
+               changes: %{display_stop_id: ^display_stop_id, stop_id: ^stop_id}
+             } = changeset
+    end
+
+    test "gives an error when stop ID is invalid" do
+      route_stop = insert(:route_stop)
+
+      changeset = RouteStop.changeset(route_stop, %{"display_stop_id" => "invalid_id"})
+
+      assert %Ecto.Changeset{
+               valid?: false,
+               errors: [display_stop_id: {"not a valid stop ID", []}]
+             } = changeset
+    end
+
+    test "can update other fields" do
+      route_stop = insert(:route_stop)
+
+      changeset = RouteStop.changeset(route_stop, %{"time_to_next_stop" => 10})
+
+      time_to_next_stop_change_value = Decimal.new("10")
+
+      assert %Ecto.Changeset{
+               valid?: true,
+               changes: %{time_to_next_stop: ^time_to_next_stop_change_value}
+             } = changeset
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -57,6 +57,13 @@ defmodule Arrow.Factory do
     %Arrow.Disruption.Note{author: "An author", body: "This is the body."}
   end
 
+  def route_stop_factory do
+    %Arrow.Shuttles.RouteStop{
+      direction_id: :"0",
+      stop_sequence: sequence(:route_stop_stop_sequence, & &1)
+    }
+  end
+
   def stop_factory do
     %Arrow.Shuttles.Stop{
       stop_id: sequence(:source_label, &"stop-#{&1}"),


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Implement "Create/Edit Shuttle Route Definition" - Reorder Stops Function](https://app.asana.com/0/584764604969369/1208403724207316/f)

The first commit, 84204a4, just adds `typescript-language-server` as a dev-only dependency, which I do to keep it installed across different runs of `npm install` / `npm ci` with how my editor is set up. It should be harmless but I can remove it and work around it some other way if people don't want it in our dependencies.

As for the actual feature implementation, I had some issues getting LiveView hooks to play along nicely with TypeScript - I really wanted some kind of type that's something along the line of "thing that will be used to build a `ViewHook`" but I don't think that exists and I didn't see an easy way to build it using TypeScript magic, so I ended up just using a type assertion (`as ViewHook`). I'd like to be able to avoid that kind of thing, though, so I'm open to suggestions on other approaches I could take.

On the backend, I set it up so that the ordering transposes stops and then does a pass to make sure that all of the `stop_sequence` values are in order, adding to them if necessary. Aside from that it doesn't currently enforce any niceties like starting from a particular value, but if we want something like that we should probably implement it in a more general way.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
