### PR TITLE
fix(shuttles): Fix indexes changing to 0-based and displayed stop names changing when stops are reordered

### DIFF
--- a/lib/arrow_web/components/stop_input.ex
+++ b/lib/arrow_web/components/stop_input.ex
@@ -32,8 +32,6 @@ defmodule ArrowWeb.StopInput do
         end
       )
 
-    IO.inspect(assigns.field)
-
     ~H"""
     <div id={@id} class={@class}>
       <.live_select

--- a/lib/arrow_web/components/stop_input.ex
+++ b/lib/arrow_web/components/stop_input.ex
@@ -38,9 +38,17 @@ defmodule ArrowWeb.StopInput do
         allow_clear={true}
         target={@myself}
         options={@options}
+        value_mapper={&stop_value_mapper/1}
       />
     </div>
     """
+  end
+
+  defp stop_value_mapper(text) do
+    case Shuttles.stop_or_gtfs_stop_for_stop_id(text) do
+      nil -> {text, text}
+      stop -> option_for_stop(stop)
+    end
   end
 
   def handle_event("live_select_change", %{"id" => live_select_id, "text" => text}, socket) do

--- a/lib/arrow_web/components/stop_input.ex
+++ b/lib/arrow_web/components/stop_input.ex
@@ -6,8 +6,6 @@ defmodule ArrowWeb.StopInput do
 
   use ArrowWeb, :live_component
 
-  import Ecto.Changeset, only: [get_assoc: 2]
-
   alias Arrow.Gtfs.Stop, as: GtfsStop
   alias Arrow.Shuttles
   alias Arrow.Shuttles.Stop
@@ -49,9 +47,9 @@ defmodule ArrowWeb.StopInput do
   defp stop_value_mapper(text, field) do
     stop =
       case Map.get(field.form.source.changes, :display_stop) do
-        %Arrow.Gtfs.Stop{id: text} = stop -> stop |> dbg()
-        %Arrow.Shuttles.Stop{stop_id: text} = stop -> stop |> dbg()
-        _ -> Shuttles.stop_or_gtfs_stop_for_stop_id(text) |> dbg()
+        %Arrow.Gtfs.Stop{} = stop -> stop
+        %Arrow.Shuttles.Stop{} = stop -> stop
+        _ -> Shuttles.stop_or_gtfs_stop_for_stop_id(text)
       end
 
     if stop == nil do

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -556,7 +556,7 @@ defmodule ArrowWeb.ShuttleViewLive do
         existing_stops
         |> List.delete_at(old)
         |> List.insert_at(new, moved_route_stop)
-        |> Enum.reduce({[], 0}, fn route_stop, {route_stop_changes, stop_sequence} ->
+        |> Enum.reduce({[], 1}, fn route_stop, {route_stop_changes, stop_sequence} ->
           {route_stop_changes ++
              [Arrow.Shuttles.RouteStop.changeset(route_stop, %{stop_sequence: stop_sequence})],
            stop_sequence + 1}

--- a/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
+++ b/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
@@ -329,7 +329,7 @@ defmodule ArrowWeb.ShuttleLiveTest do
 
       [%{id: stop_id1}, %{id: stop_id2}, %{id: stop_id3}] = [gtfs_stop1, gtfs_stop2, gtfs_stop3]
 
-      assert [%{gtfs_stop_id: ^stop_id2}, %{gtfs_stop_id: ^stop_id1}, %{gtfs_stop_id: ^stop_id3}] =
+      assert [%{gtfs_stop_id: ^stop_id2, stop_sequence: 1, display_stop_id: ^stop_id2}, %{gtfs_stop_id: ^stop_id1, stop_sequence: 2, display_stop_id: ^stop_id1}, %{gtfs_stop_id: ^stop_id3, stop_sequence: 3, display_stop_id: ^stop_id3}] =
                direction_0_route.route_stops
     end
 

--- a/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
+++ b/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
@@ -329,7 +329,11 @@ defmodule ArrowWeb.ShuttleLiveTest do
 
       [%{id: stop_id1}, %{id: stop_id2}, %{id: stop_id3}] = [gtfs_stop1, gtfs_stop2, gtfs_stop3]
 
-      assert [%{gtfs_stop_id: ^stop_id2, stop_sequence: 1, display_stop_id: ^stop_id2}, %{gtfs_stop_id: ^stop_id1, stop_sequence: 2, display_stop_id: ^stop_id1}, %{gtfs_stop_id: ^stop_id3, stop_sequence: 3, display_stop_id: ^stop_id3}] =
+      assert [
+               %{gtfs_stop_id: ^stop_id2, stop_sequence: 1, display_stop_id: ^stop_id2},
+               %{gtfs_stop_id: ^stop_id1, stop_sequence: 2, display_stop_id: ^stop_id1},
+               %{gtfs_stop_id: ^stop_id3, stop_sequence: 3, display_stop_id: ^stop_id3}
+             ] =
                direction_0_route.route_stops
     end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 🏹🐛 Map view - stops index changing (from first stop as 0 or as 1](https://app.asana.com/0/584764604969369/1209034382499890/f)

Problem:
When re-ordering shuttle stops for a new shuttle, the indexing of stops would change from 1-based to 0-based after the first reordering. 

Solution:
Start using 1-based indexing for stops in the `stop_input` component. 

Problem:
When re-ordering shuttle stops for a new shuttle, stops with auto-completed names would switch from the auto completed value (e.g.  1 - Washington St opp Ruggles St) to just the value of the stop ID e.g. just 1

Solution:
On every re-render of stops, ensure that the value of the `stop_input` component is the human readable value. I fetch from the stop from the changeset if it's already there, otherwise I fetch the stop from the DB. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
