### PR TITLE
feat(shuttles): Make the direction description a drop-down menu instead of free text

### DIFF
--- a/lib/arrow/shuttles/route.ex
+++ b/lib/arrow/shuttles/route.ex
@@ -7,7 +7,7 @@ defmodule Arrow.Shuttles.Route do
     field :suffix, :string
     field :destination, :string
     field :direction_id, Ecto.Enum, values: [:"0", :"1"]
-    field :direction_desc, :string
+    field :direction_desc, Ecto.Enum, values: [:Inbound, :Outbound, :North, :South, :East, :West]
     field :waypoint, :string
     belongs_to :shuttle, Arrow.Shuttles.Shuttle
     belongs_to :shape, Arrow.Shuttles.Shape

--- a/lib/arrow/shuttles/route.ex
+++ b/lib/arrow/shuttles/route.ex
@@ -3,11 +3,15 @@ defmodule Arrow.Shuttles.Route do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @direction_desc_values [:Inbound, :Outbound, :North, :South, :East, :West]
+
+  def direction_desc_values, do: @direction_desc_values
+
   schema "shuttle_routes" do
     field :suffix, :string
     field :destination, :string
     field :direction_id, Ecto.Enum, values: [:"0", :"1"]
-    field :direction_desc, Ecto.Enum, values: [:Inbound, :Outbound, :North, :South, :East, :West]
+    field :direction_desc, Ecto.Enum, values: @direction_desc_values
     field :waypoint, :string
     belongs_to :shuttle, Arrow.Shuttles.Shuttle
     belongs_to :shape, Arrow.Shuttles.Shape

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -459,32 +459,6 @@ defmodule ArrowWeb.ShuttleViewLive do
     end
   end
 
-  defp update_route_changeset_with_uploaded_stops(route_changeset, stop_ids, direction_id) do
-    if Ecto.Changeset.get_field(route_changeset, :direction_id) == direction_id do
-      new_route_stops =
-        stop_ids
-        |> Enum.with_index()
-        |> Enum.map(fn {stop_id, i} ->
-          Arrow.Shuttles.RouteStop.changeset(
-            %Arrow.Shuttles.RouteStop{},
-            %{
-              direction_id: direction_id,
-              stop_sequence: i,
-              display_stop_id: Integer.to_string(stop_id)
-            }
-          )
-        end)
-
-      Ecto.Changeset.put_assoc(
-        route_changeset,
-        :route_stops,
-        new_route_stops
-      )
-    else
-      route_changeset
-    end
-  end
-
   @spec get_stop_travel_times(list({:ok, any()})) ::
           {:ok, list(number())} | {:error, any()}
   defp get_stop_travel_times(stop_coordinates) do

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -359,13 +359,18 @@ defmodule ArrowWeb.ShuttleViewLive do
 
   def handle_event(
         "direction_desc_changed",
-        %{"shuttle" => %{"routes" => shuttle_routes}} = shuttle,
+        %{"shuttle" => %{"routes" => shuttle_routes}} = params,
         socket
       ) do
+    IO.inspect(params)
+
     socket =
       case shuttle_routes do
-        %{"0" => %{"direction_desc" => first_direction}} -> update_second_direction(socket, first_direction)
-        _ -> socket
+        %{"0" => %{"direction_desc" => first_direction}} ->
+          update_second_direction(socket, first_direction)
+
+        _ ->
+          socket
       end
 
     {:noreply, socket}

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -87,7 +87,6 @@ defmodule ArrowWeb.ShuttleViewLive do
                   type="select"
                   label="Direction Description"
                   prompt="Choose a value"
-                  phx-change="direction_desc_changed"
                   options={Ecto.Enum.values(Arrow.Shuttles.Route, :direction_desc)}
                 />
               </div>
@@ -457,6 +456,32 @@ defmodule ArrowWeb.ShuttleViewLive do
          |> update(:errors, fn errors ->
            put_in(errors, [:route_stops, Access.key(direction_id_string)], error)
          end)}
+    end
+  end
+
+  defp update_route_changeset_with_uploaded_stops(route_changeset, stop_ids, direction_id) do
+    if Ecto.Changeset.get_field(route_changeset, :direction_id) == direction_id do
+      new_route_stops =
+        stop_ids
+        |> Enum.with_index()
+        |> Enum.map(fn {stop_id, i} ->
+          Arrow.Shuttles.RouteStop.changeset(
+            %Arrow.Shuttles.RouteStop{},
+            %{
+              direction_id: direction_id,
+              stop_sequence: i,
+              display_stop_id: Integer.to_string(stop_id)
+            }
+          )
+        end)
+
+      Ecto.Changeset.put_assoc(
+        route_changeset,
+        :route_stops,
+        new_route_stops
+      )
+    else
+      route_changeset
     end
   end
 

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -332,50 +332,6 @@ defmodule ArrowWeb.ShuttleViewLive do
     {:noreply, socket |> assign(form: form) |> update_map()}
   end
 
