### PR TITLE
tweak: Show edit page after saving disruption

### DIFF
--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -261,9 +261,15 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
       end
 
     case save_result do
-      {:ok, _} ->
+      {:ok, disruption} ->
         {:noreply,
          socket
+         |> clear_flash()
+         |> assign(:page_title, "Edit Disruption v2")
+         |> assign(:disruption_v2, disruption)
+         |> assign(:form_action, :edit)
+         |> assign(:title, "edit disruption")
+         |> push_patch(to: ~p"/disruptionsv2/#{disruption.id}/edit")
          |> put_flash(:info, "Disruption saved successfully")}
 
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -51,8 +51,10 @@ defmodule ArrowWeb.Router do
     put("/disruptions/:id/row_status", DisruptionController, :update_row_status)
     post("/disruptions/:id/notes", NoteController, :create)
 
-    live("/disruptionsv2/new", DisruptionV2ViewLive, :new)
-    live("/disruptionsv2/:id/edit", DisruptionV2ViewLive, :edit)
+    live_session(:default) do
+      live("/disruptionsv2/new", DisruptionV2ViewLive, :new)
+      live("/disruptionsv2/:id/edit", DisruptionV2ViewLive, :edit)
+    end
 
     live("/stops/new", StopViewLive, :new)
     live("/stops/:id/edit", StopViewLive, :edit)

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -51,10 +51,8 @@ defmodule ArrowWeb.Router do
     put("/disruptions/:id/row_status", DisruptionController, :update_row_status)
     post("/disruptions/:id/notes", NoteController, :create)
 
-    live_session(:default) do
-      live("/disruptionsv2/new", DisruptionV2ViewLive, :new)
-      live("/disruptionsv2/:id/edit", DisruptionV2ViewLive, :edit)
-    end
+    live("/disruptionsv2/new", DisruptionV2ViewLive, :new)
+    live("/disruptionsv2/:id/edit", DisruptionV2ViewLive, :edit)
 
     live("/stops/new", StopViewLive, :new)
     live("/stops/:id/edit", StopViewLive, :edit)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** ad-hoc

After saving a disruption, you remain at `/new` which means you can't edit a disruption after immediately after creating it. If we move these routes into a `live_session`, we can navigate the user without reloading the page. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
