### PR TITLE
New replacement service component

### DIFF
--- a/lib/arrow/shuttles.ex
+++ b/lib/arrow/shuttles.ex
@@ -466,8 +466,7 @@ defmodule Arrow.Shuttles do
 
   @spec stops_or_gtfs_stops_by_search_string(String.t()) :: [Stop.t() | GtfsStop.t()]
   def stops_or_gtfs_stops_by_search_string(string) do
-    # See https://github.blog/engineering/like-injection/
-    sanitized_string = Regex.replace(~r/([\%_])/, string, fn _, x -> "\\#{x}" end) <> "%"
+    sanitized_string = Arrow.Util.sanitized_string_for_sql_like(string)
 
     stops_query =
       from(s in Stop,

--- a/lib/arrow/shuttles.ex
+++ b/lib/arrow/shuttles.ex
@@ -492,4 +492,12 @@ defmodule Arrow.Shuttles do
 
     Enum.concat(matching_stops, matching_gtfs_stops)
   end
+
+  def shuttles_by_search_string(string) do
+    sanitized_string = Arrow.Util.sanitized_string_for_sql_like(string)
+
+    shuttles_query = from(s in Shuttle, where: ilike(s.shuttle_name, ^sanitized_string))
+
+    Repo.all(shuttles_query)
+  end
 end

--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -3,6 +3,14 @@ defmodule Arrow.Shuttles.Shuttle do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type id :: integer
+  @type t :: %__MODULE__{
+          id: id,
+          status: :draft | :active | :inactive,
+          shuttle_name: String.t(),
+          disrupted_route_id: String.t()
+        }
+
   schema "shuttles" do
     field :status, Ecto.Enum, values: [:draft, :active, :inactive]
     field :shuttle_name, :string

--- a/lib/arrow/util.ex
+++ b/lib/arrow/util.ex
@@ -1,0 +1,9 @@
+defmodule Arrow.Util do
+  @moduledoc false
+
+  @spec sanitized_string_for_sql_like(String.t()) :: String.t()
+  def sanitized_string_for_sql_like(string) do
+    # See https://github.blog/engineering/like-injection/
+    Regex.replace(~r/([\%_])/, string, fn _, x -> "\\#{x}" end) <> "%"
+  end
+end

--- a/lib/arrow_web/components/core_components.ex
+++ b/lib/arrow_web/components/core_components.ex
@@ -415,6 +415,7 @@ defmodule ArrowWeb.CoreComponents do
   attr :value_mapper, :any
   attr :allow_clear, :boolean
   attr :target, :any, default: nil
+  attr :update_min_len, :integer
 
   def live_select(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
     assigns =
@@ -481,7 +482,35 @@ defmodule ArrowWeb.CoreComponents do
       field={@field}
       stop_or_gtfs_stop={@stop_or_gtfs_stop}
       class={@class}
-      s
+    />
+    """
+  end
+
+  @doc """
+  LiveSelect-based input for shuttle ID with autocomplete
+  """
+
+  attr :id, :string
+  attr :field, :any, required: true, doc: "Field for `shuttle_id` value"
+
+  attr :shuttle, :any, required: true, doc: "Currently selected shuttle, if any"
+
+  attr :label, :string, default: "Stop ID"
+  attr :class, :string, default: nil
+
+  def shuttle_input(assigns) do
+    assigns =
+      assign_new(assigns, :id, fn %{field: field} ->
+        "#{field.form.name}_#{field.name}_shuttle_input_component"
+      end)
+
+    ~H"""
+    <.live_component
+      module={ArrowWeb.ShuttleInput}
+      id={@id}
+      field={@field}
+      shuttle={@shuttle}
+      class={@class}
     />
     """
   end

--- a/lib/arrow_web/components/shuttle_input.ex
+++ b/lib/arrow_web/components/shuttle_input.ex
@@ -1,0 +1,62 @@
+defmodule ArrowWeb.ShuttleInput do
+  @moduledoc """
+  LiveComponent providing a wrapper around live_select tailored for
+  shuttle autocomplete
+  """
+
+  use ArrowWeb, :live_component
+
+  alias Arrow.Shuttles
+  alias Arrow.Shuttles.Shuttle
+
+  attr :id, :string, required: true
+  attr :field, :any, required: true
+  attr :shuttle, :any, required: true
+  attr :label, :string, default: "select shuttle route"
+  attr :class, :string, default: nil
+
+  def render(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :options,
+        if is_nil(assigns.shuttle) || !Ecto.assoc_loaded?(assigns.shuttle) do
+          Shuttles.list_shuttles() |> Enum.map(&option_for_shuttle/1)
+        else
+          [option_for_shuttle(assigns.shuttle)]
+        end
+      )
+
+    ~H"""
+    <div id={@id} class={@class}>
+      <.live_select
+        field={@field}
+        label={@label}
+        allow_clear={true}
+        target={@myself}
+        options={@options}
+        placeholder="Search for a route…"
+        update_min_len={0}
+      />
+    </div>
+    """
+  end
+
+  def handle_event("live_select_change", %{"id" => live_select_id, "text" => text}, socket) do
+    new_opts =
+      if String.length(text) == 0 do
+        Shuttles.list_shuttles() |> Enum.map(&option_for_shuttle/1)
+      else
+        text |> Shuttles.shuttles_by_search_string() |> Enum.map(&option_for_shuttle/1)
+      end
+
+    send_update(LiveSelect.Component, id: live_select_id, options: new_opts)
+
+    {:noreply, socket}
+  end
+
+  @spec option_for_shuttle(Shuttle.t()) :: {String.t(), integer()}
+  defp option_for_shuttle(%Shuttle{id: id, shuttle_name: shuttle_name}) do
+    {shuttle_name, id}
+  end
+end

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -135,6 +135,33 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
       <div :if={@adding_new_service?} class="border-2 border-dashed border-primary p-2">
         <span class="text-primary">add new replacement service component</span>
         <.shuttle_input field={@form[:new_shuttle_id]} shuttle={input_value(@form, :new_shuttle)} />
+        <div class="row">
+          <.input
+            field={@form[:new_shuttle_start_date]}
+            type="date"
+            label="Start date"
+            class="col-lg-3"
+          />
+          <.input field={@form[:new_shuttle_end_date]} type="date" label="End date" class="col-lg-3" />
+          <.input field={@form[:new_shuttle_activation_reason]} type="text" label="Activation reason" />
+        </div>
+        <div class="row">
+          <div class="col-lg-3">
+            <.button disabled={not Enum.empty?(@form.source.errors)} class="btn btn-primary w-100">
+              save component
+            </.button>
+          </div>
+          <div class="col-lg-3">
+            <.button
+              id="cancel_add_new_replacement_service_button"
+              class="btn-outline-primary w-100"
+              data-confirm="Are you sure you want to cancel? All changes to this replacement service component will be lost!"
+              phx-click="cancel_add_new_replacement_service"
+            >
+              cancel
+            </.button>
+          </div>
+        </div>
       </div>
     </div>
     """
@@ -198,6 +225,12 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
 
   def handle_event("add_new_replacement_service", _params, socket) do
     socket = assign(socket, :adding_new_service?, true)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("cancel_add_new_replacement_service", _params, socket) do
+    socket = assign(socket, :adding_new_service?, false)
 
     {:noreply, socket}
   end

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -1,6 +1,8 @@
 defmodule ArrowWeb.DisruptionV2ViewLive do
   use ArrowWeb, :live_view
 
+  import Phoenix.HTML.Form
+
   alias Arrow.Adjustment
   alias Arrow.Disruptions
   alias Arrow.Disruptions.DisruptionV2
@@ -88,7 +90,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
           </small>
         </fieldset>
 
-        <.replacement_service_section adding_new_service?={@adding_new_service?} />
+        <.replacement_service_section form={@form} adding_new_service?={@adding_new_service?} />
 
         <:actions>
           <div class="w-25 mr-2">
@@ -112,6 +114,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
   end
 
   attr :adding_new_service?, :boolean, required: true
+  attr :form, :any, required: true
 
   defp replacement_service_section(assigns) do
     ~H"""
@@ -131,6 +134,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
       </span>
       <div :if={@adding_new_service?} class="border-2 border-dashed border-primary p-2">
         <span class="text-primary">add new replacement service component</span>
+        <.shuttle_input field={@form[:new_shuttle_id]} shuttle={input_value(@form, :new_shuttle)} />
       </div>
     </div>
     """

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -52,7 +52,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
                 id={"#{@form[:mode].id}-#{idx}"}
                 class="form-check-input"
                 type="radio"
-                checked={to_string(@form[:mode].value) == to_string(value) |> IO.inspect()}
+                checked={to_string(@form[:mode].value) == to_string(value)}
                 value={to_string(value)}
               />
 

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -125,7 +125,6 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
           id="add_new_replacement_service_button"
           class="btn"
           type="button"
-          name="add_new_replacement_service"
           phx-click="add_new_replacement_service"
         >
           <.icon name="hero-plus" class="h-8 w-8 text-primary" />

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.html.heex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.html.heex
@@ -13,4 +13,5 @@
   form={@form}
   disruption_v2={@disruption_v2}
   icon_paths={@icon_paths}
+  adding_new_service?={@adding_new_service?}
 />

--- a/test/arrow/util_test.exs
+++ b/test/arrow/util_test.exs
@@ -1,0 +1,19 @@
+defmodule Arrow.UtilTest do
+  use ExUnit.Case, async: true
+
+  alias Arrow.Util
+
+  describe "sanitized_string_for_sql_like/1" do
+    test "Escapes % characters" do
+      assert Util.sanitized_string_for_sql_like("%foo") == "\\%foo%"
+    end
+
+    test "Escapes _ characters" do
+      assert Util.sanitized_string_for_sql_like("_foo") == "\\_foo%"
+    end
+
+    test "Makes no changes to other random characters" do
+      assert Util.sanitized_string_for_sql_like("f$o*o!") == "f$o*o!%"
+    end
+  end
+end

--- a/test/arrow_web/live/disruption_v2_live_test.exs
+++ b/test/arrow_web/live/disruption_v2_live_test.exs
@@ -63,4 +63,16 @@ defmodule ArrowWeb.DisruptionV2LiveTest do
       assert html =~ "Disruption saved successfully"
     end
   end
+
+  describe "Replacement Service" do
+    @tag :authenticated_admin
+    setup [:create_disruption_v2]
+
+    test "can activate add replacement service flow", %{conn: conn, disruption_v2: disruption_v2} do
+      {:ok, live, _html} = live(conn, ~p"/disruptionsv2/#{disruption_v2.id}/edit")
+
+      assert live |> element("button#add_new_replacement_service_button") |> render_click() =~
+               "add new replacement service component"
+    end
+  end
 end

--- a/test/arrow_web/live/disruption_v2_live_test.exs
+++ b/test/arrow_web/live/disruption_v2_live_test.exs
@@ -74,5 +74,20 @@ defmodule ArrowWeb.DisruptionV2LiveTest do
       assert live |> element("button#add_new_replacement_service_button") |> render_click() =~
                "add new replacement service component"
     end
+
+    @tag :authenticated_admin
+    setup [:create_disruption_v2]
+
+    test "can deactivate add replacement service flow", %{
+      conn: conn,
+      disruption_v2: disruption_v2
+    } do
+      {:ok, live, _html} = live(conn, ~p"/disruptionsv2/#{disruption_v2.id}/edit")
+
+      live |> element("button#add_new_replacement_service_button") |> render_click()
+
+      refute live |> element("button#cancel_add_new_replacement_service_button") |> render_click() =~
+               "add new replacement service component"
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Implement "Create New Replacement Service Component" basic view](https://app.asana.com/0/584764604969369/1208885496650094/f)

This allows a user to click and start entering a replacement shuttle, including selecting the name of the shuttle from a dropdown of available shuttles, with auto-complete. Validation and save are explicitly out of scope and will go in a followup ticket / PR.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