-  defp update_second_direction(socket, first_direction) do
-    second_direction =
-      case first_direction do
-        "Inbound" -> "Outbound"
-        "Outbound" -> "Inbound"
-        "North" -> "South"
-        "South" -> "North"
-        "East" -> "West"
-        "West" -> "East"
-      end
-
-    update(socket, :form, fn %{source: changeset} ->
-      existing_routes = Ecto.Changeset.get_assoc(changeset, :routes)
-
-      new_routes =
-        Enum.map(existing_routes, fn route_changeset ->
-          update_route_changeset_with_new_direction_desc(route_changeset, :"1", second_direction)
-        end)
-
-      changeset = Ecto.Changeset.put_assoc(changeset, :routes, new_routes)
-
-      to_form(changeset)
-    end)
-  end
-
-  def handle_event(
-        "direction_desc_changed",
-        %{"shuttle" => %{"routes" => shuttle_routes}} = params,
-        socket
-      ) do
-    IO.inspect(params)
-
-    socket =
-      case shuttle_routes do
-        %{"0" => %{"direction_desc" => first_direction}} ->
-          update_second_direction(socket, first_direction)
-
-        _ ->
-          socket
-      end
-
-    {:noreply, socket}
-  end
-
   def handle_event("edit", %{"shuttle" => shuttle_params}, socket) do
     shuttle = Shuttles.get_shuttle!(socket.assigns.shuttle.id)
 
@@ -548,19 +504,6 @@ defmodule ArrowWeb.ShuttleViewLive do
           |> Enum.map_join(", ", fn {:error, msg} -> "#{msg}" end)
 
         {:error, coordinate_errors}
-    end
-  end
-
-  defp update_route_changeset_with_new_direction_desc(
-         route_changeset,
-         direction_id,
-         direction_desc
-       ) do
-    if Ecto.Changeset.get_field(route_changeset, :direction_id) == direction_id do
-      route_changeset
-      |> Ecto.Changeset.put_change(:direction_desc, direction_desc)
-    else
-      route_changeset
     end
   end
 

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -82,7 +82,13 @@ defmodule ArrowWeb.ShuttleViewLive do
                 <.input field={f_route[:direction_id]} type="text" label="Direction id" />
               </div>
               <div class="col">
-                <.input field={f_route[:direction_desc]} type="text" label="Direction desc" />
+                <.input
+                  field={f_route[:direction_desc]}
+                  type="select"
+                  label="Direction Description"
+                  prompt="Choose a value"
+                  options={Ecto.Enum.values(Arrow.Shuttles.Route, :direction_desc)}
+                />
               </div>
               <div class="col offset-md-1">
                 <.live_select

--- a/priv/repo/migrations/20250121165457_drop_shuttles_invalid_direction_descriptions.exs
+++ b/priv/repo/migrations/20250121165457_drop_shuttles_invalid_direction_descriptions.exs
@@ -9,7 +9,12 @@ defmodule Arrow.Repo.Migrations.DropShuttlesInvalidDirectionDescriptions do
 
   def change do
     execute("""
-    DELETE FROM shuttle_routes WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()})
+    DELETE FROM shuttle_route_stops 
+    WHERE shuttle_route_id NOT IN 
+      (SELECT shuttle_route_id FROM shuttle_routes WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()}));
+
+    DELETE FROM shuttle_routes 
+    WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()});
     """)
   end
 end

--- a/priv/repo/migrations/20250121165457_drop_shuttles_invalid_direction_descriptions.exs
+++ b/priv/repo/migrations/20250121165457_drop_shuttles_invalid_direction_descriptions.exs
@@ -5,16 +5,22 @@ defmodule Arrow.Repo.Migrations.DropShuttlesInvalidDirectionDescriptions do
     Arrow.Shuttles.Route.direction_desc_values() |> Enum.map(&"'#{&1}'") |> Enum.join(",")
   end
 
-  def change do
-    execute("""
-      DELETE FROM shuttle_route_stops 
-      WHERE shuttle_route_id IN 
-        (SELECT shuttle_route_id FROM shuttle_routes WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()}));
-    """)
+  def up do
+    execute(
+      """
+        DELETE FROM shuttle_route_stops 
+        WHERE shuttle_route_id IN 
+          (SELECT shuttle_route_id FROM shuttle_routes WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()}));
+      """,
+      ""
+    )
 
-    execute("""
-      DELETE FROM shuttle_routes 
-      WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()});
-    """)
+    execute(
+      """
+        DELETE FROM shuttle_routes 
+        WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()});
+      """,
+      ""
+    )
   end
 end

