### PR TITLE
feat: v2 Calendar View

### DIFF
--- a/lib/arrow/disruptions/disruption_v2.ex
+++ b/lib/arrow/disruptions/disruption_v2.ex
@@ -52,4 +52,15 @@ defmodule Arrow.Disruptions.DisruptionV2 do
     %__MODULE__{limits: [], replacement_services: []}
     |> struct!(attrs)
   end
+
+  @spec route(String.t()) :: atom() | nil
+  def route("Blue"), do: :blue_line
+  def route("Orange"), do: :orange_line
+  def route("Red"), do: :red_line
+  def route("Mattapan"), do: :mattapan_line
+  def route("Green-B"), do: :green_line_b
+  def route("Green-C"), do: :green_line_c
+  def route("Green-D"), do: :green_line_d
+  def route("Green-E"), do: :green_line_e
+  def route(_), do: nil
 end

--- a/lib/arrow/disruptions/limit.ex
+++ b/lib/arrow/disruptions/limit.ex
@@ -94,14 +94,4 @@ defmodule Arrow.Disruptions.Limit do
   def display_label(%__MODULE__{start_stop: start_stop, end_stop: end_stop}) do
     "#{start_stop.name} to #{end_stop.name}"
   end
-
-  @spec route(t()) :: atom()
-  def route(%__MODULE__{route_id: "Blue"}), do: :blue_line
-  def route(%__MODULE__{route_id: "Orange"}), do: :orange_line
-  def route(%__MODULE__{route_id: "Red"}), do: :red_line
-  def route(%__MODULE__{route_id: "Mattapan"}), do: :mattapan_line
-  def route(%__MODULE__{route_id: "Green-B"}), do: :green_line_b
-  def route(%__MODULE__{route_id: "Green-C"}), do: :green_line_c
-  def route(%__MODULE__{route_id: "Green-D"}), do: :green_line_d
-  def route(%__MODULE__{route_id: "Green-E"}), do: :green_line_e
 end

--- a/lib/arrow/disruptions/limit.ex
+++ b/lib/arrow/disruptions/limit.ex
@@ -90,8 +90,4 @@ defmodule Arrow.Disruptions.Limit do
     %__MODULE__{limit_day_of_weeks: @default_day_of_weeks_list}
     |> struct!(attrs)
   end
-
-  def display_label(%__MODULE__{start_stop: start_stop, end_stop: end_stop}) do
-    "#{start_stop.name} to #{end_stop.name}"
-  end
 end

--- a/lib/arrow/disruptions/limit.ex
+++ b/lib/arrow/disruptions/limit.ex
@@ -90,4 +90,18 @@ defmodule Arrow.Disruptions.Limit do
     %__MODULE__{limit_day_of_weeks: @default_day_of_weeks_list}
     |> struct!(attrs)
   end
+
+  def display_label(%__MODULE__{start_stop: start_stop, end_stop: end_stop}) do
+    "#{start_stop.name} to #{end_stop.name}"
+  end
+
+  @spec route(t()) :: atom()
+  def route(%__MODULE__{route_id: "Blue"}), do: :blue_line
+  def route(%__MODULE__{route_id: "Orange"}), do: :orange_line
+  def route(%__MODULE__{route_id: "Red"}), do: :red_line
+  def route(%__MODULE__{route_id: "Mattapan"}), do: :mattapan_line
+  def route(%__MODULE__{route_id: "Green-B"}), do: :green_line_b
+  def route(%__MODULE__{route_id: "Green-C"}), do: :green_line_c
+  def route(%__MODULE__{route_id: "Green-D"}), do: :green_line_d
+  def route(%__MODULE__{route_id: "Green-E"}), do: :green_line_e
 end

--- a/lib/arrow/limits/limit_day_of_week.ex
+++ b/lib/arrow/limits/limit_day_of_week.ex
@@ -93,4 +93,13 @@ defmodule Arrow.Limits.LimitDayOfWeek do
 
     dt
   end
