### PR TITLE
fix(shuttles): call Changeset.apply_action after uploading xlsx

### DIFF
--- a/lib/arrow/shuttles/definition_upload.ex
+++ b/lib/arrow/shuttles/definition_upload.ex
@@ -81,7 +81,11 @@ defmodule Arrow.Shuttles.DefinitionUpload do
         end)
         |> Enum.reverse()
 
-      if Enum.empty?(errors), do: {:ok, stop_ids}, else: {:errors, errors}
+      if Enum.empty?(errors) do
+        {:ok, stop_ids |> Enum.map(&Integer.to_string(&1))}
+      else
+        {:errors, errors}
+      end
     else
       {:errors, ["Unable to parse Stop ID column"]}
     end

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -405,7 +405,7 @@ defmodule ArrowWeb.ShuttleViewLive do
 
     changeset = Ecto.Changeset.put_assoc(changeset, :routes, new_routes)
 
-    socket = socket |> assign(:form, to_form(changeset)) |> update_map()
+    socket = socket |> assign(form: to_form(changeset)) |> update_map()
 
     {:noreply, socket}
   end
@@ -442,7 +442,7 @@ defmodule ArrowWeb.ShuttleViewLive do
          |> update(:errors, fn errors ->
            put_in(errors, [:route_stops, Access.key(direction_id_string)], nil)
          end)
