### PR TITLE
fix: add handling for retrieve estimates on new shuttle creation

### DIFF
--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -245,9 +245,10 @@ defmodule ArrowWeb.ShuttleViewLive do
 
   defp render_route_stop(%RouteStop{stop_id: stop_id} = route_stop) when not is_nil(stop_id) do
     route_stop =
-      if !Ecto.assoc_loaded?(route_stop.stop) or route_stop.stop.id != stop_id,
-        do: Arrow.Repo.preload(route_stop, :stop, force: true),
-        else: route_stop
+      if !Ecto.assoc_loaded?(route_stop.stop) or
+           (route_stop.stop && route_stop.stop.id != stop_id),
+         do: Arrow.Repo.preload(route_stop, :stop, force: true),
+         else: route_stop
 
     if route_stop.stop do
       %{
@@ -264,9 +265,10 @@ defmodule ArrowWeb.ShuttleViewLive do
   defp render_route_stop(%RouteStop{gtfs_stop_id: gtfs_stop_id} = route_stop)
        when not is_nil(gtfs_stop_id) do
     route_stop =
-      if !Ecto.assoc_loaded?(route_stop.gtfs_stop) or route_stop.gtfs_stop.id != gtfs_stop_id,
-        do: Arrow.Repo.preload(route_stop, :gtfs_stop, force: true),
-        else: route_stop
+      if !Ecto.assoc_loaded?(route_stop.gtfs_stop) or
+           (route_stop.gtfs_stop && route_stop.gtfs_stop.id != gtfs_stop_id),
+         do: Arrow.Repo.preload(route_stop, :gtfs_stop, force: true),
+         else: route_stop
 
     if route_stop.gtfs_stop do
       %{

--- a/test/arrow/shuttles_test.exs
+++ b/test/arrow/shuttles_test.exs
@@ -362,9 +362,14 @@ defmodule Arrow.ShuttlesTest do
       lat = 42.38758
       lon = -71.11934
 
+      arrow_stop = stop_fixture(%{stop_lat: lat, stop_lon: lon})
+
       stop = %Shuttles.RouteStop{
-        stop: stop_fixture(%{stop_lat: lat, stop_lon: lon}),
-        gtfs_stop: nil
+        id: 1,
+        stop: arrow_stop,
+        gtfs_stop: nil,
+        display_stop: nil,
+        display_stop_id: arrow_stop.stop_id
       }
 
       coordinates = %{lat: lat, lon: lon}
@@ -375,7 +380,14 @@ defmodule Arrow.ShuttlesTest do
     test "gets the stop coordinates for an gtfs stop from a RouteStop" do
       gtfs_stop = insert(:gtfs_stop)
       coordinates = %{lat: gtfs_stop.lat, lon: gtfs_stop.lon}
-      stop = %Shuttles.RouteStop{gtfs_stop: gtfs_stop, stop: nil}
+
+      stop = %Shuttles.RouteStop{
+        id: 1,
+        gtfs_stop: gtfs_stop,
+        stop: nil,
+        display_stop: nil,
+        display_stop_id: gtfs_stop.id
+      }
 
       assert {:ok, ^coordinates} = Shuttles.get_stop_coordinates(stop)
     end


### PR DESCRIPTION

#### Summary of changes
**Asana Ticket:** [Follow up on "🏹 Implement "Create/Edit Shuttle Route Definition" - Time to Next Stop"](https://app.asana.com/0/584764604969369/1209003091082862/f)

* Add fetching of stop data (lat/long) when the initial shuttle hasn't been created yet
* Add explicit error handling for when there is only one stop defined for a direction

Part of this is similar to what the Map component does (Ecto.assoc_loaded? & calling `preload`) but if those values aren't set yet, then this uses a virtual field `display_stop` mirroring `display_stop_id`. This isn't the most elegant solution, opening this as a draft for now.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
