### PR TITLE
feat(disruptionsv2): show shuttle map when adding replacement service…

### DIFF
--- a/lib/arrow_web/controllers/layout_html/_footer.html.heex
+++ b/lib/arrow_web/controllers/layout_html/_footer.html.heex
@@ -1,7 +1,7 @@
 <footer class="container bg-light mt-auto px-5 py-1">
   <div class="row align-items-center">
     <div class="col-md-7 py-2 m-footer__explanation">
-      Arrow is built and maintained by the Customer Technology Department's Transit Real-time
+      Arrow is built and maintained by the Customer Technology Department's Transit Data
       team.
     </div>
 

--- a/lib/arrow_web/controllers/shape_html.ex
+++ b/lib/arrow_web/controllers/shape_html.ex
@@ -1,6 +1,10 @@
 defmodule ArrowWeb.ShapeView do
   use ArrowWeb, :html
+  alias Arrow.Shuttles
   alias Arrow.Shuttles.ShapesUpload
+  alias Arrow.Shuttles.Route
+  alias Arrow.Shuttles.RouteStop
+  alias Arrow.Shuttles.Shape
 
   embed_templates "shape_html/*"
 
@@ -39,4 +43,91 @@ defmodule ArrowWeb.ShapeView do
     |> Enum.map(&String.to_float/1)
     |> Enum.reverse()
   end
+
+  defp direction_to_layer(%Route{} = direction, existing_props) do
+    matching_shape =
+      existing_props.layers
+      |> Enum.map(& &1.shape)
+      |> Enum.find(&(&1 && direction.shape_id && &1.name == direction.shape.name))
+
+    shape = if matching_shape, do: matching_shape, else: shape_to_shapeview(direction.shape)
+
+    stops = render_route_stops(direction.route_stops)
+
+    %{
+      name: direction.direction_desc,
+      direction_id: direction.direction_id,
+      shape: shape,
+      stops: stops
+    }
+  end
+
+  def routes_to_layers(routes, existing_props) do
+    routes
+    |> Enum.sort_by(& &1.direction_id)
+    |> Enum.map(&direction_to_layer(&1, existing_props))
+  end
+
+  def routes_to_layers(routes) do
+    routes_to_layers(routes, %{layers: []})
+  end
+
+  defp shape_to_shapeview(%Shape{bucket: "disabled"}), do: nil
+
+  defp shape_to_shapeview(%Shape{} = shape) do
+    shape
+    |> Shuttles.get_shapes_upload()
+    |> shapes_map_view()
+    |> Map.get(:shapes)
+    |> List.first()
+  end
+
+  defp shape_to_shapeview(_), do: nil
+
+  defp render_route_stop(%RouteStop{stop_id: stop_id} = route_stop) when not is_nil(stop_id) do
+    route_stop =
+      if !Ecto.assoc_loaded?(route_stop.stop) or
+           (route_stop.stop && route_stop.stop.id != stop_id),
+         do: Arrow.Repo.preload(route_stop, :stop, force: true),
+         else: route_stop
+
+    if route_stop.stop do
+      %{
+        stop_sequence: route_stop.stop_sequence,
+        stop_id: route_stop.stop.stop_id,
+        stop_name: route_stop.stop.stop_name,
+        stop_desc: route_stop.stop.stop_desc,
+        stop_lat: route_stop.stop.stop_lat,
+        stop_lon: route_stop.stop.stop_lon
+      }
+    end
+  end
+
+  defp render_route_stop(%RouteStop{gtfs_stop_id: gtfs_stop_id} = route_stop)
+       when not is_nil(gtfs_stop_id) do
+    route_stop =
+      if !Ecto.assoc_loaded?(route_stop.gtfs_stop) or
+           (route_stop.gtfs_stop && route_stop.gtfs_stop.id != gtfs_stop_id),
+         do: Arrow.Repo.preload(route_stop, :gtfs_stop, force: true),
+         else: route_stop
+
+    if route_stop.gtfs_stop do
+      %{
+        stop_sequence: route_stop.stop_sequence,
+        stop_id: route_stop.gtfs_stop.id,
+        stop_name: route_stop.gtfs_stop.name,
+        stop_desc: route_stop.gtfs_stop.desc,
+        stop_lat: route_stop.gtfs_stop.lat,
+        stop_lon: route_stop.gtfs_stop.lon
+      }
+    end
+  end
+
+  defp render_route_stop(_), do: nil
+
+  defp render_route_stops([_ | _] = route_stops) do
+    route_stops |> Enum.map(&render_route_stop/1) |> Enum.filter(& &1)
+  end
+
+  defp render_route_stops(_), do: []
 end