-         |> assign(:form, to_form(changeset))}
+         |> assign(form: to_form(changeset))}
 
       {:error, error} ->
         {:noreply,
@@ -658,11 +658,11 @@ defmodule ArrowWeb.ShuttleViewLive do
             # Related Ecto error:
             # https://github.com/elixir-ecto/ecto/blob/18288287f18ce205b03b3b3dc8cb80f0f1b06dbe/lib/ecto/changeset/relation.ex#L448-L453
             new_changeset = Shuttles.change_shuttle(shuttle)
-            socket |> assign(:form, to_form(new_changeset)) |> update_map()
+            socket |> assign(form: to_form(new_changeset)) |> update_map()
 
           {:error, _invalid_changeset} ->
             # The changeset from the upload data wasn't valid, so we don't retain it
-            socket |> assign(:form, to_form(changeset)) |> update_map()
+            socket |> assign(form: to_form(changeset)) |> update_map()
         end
 
       {:error, errors} ->

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -581,14 +581,14 @@ defmodule ArrowWeb.ShuttleViewLive do
   defp get_new_route_stops_changeset_with_uploaded_stops(stop_ids, direction_id) do
     new_route_stops =
       stop_ids
-      |> Enum.with_index()
+      |> Enum.with_index(1)
       |> Enum.map(fn {stop_id, i} ->
         Arrow.Shuttles.RouteStop.changeset(
           %Arrow.Shuttles.RouteStop{},
           %{
             direction_id: direction_id,
             stop_sequence: i,
-            display_stop_id: Integer.to_string(stop_id)
+            display_stop_id: stop_id
           }
         )
       end)

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -320,7 +320,7 @@ defmodule ArrowWeb.ShuttleViewLive do
     change = Shuttles.change_shuttle(socket.assigns.shuttle, shuttle_params)
     form = to_form(change, action: :validate)
 
-    {:noreply, socket |> assign(form: form) |> update_map(change)}
+    {:noreply, socket |> assign(form: form) |> update_map()}
   end
 
   def handle_event("edit", %{"shuttle" => shuttle_params}, socket) do
@@ -403,7 +403,7 @@ defmodule ArrowWeb.ShuttleViewLive do
 
     changeset = Ecto.Changeset.put_assoc(changeset, :routes, new_routes)
 
-    socket = socket |> assign(:form, to_form(changeset)) |> update_map(changeset)
+    socket = socket |> assign(:form, to_form(changeset)) |> update_map()
 
     {:noreply, socket}
   end
@@ -546,7 +546,9 @@ defmodule ArrowWeb.ShuttleViewLive do
     end
   end
 
-  defp update_map(socket, changeset) do
+  defp update_map(socket) do
+    changeset = socket.assigns.form.source
+
     layers =
       changeset
       |> Ecto.Changeset.get_assoc(:routes, :struct)
@@ -615,11 +617,11 @@ defmodule ArrowWeb.ShuttleViewLive do
 
     case Ecto.Changeset.apply_action(changeset, :update) do
       {:error, changeset} ->
-        socket |> assign(:form, to_form(changeset)) |> update_map(changeset)
+        socket |> assign(:form, to_form(changeset)) |> update_map()
 
       {:ok, shuttle} ->
         new_changeset = Shuttles.change_shuttle(shuttle)
-        socket |> assign(:form, to_form(new_changeset)) |> update_map(new_changeset)
+        socket |> assign(:form, to_form(new_changeset)) |> update_map()
     end
   end
 end

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -317,8 +317,10 @@ defmodule ArrowWeb.ShuttleViewLive do
   end
 
   def handle_event("validate", %{"shuttle" => shuttle_params}, socket) do
-    change = Shuttles.change_shuttle(socket.assigns.shuttle, shuttle_params)
-    form = to_form(change, action: :validate)
+    form =
+      socket.assigns.shuttle
+      |> Shuttles.change_shuttle(shuttle_params)
+      |> to_form(action: :validate)
 
     {:noreply, socket |> assign(form: form) |> update_map()}
   end

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -620,6 +620,10 @@ defmodule ArrowWeb.ShuttleViewLive do
         socket |> assign(:form, to_form(changeset)) |> update_map()
 
       {:ok, shuttle} ->
+        # We replaced any existing associated stops
+        # so we must create a new changeset here to track additional changes
+        # Related Ecto error:
+        # https://github.com/elixir-ecto/ecto/blob/18288287f18ce205b03b3b3dc8cb80f0f1b06dbe/lib/ecto/changeset/relation.ex#L448-L453
         new_changeset = Shuttles.change_shuttle(shuttle)
         socket |> assign(:form, to_form(new_changeset)) |> update_map()
     end

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -598,11 +598,7 @@ defmodule ArrowWeb.ShuttleViewLive do
     else
       {:error,
        new_route_stops
-       |> Enum.flat_map(fn %Ecto.Changeset{
-                             errors: errors
-                           } ->
-         errors
-       end)
+       |> Enum.flat_map(fn %Ecto.Changeset{errors: errors} -> errors end)
        |> Enum.map(&elem(&1, 1))}
     end
   end

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -451,32 +451,6 @@ defmodule ArrowWeb.ShuttleViewLive do
     end
   end
 
-  defp update_route_changeset_with_uploaded_stops(route_changeset, stop_ids, direction_id) do
-    if Ecto.Changeset.get_field(route_changeset, :direction_id) == direction_id do
-      new_route_stops =
-        stop_ids
-        |> Enum.with_index()
-        |> Enum.map(fn {stop_id, i} ->
-          Arrow.Shuttles.RouteStop.changeset(
-            %Arrow.Shuttles.RouteStop{},
-            %{
-              direction_id: direction_id,
-              stop_sequence: i,
-              display_stop_id: Integer.to_string(stop_id)
-            }
-          )
-        end)
-
-      Ecto.Changeset.put_assoc(
-        route_changeset,
-        :route_stops,
-        new_route_stops
-      )
-    else
-      route_changeset
-    end
-  end
-
   @spec get_stop_travel_times(list({:ok, any()})) ::
           {:ok, list(number())} | {:error, any()}
   defp get_stop_travel_times(stop_coordinates) do
@@ -600,6 +574,28 @@ defmodule ArrowWeb.ShuttleViewLive do
     end
   end
 
+  defp update_route_changeset_with_uploaded_stops(route_changeset, stop_ids, direction_id) do
+    new_route_stops =
+      stop_ids
+      |> Enum.with_index()
+      |> Enum.map(fn {stop_id, i} ->
+        Arrow.Shuttles.RouteStop.changeset(
+          %Arrow.Shuttles.RouteStop{},
+          %{
+            direction_id: direction_id,
+            stop_sequence: i,
+            display_stop_id: Integer.to_string(stop_id)
+          }
+        )
+      end)
+
+    Ecto.Changeset.put_assoc(
+      route_changeset,
+      :route_stops,
+      new_route_stops
+    )
+  end
+
   defp populate_stop_ids(socket, stop_ids) do
     changeset = socket.assigns.form.source
     existing_routes = Ecto.Changeset.get_assoc(changeset, :routes)
@@ -617,6 +613,13 @@ defmodule ArrowWeb.ShuttleViewLive do
 
     changeset = Ecto.Changeset.put_assoc(changeset, :routes, new_routes)
 
-    socket |> assign(:form, to_form(changeset)) |> update_map(changeset)
+    case Ecto.Changeset.apply_action(changeset, :update) do
+      {:error, changeset} ->
+        socket |> assign(:form, to_form(changeset)) |> update_map(changeset)
+
+      {:ok, shuttle} ->
+        new_changeset = Shuttles.change_shuttle(shuttle)
+        socket |> assign(:form, to_form(new_changeset)) |> update_map(new_changeset)
+    end
   end
 end

--- a/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
+++ b/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
@@ -478,21 +478,25 @@ defmodule ArrowWeb.ShuttleLiveTest do
       direction_1_stop_rows = Floki.find(html, "#stops-dir-1 > .row")
 
       for {stop_id, index} <- Enum.with_index(direction_0_stop_sequence, 1) do
-        assert [^stop_id] =
-                 Floki.attribute(
-                   direction_0_stop_rows,
-                   "[data-stop_sequence=#{index}] > div > div.form-group > div > div > div > input[type=text]",
-                   "value"
-                 )
+        [stop] =
+          Floki.attribute(
+            direction_0_stop_rows,
+            "[data-stop_sequence=#{index}] > div > div.form-group > div > div > div > input[type=text]",
+            "value"
+          )
+
+        assert stop =~ stop_id
       end
 
       for {stop_id, index} <- Enum.with_index(direction_1_stop_sequence, 1) do
-        assert [^stop_id] =
-                 Floki.attribute(
-                   direction_1_stop_rows,
-                   "[data-stop_sequence=#{index}] > div > div.form-group > div > div > div > input[type=text]",
-                   "value"
-                 )
+        [stop] =
+          Floki.attribute(
+            direction_1_stop_rows,
+            "[data-stop_sequence=#{index}] > div > div.form-group > div > div > div > input[type=text]",
+            "value"
+          )
+
+        assert stop =~ stop_id
       end
     end
 

--- a/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
+++ b/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
@@ -477,7 +477,7 @@ defmodule ArrowWeb.ShuttleLiveTest do
       direction_0_stop_rows = Floki.find(html, "#stops-dir-0 > .row")
       direction_1_stop_rows = Floki.find(html, "#stops-dir-1 > .row")
 
-      for {stop_id, index} <- Enum.with_index(direction_0_stop_sequence) do
+      for {stop_id, index} <- Enum.with_index(direction_0_stop_sequence, 1) do
         assert [^stop_id] =
                  Floki.attribute(
                    direction_0_stop_rows,
@@ -486,7 +486,7 @@ defmodule ArrowWeb.ShuttleLiveTest do
                  )
       end
 
-      for {stop_id, index} <- Enum.with_index(direction_1_stop_sequence) do
+      for {stop_id, index} <- Enum.with_index(direction_1_stop_sequence, 1) do
         assert [^stop_id] =
                  Floki.attribute(
                    direction_1_stop_rows,
@@ -520,7 +520,7 @@ defmodule ArrowWeb.ShuttleLiveTest do
       direction_0_stop_rows = Floki.find(html, "#stops-dir-0 > .row")
       direction_1_stop_rows = Floki.find(html, "#stops-dir-1 > .row")
 
-      for {_stop_id, index} <- Enum.with_index(direction_0_stop_sequence) do
+      for {_stop_id, index} <- Enum.with_index(direction_0_stop_sequence, 1) do
         assert [] =
                  Floki.attribute(
                    direction_0_stop_rows,
@@ -529,7 +529,7 @@ defmodule ArrowWeb.ShuttleLiveTest do
                  )
       end
 
-      for {_stop_id, index} <- Enum.with_index(direction_1_stop_sequence) do
+      for {_stop_id, index} <- Enum.with_index(direction_1_stop_sequence, 1) do
         assert [] =
                  Floki.attribute(
                    direction_1_stop_rows,

--- a/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
+++ b/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
@@ -465,6 +465,13 @@ defmodule ArrowWeb.ShuttleLiveTest do
 
       direction_0_stop_sequence = ~w(9328 5327 5271)
       direction_1_stop_sequence = ~w(5271 5072 9328)
+
+      (direction_0_stop_sequence ++ direction_1_stop_sequence)
+      |> Enum.uniq()
+      |> Enum.map(fn stop_id ->
+        insert(:gtfs_stop, %{id: stop_id})
+      end)
+
       html = render_upload(definition, "valid.xlsx")
 
       direction_0_stop_rows = Floki.find(html, "#stops-dir-0 > .row")
@@ -481,6 +488,49 @@ defmodule ArrowWeb.ShuttleLiveTest do
 
       for {stop_id, index} <- Enum.with_index(direction_1_stop_sequence) do
         assert [^stop_id] =
+                 Floki.attribute(
+                   direction_1_stop_rows,
+                   "[data-stop_sequence=#{index}] > div > div.form-group > div > div > div > input[type=text]",
+                   "value"
+                 )
+      end
+    end
+
+    @tag :authenticated_admin
+    test "displays error if uploaded stop IDs contain invalid stop IDs", %{conn: conn} do
+      {:ok, new_live, _html} = live(conn, ~p"/shuttles/new")
+
+      definition =
+        file_input(new_live, "#shuttle-form", :definition, [
+          %{
+            name: "valid.xlsx",
+            content: File.read!("test/support/fixtures/xlsx/valid.xlsx")
+          }
+        ])
+
+      direction_0_stop_sequence = ~w(9328 5327 5271)
+      direction_1_stop_sequence = ~w(5271 5072 9328)
+
+      html = render_upload(definition, "valid.xlsx")
+
+      assert html =~ "Failed to upload definition:"
+      assert html =~ "not a valid stop ID &#39;9328"
+      assert html =~ "not a valid stop ID &#39;5072"
+
+      direction_0_stop_rows = Floki.find(html, "#stops-dir-0 > .row")
+      direction_1_stop_rows = Floki.find(html, "#stops-dir-1 > .row")
+
+      for {_stop_id, index} <- Enum.with_index(direction_0_stop_sequence) do
+        assert [] =
+                 Floki.attribute(
+                   direction_0_stop_rows,
+                   "[data-stop_sequence=#{index}] > div > div.form-group > div > div > div > input[type=text]",
+                   "value"
+                 )
+      end
+
+      for {_stop_id, index} <- Enum.with_index(direction_1_stop_sequence) do
+        assert [] =
                  Floki.attribute(
                    direction_1_stop_rows,
                    "[data-stop_sequence=#{index}] > div > div.form-group > div > div > div > input[type=text]",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 🏹🐛 [edit only] Upload Shuttle Definition XLSX then Retrieve Estimates - retrieve estimate does nothing (websocket crash)](https://app.asana.com/0/584764604969369/1209034382499892/f)

* This patches the issue when the uploaded XLS doesn't produce a valid route_stops changeset
* We now error on upload if the changeset would be invalid (in the current case, if the stop doesn't exist), instead of allowing the invalid casted changeset to be applied to the form

![image](https://github.com/user-attachments/assets/627c6fd1-2c96-4abd-be03-354599a70e7e)


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