+
+  @spec day_number(t()) :: 1 | 2 | 3 | 4 | 5 | 6 | 7
+  def day_number(%{day_name: :monday}), do: 1
+  def day_number(%{day_name: :tuesday}), do: 2
+  def day_number(%{day_name: :wednesday}), do: 3
+  def day_number(%{day_name: :thursday}), do: 4
+  def day_number(%{day_name: :friday}), do: 5
+  def day_number(%{day_name: :saturday}), do: 6
+  def day_number(%{day_name: :sunday}), do: 7
 end

--- a/lib/arrow/limits/limit_day_of_week.ex
+++ b/lib/arrow/limits/limit_day_of_week.ex
@@ -12,7 +12,7 @@ defmodule Arrow.Limits.LimitDayOfWeek do
                    )
 
   @type t :: %__MODULE__{
-          day_name: integer(),
+          day_name: atom(),
           start_time: String.t() | nil,
           end_time: String.t() | nil,
           active?: boolean(),

--- a/lib/arrow_web/controllers/disruption_v2_controller.ex
+++ b/lib/arrow_web/controllers/disruption_v2_controller.ex
@@ -2,16 +2,20 @@ defmodule ArrowWeb.DisruptionV2Controller do
   use ArrowWeb, :controller
 
   alias Arrow.Disruptions
+  alias ArrowWeb.DisruptionV2Controller.Filters
   alias ArrowWeb.Plug.Authorize
   alias Plug.Conn
 
   plug(Authorize, :view_disruption when action == :index)
 
   @spec index(Conn.t(), Conn.params()) :: Conn.t()
-  def index(conn, _params) do
+  def index(conn, params) do
+    filters = Filters.from_params(params)
+
     render(conn, "index.html",
       user: conn.assigns.current_user,
-      disruptions: Disruptions.list_disruptionsv2()
+      disruptions: Disruptions.list_disruptionsv2(),
+      filters: filters
     )
   end
 end

--- a/lib/arrow_web/controllers/disruption_v2_controller/filters.ex
+++ b/lib/arrow_web/controllers/disruption_v2_controller/filters.ex
@@ -1,0 +1,75 @@
+defmodule ArrowWeb.DisruptionV2Controller.Filters do
+  @moduledoc """
+  Handles parsing, encoding, and updating the filters that can be applied to the disruptions
+  index. For the purposes of this module, all parameters that are part of the "state" of the
+  index (including e.g. sorting, in the table view) are considered filters.
+  """
+
+  alias __MODULE__.{Calendar, Table}
+  import __MODULE__.Helpers
+
+  @empty_set MapSet.new()
+
+  defmodule Behaviour do
+    @moduledoc "Required behaviour for `Filters` sub-modules."
+    @callback from_params(Plug.Conn.params()) :: struct
+    @callback resettable?(struct) :: boolean
+    @callback reset(struct) :: struct
+    @callback to_params(struct) :: Plug.Conn.params()
+  end
+
+  @behaviour Behaviour
+
+  @type t :: %__MODULE__{view: Calendar.t() | Table.t()}
+
+  defstruct kinds: @empty_set, only_approved?: false, search: nil, view: %Table{}
+
+  @spec calendar?(%__MODULE__{}) :: boolean
+  def calendar?(%__MODULE__{view: %Calendar{}}), do: true
+  def calendar?(%__MODULE__{view: %Table{}}), do: false
+
+  @spec flatten(%__MODULE__{}) :: %{atom => any}
+  def flatten(%__MODULE__{view: view} = filters) do
+    filters |> Map.from_struct() |> Map.delete(:view) |> Map.merge(Map.from_struct(view))
+  end
+
+  @impl true
+  def from_params(params) when is_map(params) do
+    view_mod = if(params["view"] == "calendar", do: Calendar, else: Table)
+
+    %__MODULE__{view: view_mod.from_params(params)}
+  end
+
+  @impl true
+  def resettable?(%__MODULE__{view: %{__struct__: view_mod} = view} = filters) do
+    %{filters | view: nil} != %__MODULE__{view: nil} or view_mod.resettable?(view)
+  end
+
+  @impl true
+  def reset(%__MODULE__{view: %{__struct__: view_mod} = view}) do
+    %__MODULE__{view: view_mod.reset(view)}
+  end
+
+  @spec toggle_view(%__MODULE__{}) :: %__MODULE__{}
+  def toggle_view(%__MODULE__{view: %Calendar{}} = filters), do: %{filters | view: %Table{}}
+  def toggle_view(%__MODULE__{view: %Table{}} = filters), do: %{filters | view: %Calendar{}}
+
+  @impl true
+  def to_params(%__MODULE__{
+        view: %{__struct__: view_mod} = view
+      }) do
+    %{}
+    |> put_if(view_mod == Calendar, "view", "calendar")
+    |> Map.merge(view_mod.to_params(view))
+  end
+
+  @spec to_flat_params(%__MODULE__{}) :: [{String.t(), String.t()}]
+  def to_flat_params(%__MODULE__{} = filters) do
+    filters
+    |> to_params()
+    |> Enum.flat_map(fn
+      {key, value} when is_list(value) -> Enum.map(value, &{"#{key}[]", &1})
+      {key, value} -> [{key, value}]
+    end)
+  end
+end

--- a/lib/arrow_web/controllers/disruption_v2_controller/filters/calendar.ex
+++ b/lib/arrow_web/controllers/disruption_v2_controller/filters/calendar.ex
@@ -1,0 +1,14 @@
+defmodule ArrowWeb.DisruptionV2Controller.Filters.Calendar do
+  @moduledoc "Handles filters unique to the calendar view (currently none)."
+
+  @behaviour ArrowWeb.DisruptionController.Filters.Behaviour
+
+  @type t :: %__MODULE__{}
+
+  defstruct []
+
+  def from_params(_), do: %__MODULE__{}
+  def resettable?(_), do: false
+  def reset(calendar), do: calendar
+  def to_params(_), do: %{}
+end

--- a/lib/arrow_web/controllers/disruption_v2_controller/filters/helpers.ex
+++ b/lib/arrow_web/controllers/disruption_v2_controller/filters/helpers.ex
@@ -1,0 +1,7 @@
+defmodule ArrowWeb.DisruptionV2Controller.Filters.Helpers do
+  @moduledoc "Functions shared by the `Filters` modules."
+
+  @spec put_if(map, boolean, any, any) :: map
+  def put_if(map, true, key, value), do: Map.put(map, key, value)
+  def put_if(map, false, _, _), do: map
+end

--- a/lib/arrow_web/controllers/disruption_v2_controller/filters/table.ex
+++ b/lib/arrow_web/controllers/disruption_v2_controller/filters/table.ex
@@ -1,0 +1,35 @@
+defmodule ArrowWeb.DisruptionV2Controller.Filters.Table do
+  @moduledoc "Handles filters unique to the table view."
+
+  import ArrowWeb.DisruptionController.Filters.Helpers
+
+  @type sort :: :id | :start_date
+  @type t :: %__MODULE__{include_past?: boolean, sort: {:asc | :desc, sort}}
+
+  defstruct include_past?: false, sort: {:asc, :start_date}
+
+  def from_params(params) when is_map(params) do
+    %__MODULE__{
+      include_past?: not is_nil(params["include_past"]),
+      sort: parse_sort(params["sort"])
+    }
+  end
+
+  def resettable?(%__MODULE__{include_past?: true}), do: true
+  def resettable?(_), do: false
+
+  def reset(%__MODULE__{} = table), do: %{table | include_past?: false}
+
+  def to_params(%__MODULE__{include_past?: include_past, sort: sort}) do
+    %{}
+    |> put_if(include_past, "include_past", "true")
+    |> put_if(sort != %__MODULE__{}.sort, "sort", encode_sort(sort))
+  end
+
+  defp encode_sort({:asc, field}), do: to_string(field)
+  defp encode_sort({:desc, field}), do: "-" <> to_string(field)
+
+  defp parse_sort(nil), do: %__MODULE__{}.sort
+  defp parse_sort("-" <> sort), do: {:desc, String.to_existing_atom(sort)}
+  defp parse_sort(sort), do: {:asc, String.to_existing_atom(sort)}
+end

--- a/lib/arrow_web/controllers/disruption_v2_html.ex
+++ b/lib/arrow_web/controllers/disruption_v2_html.ex
@@ -1,9 +1,9 @@
 defmodule ArrowWeb.DisruptionV2View do
   use ArrowWeb, :html
 
+  alias __MODULE__.Calendar, as: DCalendar
   alias Arrow.Disruptions.DisruptionV2
   alias Arrow.Permissions
-  alias __MODULE__.Calendar, as: DCalendar
   alias ArrowWeb.DisruptionV2Controller.Filters
   alias Phoenix.Controller
 

--- a/lib/arrow_web/controllers/disruption_v2_html.ex
+++ b/lib/arrow_web/controllers/disruption_v2_html.ex
@@ -3,6 +3,8 @@ defmodule ArrowWeb.DisruptionV2View do
 
   alias Arrow.Disruptions.DisruptionV2
   alias Arrow.Permissions
+  alias __MODULE__.Calendar, as: DCalendar
+  alias ArrowWeb.DisruptionV2Controller.Filters
   alias Phoenix.Controller
 
   embed_templates "disruption_v2_html/*"
@@ -66,5 +68,9 @@ defmodule ArrowWeb.DisruptionV2View do
 
   defp format_date(date) do
     Calendar.strftime(date, "%m/%d/%y")
+  end
+
+  defp update_filters_path(conn, filters) do
+    Controller.current_path(conn, Filters.to_params(filters))
   end
 end

--- a/lib/arrow_web/controllers/disruption_v2_html/calendar.ex
+++ b/lib/arrow_web/controllers/disruption_v2_html/calendar.ex
@@ -1,0 +1,89 @@
+defmodule ArrowWeb.DisruptionV2View.Calendar do
+  @moduledoc "An interface between Ecto structs and the `DisruptionCalendar` React component."
+
+  alias Arrow.Disruptions.{DisruptionV2, Limit}
+  alias Arrow.Limits.LimitDayOfWeek
+  alias ArrowWeb.Endpoint
+  alias ArrowWeb.Router.Helpers, as: Routes
+
+  @doc """
+  Generates props for `DisruptionCalendar`, which has the same interface as `FullCalendar`.
+  Reference: https://fullcalendar.io/docs/event-parsing
+  """
+  @spec props([DisruptionV2.t()]) :: %{atom => any}
+  def props(disruptions), do: %{events: events(disruptions)}
+
+  defp events(disruptions) when is_list(disruptions) do
+    Enum.flat_map(disruptions, &events/1)
+  end
+
+  defp events(%DisruptionV2{id: id, limits: [limit], is_active: is_active}) do
+    events(id, limit, "(disruption #{id})", is_active)
+  end
+
+  defp events(%DisruptionV2{id: id, limits: limits, is_active: is_active}) do
+    Enum.flat_map(limits, fn limit ->
+      events(id, limit, Limit.display_label(limit), is_active)
+    end)
+  end
+
+  defp events(
+         disruption_id,
+         %Limit{
+           start_date: start_date,
+           end_date: end_date,
+           limit_day_of_weeks: day_of_weeks
+         } = limit,
+         event_title,
+         is_active
+       ) do
+    day_numbers =
+      day_of_weeks
+      |> Enum.filter(& &1.active?)
+      |> MapSet.new(&LimitDayOfWeek.day_number/1)
+
+    Date.range(start_date, end_date)
+    |> Enum.filter(&(Date.day_of_week(&1) in day_numbers))
+    |> Enum.chunk_while([], &chunk_dates/2, &chunk_dates/1)
+    |> Enum.map(&{List.last(&1), List.first(&1)})
+    |> Enum.map(fn
+      {nil, nil} ->
+        %{}
+
+      {event_start, event_end} ->
+        route = Limit.route(limit)
+
+        %{
+          title: event_title,
+          classNames: "kind-#{route_class(route)} status-#{status_class(is_active)}",
+          start: event_start,
+          # end date is treated as exclusive
+          end: Date.add(event_end, 1),
+          url: Routes.disruption_v2_view_path(Endpoint, :edit, disruption_id),
+          extendedProps: %{
+            statusOrder: if(is_active, do: 0, else: 1)
+          }
+        }
+    end)
+  end
+
+  # Starting a new chunk
+  defp chunk_dates(date, []), do: {:cont, [date]}
+
+  # Determine whether a date should be added to the current chunk or start a new one
+  defp chunk_dates(date, [prev | _] = dates) do
+    if Date.diff(date, prev) == 1 do
+      {:cont, [date | dates]}
+    else
+      {:cont, dates, [date]}
+    end
+  end
+
+  # Receives the leftover accumulator at the end, which is the last chunk, so emit it
+  defp chunk_dates(dates), do: {:cont, dates, []}
+
+  defp route_class(route), do: route |> to_string() |> String.replace("_", "-")
+
+  defp status_class(true), do: "approved"
+  defp status_class(false), do: "pending"
+end

--- a/lib/arrow_web/controllers/disruption_v2_html/calendar.ex
+++ b/lib/arrow_web/controllers/disruption_v2_html/calendar.ex
@@ -1,8 +1,9 @@
 defmodule ArrowWeb.DisruptionV2View.Calendar do
   @moduledoc "An interface between Ecto structs and the `DisruptionCalendar` React component."
 
-  alias Arrow.Disruptions.{DisruptionV2, Limit}
+  alias Arrow.Disruptions.{DisruptionV2, Limit, ReplacementService}
   alias Arrow.Limits.LimitDayOfWeek
+  alias Arrow.Shuttles.Shuttle
   alias ArrowWeb.Endpoint
   alias ArrowWeb.Router.Helpers, as: Routes
 
@@ -17,14 +18,32 @@ defmodule ArrowWeb.DisruptionV2View.Calendar do
     Enum.flat_map(disruptions, &events/1)
   end
 
-  defp events(%DisruptionV2{id: id, limits: [limit], is_active: is_active}) do
+  defp events(%DisruptionV2{
+         id: id,
+         limits: [limit],
+         replacement_services: [],
+         is_active: is_active
+       }) do
     events(id, limit, "(disruption #{id})", is_active)
   end
 
-  defp events(%DisruptionV2{id: id, limits: limits, is_active: is_active}) do
-    Enum.flat_map(limits, fn limit ->
-      events(id, limit, Limit.display_label(limit), is_active)
-    end)
+  defp events(%DisruptionV2{
+         id: id,
+         limits: [],
+         replacement_services: [replacement_service],
+         is_active: is_active
+       }) do
+    events(id, replacement_service, "(disruption #{id})", is_active)
+  end
+
+  defp events(%DisruptionV2{
+         id: id,
+         limits: limits,
+         replacement_services: replacement_services,
+         is_active: is_active
+       }) do
+    Enum.flat_map(limits, &events(id, &1, Limit.display_label(&1), is_active)) ++
+      Enum.flat_map(replacement_services, &events(id, &1, &1.shuttle.shuttle_name, is_active))
   end
 
   defp events(
@@ -32,8 +51,9 @@ defmodule ArrowWeb.DisruptionV2View.Calendar do
          %Limit{
            start_date: start_date,
            end_date: end_date,
-           limit_day_of_weeks: day_of_weeks
-         } = limit,
+           limit_day_of_weeks: day_of_weeks,
+           route_id: route_id
+         },
          event_title,
          is_active
        ) do
