### PR TITLE
refactor(shuttles): use nested form for route_stops

### DIFF
--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -403,12 +403,14 @@ defmodule ArrowWeb.ShuttleViewLive do
     {:ok, socket}
   end
 
-  def handle_event("validate", params, socket) do
-    validate(params, socket)
+  def handle_event("validate", %{"shuttle" => shuttle_params}, socket) do
+    change = Shuttles.change_shuttle(socket.assigns.shuttle, shuttle_params)
+    form = to_form(change, action: :validate)
+
+    {:noreply, socket |> assign(form: form) |> update_map(change)}
   end
 
-  def handle_event("edit", params, socket) do
-    shuttle_params = params["shuttle"]
+  def handle_event("edit", %{"shuttle" => shuttle_params}, socket) do
     shuttle = Shuttles.get_shuttle!(socket.assigns.shuttle.id)
 
     case Shuttles.update_shuttle(shuttle, shuttle_params) do
@@ -423,9 +425,7 @@ defmodule ArrowWeb.ShuttleViewLive do
     end
   end
 
-  def handle_event("create", params, socket) do
-    shuttle_params = params["shuttle"]
-
+  def handle_event("create", %{"shuttle" => shuttle_params}, socket) do
     case Shuttles.create_shuttle(shuttle_params) do
       {:ok, shuttle} ->
         {:noreply,
@@ -667,15 +667,6 @@ defmodule ArrowWeb.ShuttleViewLive do
       |> routes_to_layers(socket.assigns.map_props)
 
     assign(socket, :map_props, %{layers: layers})
-  end
-
-  defp validate(params, socket) do
-    shuttle_params = params["shuttle"]
-
-    change = Shuttles.change_shuttle(socket.assigns.shuttle, shuttle_params)
-    form = to_form(change, action: :validate)
-
-    {:noreply, socket |> assign(form: form) |> update_map(change)}
   end
 
   defp handle_progress(:definition, entry, socket) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket

* Uses inputs_for for the route_stops section on the initial form (nested)
* Removes combine_params (no longer needed)
* Uses flex ordering to visually order the form inputs by route definition then by route_stops

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
