### PR TITLE
fix(disruptionsv2): disruption limit form is closed after limit is created

### DIFF
--- a/lib/arrow_web/components/limit_section.ex
+++ b/lib/arrow_web/components/limit_section.ex
@@ -70,8 +70,12 @@ defmodule ArrowWeb.LimitSection do
         </div>
       <% end %>
 
-
-      <.link_button :if={is_nil(@limit_form)} class="btn-link" phx-click="add_limit" id="add-limit-component">
+      <.link_button
+        :if={is_nil(@limit_form)}
+        class="btn-link"
+        phx-click="add_limit"
+        id="add-limit-component"
+      >
         <.icon name="hero-plus" /> <span>add limit component</span>
       </.link_button>
 

--- a/lib/arrow_web/components/limit_section.ex
+++ b/lib/arrow_web/components/limit_section.ex
@@ -96,6 +96,7 @@ defmodule ArrowWeb.LimitSection do
             <div class="col-lg-3">
               <.input
                 class="h-100"
+                id="select-route-id"
                 field={@limit_form[:route_id]}
                 type="select"
                 label="route"

--- a/lib/arrow_web/components/limit_section.ex
+++ b/lib/arrow_web/components/limit_section.ex
@@ -70,7 +70,8 @@ defmodule ArrowWeb.LimitSection do
         </div>
       <% end %>
 
-      <.link_button :if={is_nil(@limit_form)} class="btn-link" phx-click="add_limit">
+
+      <.link_button :if={is_nil(@limit_form)} class="btn-link" phx-click="add_limit" id="add-limit-component">
         <.icon name="hero-plus" /> <span>add limit component</span>
       </.link_button>
 

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -310,7 +310,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
     {:noreply,
      socket
      |> assign(
-       limit_form: nil,
+       limit_in_form: nil,
        replacement_service_form: nil,
        disruption_v2: disruption,
        form: form


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹🐛 Disruption limit component create form doesn't close after save](https://app.asana.com/0/584764604969369/1209292019824563/f)

Problem:
The limit form was not closing after a new limit was created.

Solution:
Set the correct value (`@limit_in_form`) to `nil` such that the limit form is no longer displayed after a new disruption limit gets created. Add unit test covering this case

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
