### PR TITLE
feat: add data to RouteStop changeset error for an invalid stop ID

### DIFF
--- a/lib/arrow/shuttles/route_stop.ex
+++ b/lib/arrow/shuttles/route_stop.ex
@@ -50,9 +50,14 @@ defmodule Arrow.Shuttles.RouteStop do
       if display_stop_id = Ecto.Changeset.get_change(change, :display_stop_id) do
         {stop_id, gtfs_stop_id, stop, error} =
           case Shuttles.stop_or_gtfs_stop_for_stop_id(display_stop_id) do
-            %Stop{id: id} = stop -> {id, nil, stop, nil}
-            %GtfsStop{id: id} = stop -> {nil, id, stop, nil}
-            nil -> {nil, nil, nil, "not a valid stop ID"}
+            %Stop{id: id} = stop ->
+              {id, nil, stop, nil}
+
+            %GtfsStop{id: id} = stop ->
+              {nil, id, stop, nil}
+
+            nil ->
+              {nil, nil, nil, "not a valid stop ID '%{display_stop_id}'"}
           end
 
         change =
@@ -64,7 +69,7 @@ defmodule Arrow.Shuttles.RouteStop do
         if is_nil(error) do
           change
         else
-          add_error(change, :display_stop_id, error)
+          add_error(change, :display_stop_id, error, display_stop_id: display_stop_id)
         end
       else
         change

--- a/test/arrow/shuttle/route_stop_test.exs
+++ b/test/arrow/shuttle/route_stop_test.exs
@@ -44,7 +44,10 @@ defmodule Arrow.Shuttles.RouteStopTest do
 
       assert %Ecto.Changeset{
                valid?: false,
-               errors: [display_stop_id: {"not a valid stop ID", []}]
+               errors: [
+                 display_stop_id:
+                   {"not a valid stop ID '%{display_stop_id}'", [display_stop_id: "invalid_id"]}
+               ]
              } = changeset
     end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket, came out of investigation from another ticket

Adds invalid stop_id value to the Changeset error (see [add_error docs](https://hexdocs.pm/ecto/Ecto.Changeset.html#add_error/4-examples))

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