--- a/priv/repo/migrations/20250121165457_drop_shuttles_invalid_direction_descriptions.exs
+++ b/priv/repo/migrations/20250121165457_drop_shuttles_invalid_direction_descriptions.exs
@@ -8,7 +8,7 @@ defmodule Arrow.Repo.Migrations.DropShuttlesInvalidDirectionDescriptions do
   def change do
     execute("""
       DELETE FROM shuttle_route_stops 
-      WHERE shuttle_route_id NOT IN 
+      WHERE shuttle_route_id IN 
         (SELECT shuttle_route_id FROM shuttle_routes WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()}));
     """)
 

--- a/priv/repo/migrations/20250121165457_drop_shuttles_invalid_direction_descriptions.exs
+++ b/priv/repo/migrations/20250121165457_drop_shuttles_invalid_direction_descriptions.exs
@@ -1,20 +1,20 @@
 defmodule Arrow.Repo.Migrations.DropShuttlesInvalidDirectionDescriptions do
   use Ecto.Migration
 
-  alias Arrow.Shuttles.Route
-
   defp get_valid_direction_sql_strings() do
     Arrow.Shuttles.Route.direction_desc_values() |> Enum.map(&"'#{&1}'") |> Enum.join(",")
   end
 
   def change do
     execute("""
-    DELETE FROM shuttle_route_stops 
-    WHERE shuttle_route_id NOT IN 
-      (SELECT shuttle_route_id FROM shuttle_routes WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()}));
+      DELETE FROM shuttle_route_stops 
+      WHERE shuttle_route_id NOT IN 
+        (SELECT shuttle_route_id FROM shuttle_routes WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()}));
+    """)
 
-    DELETE FROM shuttle_routes 
-    WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()});
+    execute("""
+      DELETE FROM shuttle_routes 
+      WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()});
     """)
   end
 end

--- a/priv/repo/migrations/20250121165457_drop_shuttles_invalid_direction_descriptions.exs
+++ b/priv/repo/migrations/20250121165457_drop_shuttles_invalid_direction_descriptions.exs
@@ -1,0 +1,15 @@
+defmodule Arrow.Repo.Migrations.DropShuttlesInvalidDirectionDescriptions do
+  use Ecto.Migration
+
+  alias Arrow.Shuttles.Route
+
+  defp get_valid_direction_sql_strings() do
+    Arrow.Shuttles.Route.direction_desc_values() |> Enum.map(&"'#{&1}'") |> Enum.join(",")
+  end
+
+  def change do
+    execute("""
+    DELETE FROM shuttle_routes WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()})
+    """)
+  end
+end

--- a/priv/repo/migrations/20250121165457_drop_shuttles_invalid_direction_descriptions.exs
+++ b/priv/repo/migrations/20250121165457_drop_shuttles_invalid_direction_descriptions.exs
@@ -12,7 +12,7 @@ defmodule Arrow.Repo.Migrations.DropShuttlesInvalidDirectionDescriptions do
         WHERE shuttle_route_id IN 
           (SELECT shuttle_route_id FROM shuttle_routes WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()}));
       """,
-      ""
+      "SELECT 0"
     )
 
     execute(
@@ -20,7 +20,7 @@ defmodule Arrow.Repo.Migrations.DropShuttlesInvalidDirectionDescriptions do
         DELETE FROM shuttle_routes 
         WHERE direction_desc NOT IN (#{get_valid_direction_sql_strings()});
       """,
-      ""
+      "SELECT 0"
     )
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -135,7 +135,7 @@ route =
     shape_id: 1,
     destination: "Harvard",
     direction_id: :"0",
-    direction_desc: "Southbound",
+    direction_desc: :South,
     suffix: nil,
     waypoint: "Brattle"
   })
@@ -146,7 +146,7 @@ route1 =
     shape_id: 2,
     destination: "Alewife",
     direction_id: :"1",
-    direction_desc: "Northbound",
+    direction_desc: :North,
     suffix: nil,
     waypoint: "Brattle"
   })

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -1826,3 +1826,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20241209204043);
 INSERT INTO public."schema_migrations" (version) VALUES (20241210155455);
 INSERT INTO public."schema_migrations" (version) VALUES (20241219160941);
 INSERT INTO public."schema_migrations" (version) VALUES (20241231110033);
+INSERT INTO public."schema_migrations" (version) VALUES (20250121165457);

--- a/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
+++ b/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
@@ -108,23 +108,6 @@ defmodule ArrowWeb.ShuttleLiveTest do
       assert new_live |> form("#shuttle-form", shuttle: @invalid_attrs) |> render_submit() =~
                "can&#39;t be blank"
     end