--- a/lib/arrow_web/controllers/shape_html.ex
+++ b/lib/arrow_web/controllers/shape_html.ex
@@ -1,10 +1,10 @@
 defmodule ArrowWeb.ShapeView do
   use ArrowWeb, :html
   alias Arrow.Shuttles
-  alias Arrow.Shuttles.ShapesUpload
   alias Arrow.Shuttles.Route
   alias Arrow.Shuttles.RouteStop
   alias Arrow.Shuttles.Shape
+  alias Arrow.Shuttles.ShapesUpload
 
   embed_templates "shape_html/*"
 

--- a/lib/arrow_web/controllers/shape_html.ex
+++ b/lib/arrow_web/controllers/shape_html.ex
@@ -1,10 +1,7 @@
 defmodule ArrowWeb.ShapeView do
   use ArrowWeb, :html
   alias Arrow.Shuttles
-  alias Arrow.Shuttles.Route
-  alias Arrow.Shuttles.RouteStop
-  alias Arrow.Shuttles.Shape
-  alias Arrow.Shuttles.ShapesUpload
+  alias Arrow.Shuttles.{Route, RouteStop, Shape, ShapesUpload}
 
   embed_templates "shape_html/*"
 

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -6,6 +6,8 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
   alias Arrow.Adjustment
   alias Arrow.Disruptions
   alias Arrow.Disruptions.DisruptionV2
+  alias Arrow.Shuttles
+  alias ArrowWeb.ShuttleViewLive
 
   @spec disruption_status_labels :: map()
   def disruption_status_labels, do: %{Approved: true, Pending: false}
