### PR TITLE
fix(disruptionsv2): add value_mapper for shuttle_input

### DIFF
--- a/lib/arrow_web/components/replacement_service_section.ex
+++ b/lib/arrow_web/components/replacement_service_section.ex
@@ -28,7 +28,6 @@ defmodule ArrowWeb.ReplacementServiceSection do
       <%= if Ecto.assoc_loaded?(@disruption.replacement_services) and Enum.any?(@disruption.replacement_services) do %>
         <div
           :for={replacement_service <- @disruption.replacement_services}
-          id="replacement_services_list"
           class="container border-2 border-dashed border-secondary border-mb-3 pt-3 mb-3"
         >
           <div class="row">

--- a/lib/arrow_web/components/replacement_service_section.ex
+++ b/lib/arrow_web/components/replacement_service_section.ex
@@ -60,6 +60,7 @@ defmodule ArrowWeb.ReplacementServiceSection do
               <.button
                 class="btn-link btn-sm pl-0"
                 disabled={!is_nil(@form)}
+                id={"edit_replacement_service-#{replacement_service.id}"}
                 type="button"
                 phx-click="edit_replacement_service"
                 phx-value-replacement_service={replacement_service.id}

--- a/lib/arrow_web/components/shuttle_input.ex
+++ b/lib/arrow_web/components/shuttle_input.ex
@@ -4,11 +4,11 @@ defmodule ArrowWeb.ShuttleInput do
   shuttle autocomplete
   """
 
-  alias Phoenix.HTML.FormField
   use ArrowWeb, :live_component
 
   alias Arrow.Shuttles
   alias Arrow.Shuttles.Shuttle
+  alias Phoenix.HTML.FormField
 
   attr :id, :string, required: true
   attr :field, :any, required: true
@@ -57,6 +57,9 @@ defmodule ArrowWeb.ShuttleInput do
     {:noreply, socket}
   end
 
+  # This credo:disable can be removed once a new phoenix_html release is cut
+  # https://github.com/phoenixframework/phoenix_html/commit/1bea177dfb6d6e3e326ee60dab87175a6d92e88d
+  # credo:disable-for-next-line Credo.Check.Warning.SpecWithStruct
   @spec shuttle_value_mapper(String.t(), %FormField{}) ::
           {String.t(), integer() | String.t()}
   defp shuttle_value_mapper(text, field) do

--- a/lib/arrow_web/components/shuttle_input.ex
+++ b/lib/arrow_web/components/shuttle_input.ex
@@ -4,6 +4,7 @@ defmodule ArrowWeb.ShuttleInput do
   shuttle autocomplete
   """
 
+  alias Phoenix.HTML.FormField
   use ArrowWeb, :live_component
 
   alias Arrow.Shuttles
@@ -37,6 +38,7 @@ defmodule ArrowWeb.ShuttleInput do
         options={@options}
         placeholder="Search for a route…"
         update_min_len={0}
+        value_mapper={&shuttle_value_mapper(&1, assigns.field)}
       />
     </div>
     """
@@ -53,6 +55,23 @@ defmodule ArrowWeb.ShuttleInput do
     send_update(LiveSelect.Component, id: live_select_id, options: new_opts)
 
     {:noreply, socket}
+  end
+
+  @spec shuttle_value_mapper(String.t(), %FormField{}) ::
+          {String.t(), integer() | String.t()}
+  defp shuttle_value_mapper(text, field) do
+    shuttle =
+      case field.value do
+        nil -> nil
+        "" -> nil
+        shuttle_id -> Shuttles.get_shuttle!(shuttle_id)
+      end
+
+    if shuttle == nil do
+      {text, text}
+    else
+      option_for_shuttle(shuttle)
+    end
   end
 
   @spec option_for_shuttle(Shuttle.t()) :: {String.t(), integer()}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐛🏹 Shuttle input reverts to shuttle_id](https://app.asana.com/0/1205718273834959/1209370632856918)

This input is used in a form where it passes the value via `form[:shuttle_id]`

This fixes a bug where we display the form field value of `:shuttle_id` if the input value is reset

Reproduced on dev after selecting a new input value
<img width="985" alt="Screenshot 2025-02-10 at 2 54 32 PM" src="https://github.com/user-attachments/assets/31e55abc-90d0-4105-aded-6b0f34883a59">

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
