### PR TITLE
fix: Keycloak Logout

### DIFF
--- a/lib/arrow_web/controllers/layout_html/_header.html.heex
+++ b/lib/arrow_web/controllers/layout_html/_header.html.heex
@@ -8,12 +8,10 @@
     </div>
 
     <div class="m-header__long-name navbar-text justify-content-end navbar-collapse">
-      Adjustments to the Regular Right of Way <%= if @logout_url,
-        do:
-          link("logout",
-            to: ~p"/auth/logout",
-            class: "ml-2 btn btn-outline-danger"
-          ) %>
+      Adjustments to the Regular Right of Way <%= link("logout",
+        to: ~p"/auth/keycloak/logout",
+        class: "ml-2 btn btn-outline-danger"
+      ) %>
       <div class="hidden">
         <%= @view %>
       </div>

--- a/lib/arrow_web/controllers/layout_html/app.html.heex
+++ b/lib/arrow_web/controllers/layout_html/app.html.heex
@@ -1,4 +1,4 @@
-<._header logout_url={Plug.Conn.get_session(@conn, :logout_url)} view="app" />
+<._header view="app" />
 
 <main class="container">
   <._flash flash={@flash} />

--- a/lib/arrow_web/controllers/layout_html/live.html.heex
+++ b/lib/arrow_web/controllers/layout_html/live.html.heex
@@ -1,4 +1,4 @@
-<._header logout_url={@logout_url} view="live" />
+<._header view="live" />
 
 <main class="container">
   <._flash flash={@flash} />

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -207,8 +207,7 @@ defmodule ArrowWeb.ShuttleViewLive do
     id
   end
 
-  def mount(%{"id" => id} = _params, session, socket) do
-    logout_url = session["logout_url"]
+  def mount(%{"id" => id} = _params, _session, socket) do
     shuttle = Shuttles.get_shuttle!(id)
     changeset = Shuttles.change_shuttle(shuttle)
     gtfs_disruptable_routes = Shuttles.list_disruptable_routes()
@@ -232,15 +231,12 @@ defmodule ArrowWeb.ShuttleViewLive do
       |> assign(:title, "edit shuttle")
       |> assign(:gtfs_disruptable_routes, gtfs_disruptable_routes)
       |> assign(:shapes, shapes)
-      |> assign(:logout_url, logout_url)
       |> assign(:map_props, %{shapes: shapes_map_view})
 
     {:ok, socket}
   end
 
-  def mount(%{} = _params, session, socket) do
-    logout_url = session["logout_url"]
-
+  def mount(%{} = _params, _session, socket) do
     shuttle = %Shuttle{
       status: :draft,
       routes: [%Shuttles.Route{direction_id: :"0"}, %Shuttles.Route{direction_id: :"1"}]
@@ -259,7 +255,6 @@ defmodule ArrowWeb.ShuttleViewLive do
       |> assign(:shuttle, shuttle)
       |> assign(:gtfs_disruptable_routes, gtfs_disruptable_routes)
       |> assign(:shapes, shapes)
-      |> assign(:logout_url, logout_url)
       |> assign(:map_props, %{shapes: []})
 
     {:ok, socket}

--- a/lib/arrow_web/live/stop_live/stop_live.ex
+++ b/lib/arrow_web/live/stop_live/stop_live.ex
@@ -81,8 +81,7 @@ defmodule ArrowWeb.StopViewLive do
     """
   end
 
-  def mount(%{"id" => id} = _params, session, socket) do
-    logout_url = session["logout_url"]
+  def mount(%{"id" => id} = _params, _session, socket) do
     stop = Stops.get_stop!(id)
     form = to_form(Stops.change_stop(stop))
 
@@ -94,14 +93,12 @@ defmodule ArrowWeb.StopViewLive do
       |> assign(:stop, stop)
       |> assign(:title, "edit shuttle stop")
       |> assign(:stop_map_props, stop)
-      |> assign(:logout_url, logout_url)
       |> assign(:trigger_submit, false)
 
     {:ok, socket}
   end
 
-  def mount(_params, session, socket) do
-    logout_url = session["logout_url"]
+  def mount(_params, _session, socket) do
     form = to_form(Stops.change_stop(%Stop{}))
 
     socket =
@@ -112,7 +109,6 @@ defmodule ArrowWeb.StopViewLive do
       |> assign(:stop, %Stop{})
       |> assign(:title, "create shuttle stop")
       |> assign(:stop_map_props, %{})
-      |> assign(:logout_url, logout_url)
       |> assign(:trigger_submit, false)
 
     {:ok, socket}

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -43,7 +43,6 @@ defmodule ArrowWeb.Router do
   scope "/", ArrowWeb do
     pipe_through([:redirect_prod_http, :browser, :authenticate])
 
-    get("/logout", AuthController, :logout)
     get("/unauthorized", UnauthorizedController, :index)
     get("/feed", FeedController, :index)
     get("/mytoken", MyTokenController, :show)
@@ -77,6 +76,7 @@ defmodule ArrowWeb.Router do
 
     get("/:provider", AuthController, :request)
     get("/:provider/callback", AuthController, :callback)
+    get("/:provider/logout", AuthController, :logout)
   end
 
   scope "/api", as: :api, alias: ArrowWeb.API do

--- a/test/arrow_web/controllers/auth_controller_test.exs
+++ b/test/arrow_web/controllers/auth_controller_test.exs
@@ -41,4 +41,38 @@ defmodule ArrowWeb.Controllers.AuthControllerTest do
       assert response =~ "unauthenticated"
     end
   end
+
+  describe "logout" do
+    test "logs user out and redirects to keycloak logout", %{conn: conn} do
+      current_time = System.system_time(:second)
+
+      auth = %Ueberauth.Auth{
+        uid: "foo@mbta.com",
+        provider: :keycloak,
+        credentials: %Ueberauth.Auth.Credentials{
+          expires_at: current_time + 1_000,
+          other: %{id_token: "id_token"}
+        },
+        extra: %{
+          raw_info: %UeberauthOidcc.RawInfo{
+            userinfo: %{
+              "resource_access" => %{
+                "fake_client" => %{"roles" => ["admin"]}
+              }
+            }
+          }
+        }
+      }
+
+      conn =
+        conn
+        |> assign(:ueberauth_auth, auth)
+        |> get(ArrowWeb.Router.Helpers.auth_path(conn, :callback, "keycloak"))
+
+      assert Guardian.Plug.authenticated?(conn)
+      conn = get(conn, ArrowWeb.Router.Helpers.auth_path(conn, :logout, "keycloak"))
+
+      refute Guardian.Plug.authenticated?(conn)
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐛🏹 User attempting to log out receives internal server error](https://app.asana.com/0/584764604969369/1208162530217806/f)

When logging out through Keycloak, the logout URL was not including the auth provider in the URL. This trips up `Ueberauth` and causes it to load the request through the `request/2` endpoint instead of the intended `logout/2` endpoint. The logout URL can be the same (`~p"/auth/keycloak/logout"`) throughout the app so I removed the `@logout_url` param and hardcoded it into the logout button in the header.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