@@ -113,6 +115,10 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
     """
   end
 
+  defp get_shuttle_map_props(shuttle_id) do
+     %{layers: Shuttles.get_shuttle!(shuttle_id).routes |> ShuttleViewLive.routes_to_layers()}
+  end
+
   attr :adding_new_service?, :boolean, required: true
   attr :form, :any, required: true
 
@@ -134,6 +140,9 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
       <div :if={@adding_new_service?} class="border-2 border-dashed border-primary p-2">
         <span class="text-primary">add new replacement service component</span>
         <.shuttle_input field={@form[:new_shuttle_id]} shuttle={input_value(@form, :new_shuttle)} />
+        {
+          if @form[:new_shuttle_id].value != nil, do: live_react_component("Components.ShapeStopViewMap", get_shuttle_map_props(@form[:new_shuttle_id].value), id: "shuttle-view-map-disruptionsv2")
+        }
         <div class="row">
           <.input
             field={@form[:new_shuttle_start_date]}

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -7,7 +7,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
   alias Arrow.Disruptions
   alias Arrow.Disruptions.DisruptionV2
   alias Arrow.Shuttles
-  alias ArrowWeb.ShuttleViewLive
+  alias ArrowWeb.ShapeView
 
   @spec disruption_status_labels :: map()
   def disruption_status_labels, do: %{Approved: true, Pending: false}
@@ -116,7 +116,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
   end
 
   defp get_shuttle_map_props(shuttle_id) do
-    %{layers: Shuttles.get_shuttle!(shuttle_id).routes |> ShuttleViewLive.routes_to_layers()}
+    %{layers: Shuttles.get_shuttle!(shuttle_id).routes |> ShapeView.routes_to_layers()}
   end
 
   attr :adding_new_service?, :boolean, required: true

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -116,7 +116,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
   end
 
   defp get_shuttle_map_props(shuttle_id) do
-     %{layers: Shuttles.get_shuttle!(shuttle_id).routes |> ShuttleViewLive.routes_to_layers()}
+    %{layers: Shuttles.get_shuttle!(shuttle_id).routes |> ShuttleViewLive.routes_to_layers()}
   end
 
   attr :adding_new_service?, :boolean, required: true
@@ -140,9 +140,13 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
       <div :if={@adding_new_service?} class="border-2 border-dashed border-primary p-2">
         <span class="text-primary">add new replacement service component</span>
         <.shuttle_input field={@form[:new_shuttle_id]} shuttle={input_value(@form, :new_shuttle)} />
-        {
-          if @form[:new_shuttle_id].value != nil, do: live_react_component("Components.ShapeStopViewMap", get_shuttle_map_props(@form[:new_shuttle_id].value), id: "shuttle-view-map-disruptionsv2")
-        }
+        {if @form[:new_shuttle_id].value != nil,
+          do:
+            live_react_component(
+              "Components.ShapeStopViewMap",
+              get_shuttle_map_props(@form[:new_shuttle_id].value),
+              id: "shuttle-view-map-disruptionsv2"
+            )}
         <div class="row">
           <.input
             field={@form[:new_shuttle_start_date]}

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -3,7 +3,7 @@ defmodule ArrowWeb.ShuttleViewLive do
   import Phoenix.HTML.Form
 
   alias Arrow.Shuttles
-  alias Arrow.Shuttles.{DefinitionUpload, Route, RouteStop, Shape, Shuttle}
+  alias Arrow.Shuttles.{DefinitionUpload, Shuttle}
   alias ArrowWeb.ShapeView
 
   embed_templates "shuttle_live/*"
@@ -243,93 +243,6 @@ defmodule ArrowWeb.ShuttleViewLive do
     """
   end
 
-  defp shape_to_shapeview(%Shape{bucket: "disabled"}), do: nil
-
-  defp shape_to_shapeview(%Shape{} = shape) do
-    shape
-    |> Shuttles.get_shapes_upload()
-    |> ShapeView.shapes_map_view()
-    |> Map.get(:shapes)
-    |> List.first()
-  end
-
-  defp shape_to_shapeview(_), do: nil
-
-  defp render_route_stop(%RouteStop{stop_id: stop_id} = route_stop) when not is_nil(stop_id) do
-    route_stop =
-      if !Ecto.assoc_loaded?(route_stop.stop) or
-           (route_stop.stop && route_stop.stop.id != stop_id),
-         do: Arrow.Repo.preload(route_stop, :stop, force: true),
-         else: route_stop
-
-    if route_stop.stop do
-      %{
-        stop_sequence: route_stop.stop_sequence,
-        stop_id: route_stop.stop.stop_id,
-        stop_name: route_stop.stop.stop_name,
-        stop_desc: route_stop.stop.stop_desc,
-        stop_lat: route_stop.stop.stop_lat,
-        stop_lon: route_stop.stop.stop_lon
-      }
-    end
-  end
-
-  defp render_route_stop(%RouteStop{gtfs_stop_id: gtfs_stop_id} = route_stop)
-       when not is_nil(gtfs_stop_id) do
-    route_stop =
-      if !Ecto.assoc_loaded?(route_stop.gtfs_stop) or
-           (route_stop.gtfs_stop && route_stop.gtfs_stop.id != gtfs_stop_id),
-         do: Arrow.Repo.preload(route_stop, :gtfs_stop, force: true),
-         else: route_stop
-
-    if route_stop.gtfs_stop do
-      %{
-        stop_sequence: route_stop.stop_sequence,
-        stop_id: route_stop.gtfs_stop.id,
-        stop_name: route_stop.gtfs_stop.name,
-        stop_desc: route_stop.gtfs_stop.desc,
-        stop_lat: route_stop.gtfs_stop.lat,
-        stop_lon: route_stop.gtfs_stop.lon
-      }
-    end
-  end
-
-  defp render_route_stop(_), do: nil
-
-  defp render_route_stops([_ | _] = route_stops) do
-    route_stops |> Enum.map(&render_route_stop/1) |> Enum.filter(& &1)
-  end
-
-  defp render_route_stops(_), do: []
-
-  defp direction_to_layer(%Route{} = direction, existing_props) do
-    matching_shape =
-      existing_props.layers
-      |> Enum.map(& &1.shape)
-      |> Enum.find(&(&1 && direction.shape_id && &1.name == direction.shape.name))
-
-    shape = if matching_shape, do: matching_shape, else: shape_to_shapeview(direction.shape)
-
-    stops = render_route_stops(direction.route_stops)
-
-    %{
-      name: direction.direction_desc,
-      direction_id: direction.direction_id,
-      shape: shape,
-      stops: stops
-    }
-  end
-
-  def routes_to_layers(routes, existing_props) do
-    routes
-    |> Enum.sort_by(& &1.direction_id)
-    |> Enum.map(&direction_to_layer(&1, existing_props))
-  end
-
-  def routes_to_layers(routes) do
-    routes_to_layers(routes, %{layers: []})
-  end
-
   defp shape_options_mapper(shapes) do
     Enum.map(shapes, &shape_option_mapper/1)
   end