@@ -51,11 +71,38 @@ defmodule ArrowWeb.DisruptionV2View.Calendar do
         %{}
 
       {event_start, event_end} ->
-        route = Limit.route(limit)
-
         %{
           title: event_title,
-          classNames: "kind-#{route_class(route)} status-#{status_class(is_active)}",
+          classNames: "kind-#{route_class(route_id)} status-#{status_class(is_active)}",
+          start: event_start,
+          # end date is treated as exclusive
+          end: Date.add(event_end, 1),
+          url: Routes.disruption_v2_view_path(Endpoint, :edit, disruption_id),
+          extendedProps: %{
+            statusOrder: if(is_active, do: 0, else: 1)
+          }
+        }
+    end)
+  end
+
+  defp events(
+         disruption_id,
+         %ReplacementService{
+           start_date: start_date,
+           end_date: end_date,
+           shuttle: %Shuttle{disrupted_route_id: route_id}
+         },
+         event_title,
+         is_active
+       ) do
+    Date.range(start_date, end_date)
+    |> Enum.chunk_while([], &chunk_dates/2, &chunk_dates/1)
+    |> Enum.map(&{List.last(&1), List.first(&1)})
+    |> Enum.map(fn
+      {event_start, event_end} ->
+        %{
+          title: event_title,
+          classNames: "kind-#{route_class(route_id)} status-#{status_class(is_active)}",
           start: event_start,
           # end date is treated as exclusive
           end: Date.add(event_end, 1),
@@ -82,7 +129,10 @@ defmodule ArrowWeb.DisruptionV2View.Calendar do
   # Receives the leftover accumulator at the end, which is the last chunk, so emit it
   defp chunk_dates(dates), do: {:cont, dates, []}
 
-  defp route_class(route), do: route |> to_string() |> String.replace("_", "-")
+  defp route_class(nil), do: "none"
+
+  defp route_class(route_id),
+    do: route_id |> DisruptionV2.route() |> to_string() |> String.replace("_", "-")
 
   defp status_class(true), do: "approved"
   defp status_class(false), do: "pending"

--- a/lib/arrow_web/controllers/disruption_v2_html/calendar.ex
+++ b/lib/arrow_web/controllers/disruption_v2_html/calendar.ex
@@ -18,32 +18,17 @@ defmodule ArrowWeb.DisruptionV2View.Calendar do
     Enum.flat_map(disruptions, &events/1)
   end
 
-  defp events(%DisruptionV2{
-         id: id,
-         limits: [limit],
-         replacement_services: [],
-         is_active: is_active
-       }) do
-    events(id, limit, "(disruption #{id})", is_active)
-  end
+  defp events(%DisruptionV2{limits: [], replacement_services: []}), do: []
 
   defp events(%DisruptionV2{
          id: id,
-         limits: [],
-         replacement_services: [replacement_service],
-         is_active: is_active
-       }) do
-    events(id, replacement_service, "(disruption #{id})", is_active)
-  end
-
-  defp events(%DisruptionV2{
-         id: id,
+         title: title,
          limits: limits,
          replacement_services: replacement_services,
          is_active: is_active
        }) do
-    Enum.flat_map(limits, &events(id, &1, Limit.display_label(&1), is_active)) ++
-      Enum.flat_map(replacement_services, &events(id, &1, &1.shuttle.shuttle_name, is_active))
+    Enum.flat_map(limits, &events(id, &1, title, is_active)) ++
+      Enum.flat_map(replacement_services, &events(id, &1, title, is_active))
   end
 
   defp events(

--- a/lib/arrow_web/controllers/disruption_v2_html/index.html.heex
+++ b/lib/arrow_web/controllers/disruption_v2_html/index.html.heex
@@ -1,6 +1,6 @@
 <div class="row my-3">
   <.navbar
-    page={Controller.current_path(@conn)}
+    page={Controller.current_path(@conn, %{})}
     create_disruption_permission?={Permissions.authorize?(:create_disruption, @user)}
   />
   <%= form_tag(Controller.current_path(@conn), method: "get", class: "col-3") do %>
@@ -14,8 +14,23 @@
   <% end %>
 </div>
 
+<div class="row my-3">
+  <div class="col">
+    {link("⬒ #{if(Filters.calendar?(@filters), do: "list", else: "calendar")} view",
+      class: "ml-auto btn btn-outline-secondary",
+      to: update_filters_path(@conn, Filters.toggle_view(@filters))
+    )}
+  </div>
+</div>
+
 <div class="row">
   <div class="col">
-    <._table conn={@conn} disruptions={@disruptions} />
+    <%= if Filters.calendar?(@filters) do %>
+      <div class="my-3">
+        {react_component("Components.DisruptionCalendar", DCalendar.props(@disruptions))}
+      </div>
+    <% else %>
+      <._table conn={@conn} disruptions={@disruptions} />
+    <% end %>
   </div>
 </div>

--- a/test/arrow_web/views/disruption_v2_view/calendar_test.exs
+++ b/test/arrow_web/views/disruption_v2_view/calendar_test.exs
@@ -1,0 +1,95 @@
+defmodule ArrowWeb.DisruptionV2View.CalendarTest do
+  use ExUnit.Case, async: true
+
+  alias Arrow.Disruptions.{DisruptionV2, Limit, ReplacementService}
+  alias Arrow.Limits.LimitDayOfWeek
+  alias Arrow.Shuttles.Shuttle
+  alias ArrowWeb.DisruptionV2View.Calendar, as: DCalendar
+
+  describe "props/1" do
+    test "converts a list of Disruptions to DisruptionCalendar props" do
+      disruption = %DisruptionV2{
+        id: 123,
+        title: "Disruption Title",
+        limits: [
+          %Limit{
+            start_date: ~D[2021-01-01],
+            end_date: ~D[2021-01-31],
+            route_id: "Red",
+            limit_day_of_weeks: [
+              %LimitDayOfWeek{
+                day_name: :monday,
+                start_time: ~T[20:45:00],
+                end_time: nil,
+                active?: true
+              },
+              %LimitDayOfWeek{
+                day_name: :tuesday,
+                start_time: ~T[20:45:00],
+                end_time: nil,
+                active?: true
+              }
+            ]
+          }
+        ],
+        replacement_services: [
+          %ReplacementService{
+            start_date: ~D[2021-02-01],
+            end_date: ~D[2021-02-28],
+            shuttle: %Shuttle{disrupted_route_id: "Blue"}
+          }
+        ],
+        is_active: true
+      }
+
+      expected_events = [
+        %{
+          title: "Disruption Title",
+          classNames: "kind-red-line status-approved",
+          start: ~D[2021-01-04],
+          end: ~D[2021-01-06],
+          url: "/disruptionsv2/123/edit",
+          extendedProps: %{statusOrder: 0}
+        },
+        %{
+          title: "Disruption Title",
+          classNames: "kind-red-line status-approved",
+          start: ~D[2021-01-11],
+          end: ~D[2021-01-13],
+          url: "/disruptionsv2/123/edit",
+          extendedProps: %{statusOrder: 0}
+        },
+        %{
+          title: "Disruption Title",
+          classNames: "kind-red-line status-approved",
+          start: ~D[2021-01-18],
+          end: ~D[2021-01-20],
+          url: "/disruptionsv2/123/edit",
+          extendedProps: %{statusOrder: 0}
+        },
+        %{
+          title: "Disruption Title",
+          classNames: "kind-red-line status-approved",
+          start: ~D[2021-01-25],
+          end: ~D[2021-01-27],
+          url: "/disruptionsv2/123/edit",
+          extendedProps: %{statusOrder: 0}
+        },
+        %{
+          title: "Disruption Title",
+          classNames: "kind-blue-line status-approved",
+          start: ~D[2021-02-01],
+          end: ~D[2021-03-01],
+          url: "/disruptionsv2/123/edit",
+          extendedProps: %{statusOrder: 0}
+        }
+      ]
+
+      assert DCalendar.props([disruption]) == %{events: expected_events}
+    end
+
+    test "returns no events when passed no disruptions" do
+      assert DCalendar.props([]) == %{events: []}
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Implement Arrow v2 calendar view](https://app.asana.com/0/584764604969369/1209170968037057)

Added the calendar view for v2 Arrow disruptions. The framework of the view was copied from v1. Had to massage the data a bit to make it work for limits/replace services. Decided to keep the `DisruptionCalendar` component piece of it because it was easier than building a new calendar from scratch.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
