### PR TITLE
fix: don't open a new replacement_service form after create or update

### DIFF
--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -311,7 +311,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
      socket
      |> assign(
        limit_in_form: nil,
-       replacement_service_form: nil,
+       replacement_service_in_form: nil,
        disruption_v2: disruption,
        form: form
      )}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 🏹🐛 Disruption replacement service component create form doesn't close after save](https://app.asana.com/0/1205718273834959/1209333426359266)

Same fix as [🏹🐛 Disruption limit component create form doesn't close after save](https://app.asana.com/0/584764604969369/1209292019824563) given the pattern duplication
#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