@@ -362,7 +275,7 @@ defmodule ArrowWeb.ShuttleViewLive do
       |> assign(:title, "edit shuttle")
       |> assign(:gtfs_disruptable_routes, gtfs_disruptable_routes)
       |> assign(:shapes, shapes)
-      |> assign(:map_props, %{layers: routes_to_layers(shuttle.routes)})
+      |> assign(:map_props, %{layers: ShapeView.routes_to_layers(shuttle.routes)})
       |> assign(:errors, %{route_stops: %{}})
       |> allow_upload(:definition,
         accept: ~w(.xlsx),
@@ -392,7 +305,7 @@ defmodule ArrowWeb.ShuttleViewLive do
       |> assign(:shuttle, shuttle)
       |> assign(:gtfs_disruptable_routes, gtfs_disruptable_routes)
       |> assign(:shapes, shapes)
-      |> assign(:map_props, %{layers: routes_to_layers(shuttle.routes)})
+      |> assign(:map_props, %{layers: ShapeView.routes_to_layers(shuttle.routes)})
       |> assign(:errors, %{route_stops: %{}})
       |> allow_upload(:definition,
         accept: ~w(.xlsx),
@@ -664,7 +577,7 @@ defmodule ArrowWeb.ShuttleViewLive do
       changeset
       |> Ecto.Changeset.get_assoc(:routes, :struct)
       |> Enum.map(&Arrow.Repo.preload(&1, :shape, force: true))
-      |> routes_to_layers(socket.assigns.map_props)
+      |> ShapeView.routes_to_layers(socket.assigns.map_props)
 
     assign(socket, :map_props, %{layers: layers})
   end

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -320,13 +320,13 @@ defmodule ArrowWeb.ShuttleViewLive do
     }
   end
 
-  defp routes_to_layers(routes, existing_props) do
+  def routes_to_layers(routes, existing_props) do
     routes
     |> Enum.sort_by(& &1.direction_id)
     |> Enum.map(&direction_to_layer(&1, existing_props))
   end
 
-  defp routes_to_layers(routes) do
+  def routes_to_layers(routes) do
     routes_to_layers(routes, %{layers: []})
   end
 

--- a/test/arrow_web/live/disruption_v2_live_test.exs
+++ b/test/arrow_web/live/disruption_v2_live_test.exs
@@ -71,6 +71,7 @@ defmodule ArrowWeb.DisruptionV2LiveTest do
 
     @tag :authenticated_admin
     setup [:create_disruption_v2]
+
     test "can activate add replacement service flow", %{conn: conn, disruption_v2: disruption_v2} do
       {:ok, live, _html} = live(conn, ~p"/disruptionsv2/#{disruption_v2.id}/edit")
 
@@ -81,7 +82,8 @@ defmodule ArrowWeb.DisruptionV2LiveTest do
 
       live_component_selector = ~s{[id="shuttle[routes][0]_shape_id_live_select_component"]}
 
-      stop_map_container = live
+      stop_map_container =
+        live
         |> form("#disruption_v2-form")
         |> render_change(%{"disruption_v2[new_shuttle_id]" => shuttle.id})
         |> Floki.find("#shuttle-view-map-disruptionsv2-container")

--- a/test/arrow_web/live/disruption_v2_live_test.exs
+++ b/test/arrow_web/live/disruption_v2_live_test.exs
@@ -80,8 +80,6 @@ defmodule ArrowWeb.DisruptionV2LiveTest do
 
       shuttle = shuttle_fixture()
 
-      live_component_selector = ~s{[id="shuttle[routes][0]_shape_id_live_select_component"]}
-
       stop_map_container =
         live
         |> form("#disruption_v2-form")

--- a/test/arrow_web/live/disruption_v2_live_test.exs
+++ b/test/arrow_web/live/disruption_v2_live_test.exs
@@ -89,7 +89,7 @@ defmodule ArrowWeb.DisruptionV2LiveTest do
         |> Floki.find("#shuttle-view-map-disruptionsv2-container")
 
       # make sure the shuttle map container is displayed when we have entered a new shuttle
-      assert !Enum.empty?(stop_map_container)
+      assert [_shuttle_map_div] = stop_map_container
     end
 
     @tag :authenticated_admin

--- a/test/arrow_web/live/disruption_v2_live_test.exs
+++ b/test/arrow_web/live/disruption_v2_live_test.exs
@@ -3,6 +3,7 @@ defmodule ArrowWeb.DisruptionV2LiveTest do
 
   import Phoenix.LiveViewTest
   import Arrow.DisruptionsFixtures
+  import Arrow.ShuttlesFixtures
 
   @create_attrs %{
     title: "the great molasses disruption of 2025",
@@ -68,11 +69,25 @@ defmodule ArrowWeb.DisruptionV2LiveTest do
     @tag :authenticated_admin
     setup [:create_disruption_v2]
 
+    @tag :authenticated_admin
+    setup [:create_disruption_v2]
     test "can activate add replacement service flow", %{conn: conn, disruption_v2: disruption_v2} do
       {:ok, live, _html} = live(conn, ~p"/disruptionsv2/#{disruption_v2.id}/edit")
 
       assert live |> element("button#add_new_replacement_service_button") |> render_click() =~
                "add new replacement service component"
+
+      shuttle = shuttle_fixture()
+
+      live_component_selector = ~s{[id="shuttle[routes][0]_shape_id_live_select_component"]}
+
+      stop_map_container = live
+        |> form("#disruption_v2-form")
+        |> render_change(%{"disruption_v2[new_shuttle_id]" => shuttle.id})
+        |> Floki.find("#shuttle-view-map-disruptionsv2-container")
+
+      # make sure the shuttle map container is displayed when we have entered a new shuttle
+      assert !Enum.empty?(stop_map_container)
     end
 
     @tag :authenticated_admin


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 🏹 Implement "Create Replacement Service Component" map view](https://app.asana.com/0/584764604969369/1209053528462959/f)

Problem:
You can't easily visualize the shuttle that you're choosing for replacement service in a disruption without navigating to the shuttles page

Solution:
Shows the shuttle map view from the "create new shuttle" map page inline in the new "create disruption" page.
![image](https://github.com/user-attachments/assets/0a4b50ea-6daa-4cdb-8a3c-776e54d0211d)

This corresponds to the mockup for the new disruption page on [miro](https://miro.com/app/board/uXjVKVLTOI0=/):
![image](https://github.com/user-attachments/assets/723970f5-d305-4fa1-b0b7-699bd64b0d63)



#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
