### PR TITLE
fix(disruptionsv2): allow shuttle select dropdown on top of map

### DIFF
--- a/lib/arrow_web/components/replacement_service_section.ex
+++ b/lib/arrow_web/components/replacement_service_section.ex
@@ -110,7 +110,7 @@ defmodule ArrowWeb.ReplacementServiceSection do
               else: "edit disruption replacement service component"}
           </h4>
           <.shuttle_input field={@form[:shuttle_id]} shuttle={input_value(@form, :shuttle)} />
-          <div :if={not empty_input_value?(@form[:shuttle_id].value)} class="row">
+          <div :if={not empty_input_value?(@form[:shuttle_id].value)} class="row relative z-0">
             <div class="col p-0">
               {live_react_component(
                 "Components.ShapeStopViewMap",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐛🏹 Disruptions: map sits on top of shuttle selection dropdown](https://app.asana.com/0/1205718273834959/1209309553641279)

The dropdown already sets a z-index of 50. Set the sibling map row to have a lower z-index.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
