### PR TITLE
fix: validate time_to_next stop for activating shuttle

### DIFF
--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -47,11 +47,7 @@ defmodule Arrow.Shuttles.Shuttle do
 
           routes
           |> Enum.map(&get_assoc(&1, :route_stops))
-          |> Enum.any?(fn route_stops ->
-            route_stops
-            |> Enum.slice(0..-2//1)
-            |> Enum.any?(&(&1 |> get_field(:time_to_next_stop) |> is_nil()))
-          end) ->
+          |> Enum.any?(&route_stops_missing_time_to_next_stop?/1) ->
             add_error(
               changeset,
               :status,
@@ -65,5 +61,12 @@ defmodule Arrow.Shuttles.Shuttle do
       _ ->
         changeset
     end
+  end
+
+  @spec route_stops_missing_time_to_next_stop?([Arrow.Shuttles.RouteStop.t()]) :: boolean()
+  defp route_stops_missing_time_to_next_stop?(route_stops) do
+    route_stops
+    |> Enum.slice(0..-2//1)
+    |> Enum.any?(&(&1 |> get_field(:time_to_next_stop) |> is_nil()))
   end
 end

--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -41,13 +41,25 @@ defmodule Arrow.Shuttles.Shuttle do
       :active ->
         routes = get_assoc(changeset, :routes)
 
-        enough_stops? =
-          routes |> Enum.map(&get_assoc(&1, :route_stops)) |> Enum.all?(&(length(&1) >= 2))
+        cond do
+          routes |> Enum.map(&get_assoc(&1, :route_stops)) |> Enum.any?(&(length(&1) < 2)) ->
+            add_error(changeset, :status, "must have at least two stops in each direction")
 
-        if enough_stops? do
-          changeset
-        else
-          add_error(changeset, :status, "must have at least two stops in each direction")
+          routes
+          |> Enum.map(&get_assoc(&1, :route_stops))
+          |> Enum.any?(fn route_stops ->
+            route_stops
+            |> Enum.slice(0..-2//1)
+            |> Enum.any?(&(&1 |> get_field(:time_to_next_stop) |> is_nil()))
+          end) ->
+            add_error(
+              changeset,
+              :status,
+              "all stops except the last in each direction must have a time to next stop"
+            )
+
+          true ->
+            changeset
         end
 
       _ ->

--- a/test/arrow_web/controllers/api/shuttle_controller_test.exs
+++ b/test/arrow_web/controllers/api/shuttle_controller_test.exs
@@ -28,7 +28,8 @@ defmodule ArrowWeb.API.ShuttleControllerTest do
           %{
             "direction_id" => "0",
             "stop_sequence" => "1",
-            "display_stop_id" => stop1.id
+            "display_stop_id" => stop1.id,
+            "time_to_next_stop" => 30.0
           },
           %{
             "direction_id" => "0",
@@ -45,11 +46,12 @@ defmodule ArrowWeb.API.ShuttleControllerTest do
           %{
             "direction_id" => "1",
             "stop_sequence" => "1",
-            "display_stop_id" => stop3.id
+            "display_stop_id" => stop3.id,
+            "time_to_next_stop" => 30.0
           },
           %{
             "direction_id" => "0",
-            "stop_sequence" => "1",
+            "stop_sequence" => "2",
             "display_stop_id" => stop4.id
           }
         ]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 🏹🐛 Shuttles can be saved as active without time to next stop](https://app.asana.com/0/584764604969369/1209094056922520/f)

I wonder if it would also make sense to add validation that the final stop in each direction does _not_ have a `time_to_next_stop`, since it isn't meaningful. That might be a bit over-zealous, though.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