-
-    @tag :authenticated_admin
-    test "second direction is automatically populated with a sane value", %{conn: conn} do
-      {:ok, new_live, _html} = live(conn, ~p"/shuttles/new")
-
-      [second_direction_desc] =
-        new_live
-        |> element("select#shuttle_routes_0_direction_desc")
-        |> render_change(%{
-          "_target" => ["shuttle", "routes", "0", "direction_desc"],
-          "shuttle" => %{"routes" => %{"0" => %{"direction_desc" => "Inbound"}}}
-        })
-        |> Floki.find("select#shuttle_routes_1_direction_desc > [selected=selected]")
-        |> Floki.attribute("value")
-
-      assert second_direction_desc == "Outbound"
-    end
   end
 
   describe "edit shuttle" do

--- a/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
+++ b/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
@@ -23,7 +23,7 @@ defmodule ArrowWeb.ShuttleLiveTest do
       "1" => %{
         :_persistent_id => "1",
         destination: "Harvard",
-        direction_desc: "North",
+        direction_desc: "South",
         direction_id: "1",
         shape_id: "",
         suffix: "",
@@ -107,6 +107,23 @@ defmodule ArrowWeb.ShuttleLiveTest do
 
       assert new_live |> form("#shuttle-form", shuttle: @invalid_attrs) |> render_submit() =~
                "can&#39;t be blank"
+    end
+
+    @tag :authenticated_admin
+    test "second direction is automatically populated with a sane value", %{conn: conn} do
+      {:ok, new_live, _html} = live(conn, ~p"/shuttles/new")
+
+      [second_direction_desc] =
+        new_live
+        |> element("select#shuttle_routes_0_direction_desc")
+        |> render_change(%{
+          "_target" => ["shuttle", "routes", "0", "direction_desc"],
+          "shuttle" => %{"routes" => %{"0" => %{"direction_desc" => "Inbound"}}}
+        })
+        |> Floki.find("select#shuttle_routes_1_direction_desc > [selected=selected]")
+        |> Floki.attribute("value")
+
+      assert second_direction_desc == "Outbound"
     end
   end
 

--- a/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
+++ b/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
@@ -14,7 +14,7 @@ defmodule ArrowWeb.ShuttleLiveTest do
       "0" => %{
         :_persistent_id => "0",
         destination: "Broadway",
-        direction_desc: "Southbound",
+        direction_desc: "South",
         direction_id: "0",
         shape_id: "",
         suffix: "",
@@ -23,7 +23,7 @@ defmodule ArrowWeb.ShuttleLiveTest do
       "1" => %{
         :_persistent_id => "1",
         destination: "Harvard",
-        direction_desc: "Northbound",
+        direction_desc: "North",
         direction_id: "1",
         shape_id: "",
         suffix: "",
@@ -40,7 +40,7 @@ defmodule ArrowWeb.ShuttleLiveTest do
       "0" => %{
         :_persistent_id => "0",
         destination: "Broadway",
-        direction_desc: "Southbound",
+        direction_desc: "South",
         direction_id: "0",
         suffix: "",
         waypoint: ""
@@ -48,7 +48,7 @@ defmodule ArrowWeb.ShuttleLiveTest do
       "1" => %{
         :_persistent_id => "1",
         destination: "Harvard",
-        direction_desc: "Northbound",
+        direction_desc: "North",
         direction_id: "1",
         suffix: "",
         waypoint: ""
@@ -242,7 +242,7 @@ defmodule ArrowWeb.ShuttleLiveTest do
         routes: %{
           "0" => %{
             destination: "Broadway",
-            direction_desc: "Southbound",
+            direction_desc: "South",
             direction_id: "0",
             suffix: "",
             waypoint: "",

--- a/test/support/fixtures/shuttles_fixtures.ex
+++ b/test/support/fixtures/shuttles_fixtures.ex
@@ -107,7 +107,7 @@ defmodule Arrow.ShuttlesFixtures do
         shape: shape1,
         destination: "Harvard",
         direction_id: :"0",
-        direction_desc: "Southbound",
+        direction_desc: :South,
         suffix: nil,
         waypoint: "Brattle",
         route_stops: route_stops
@@ -117,7 +117,7 @@ defmodule Arrow.ShuttlesFixtures do
         shape: shape2,
         destination: "Alewife",
         direction_id: :"1",
-        direction_desc: "Northbound",
+        direction_desc: :North,
         suffix: nil,
         waypoint: "Brattle",
         route_stops: route_stops


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 🏹 Change direction_desc to drop-down (in Shuttle Definitions)](https://app.asana.com/0/584764604969369/1209163082064165/f)

Problem:
Direction description on the shuttle form was a free text field, but in reality there are a fixed number of potential descriptions [for a direction.](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs.md#directionstxt)

Solution:
Make direction description a drop-down menu instead of a free-text box. 


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
