### PR TITLE
fix: fix clear button on live-selects by clearing option on focus

### DIFF
--- a/lib/arrow_web/components/core_components.ex
+++ b/lib/arrow_web/components/core_components.ex
@@ -425,6 +425,7 @@ defmodule ArrowWeb.CoreComponents do
   attr :allow_clear, :boolean
   attr :target, :any, default: nil
   attr :update_min_len, :integer
+  attr :"phx-focus", :string
 
   def live_select(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
     assigns =

--- a/lib/arrow_web/components/shuttle_input.ex
+++ b/lib/arrow_web/components/shuttle_input.ex
@@ -37,6 +37,7 @@ defmodule ArrowWeb.ShuttleInput do
         options={@options}
         placeholder="Search for a route…"
         update_min_len={0}
+        phx-focus="clear"
       />
     </div>
     """
@@ -51,6 +52,12 @@ defmodule ArrowWeb.ShuttleInput do
       end
 
     send_update(LiveSelect.Component, id: live_select_id, options: new_opts)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("clear", %{"id" => id}, socket) do
+    send_update(LiveSelect.Component, options: [], id: id)
 
     {:noreply, socket}
   end

--- a/lib/arrow_web/components/stop_input.ex
+++ b/lib/arrow_web/components/stop_input.ex
@@ -40,6 +40,7 @@ defmodule ArrowWeb.StopInput do
         target={@myself}
         options={@options}
         value_mapper={&stop_value_mapper(&1, assigns.field)}
+        phx-focus="clear"
       />
     </div>
     """
@@ -73,6 +74,12 @@ defmodule ArrowWeb.StopInput do
       end
 
     send_update(LiveSelect.Component, id: live_select_id, options: new_opts)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("clear", %{"id" => id}, socket) do
+    send_update(LiveSelect.Component, options: [], id: id)
 
     {:noreply, socket}
   end

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -98,6 +98,7 @@ defmodule ArrowWeb.ShuttleViewLive do
                   options={shape_options_mapper(@shapes)}
                   value_mapper={&shape_value_mapper/1}
                   allow_clear={true}
+                  phx-focus="live_select_clear"
                 />
               </div>
             </div>
@@ -366,6 +367,12 @@ defmodule ArrowWeb.ShuttleViewLive do
       |> Enum.map(&shape_option_mapper/1)
 
     send_update(LiveSelect.Component, id: live_select_id, options: shapes)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("live_select_clear", %{"id" => id}, socket) do
+    send_update(LiveSelect.Component, options: [], id: id)
 
     {:noreply, socket}
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket, need to confirm desired behavior

Clear options on focus
* Clear button on input will now clear the previous search terms (i.e. user typed "Ale" and chose a value, it no longer shows filtering by "Ale" until they type a new value)

In draft for now

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
