### PR TITLE
tweak: Ignore heroicons.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  ignore:
+    - dependency-name: "heroicons"
 - package-ecosystem: npm
   directory: "/assets"
   schedule:


### PR DESCRIPTION
#### Summary of changes

We use a specific version of `heroicons` so there is no need to Dependabot to try updating it. It actually causes [issues](https://github.com/mbta/arrow/actions/runs/12548391083/job/34987545138#step:3:8420) because it is unsure how to update it.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
