### PR TITLE
tweak: Expose Shuttle shapes in API response

### DIFF
--- a/lib/arrow/disruptions/replacement_service.ex
+++ b/lib/arrow/disruptions/replacement_service.ex
@@ -228,7 +228,7 @@ defmodule Arrow.Disruptions.ReplacementService do
            [
              %{
                stop_id: route_stop.display_stop_id,
-               stop_time: current_stop_time
+               stop_time: "#{current_stop_time}:00"
              }
            ]}
       end)

--- a/lib/arrow/disruptions/replacement_service.ex
+++ b/lib/arrow/disruptions/replacement_service.ex
@@ -122,10 +122,10 @@ defmodule Arrow.Disruptions.ReplacementService do
   @spec schedule_service_types :: list(atom())
   def schedule_service_types, do: [:weekday, :saturday, :sunday]
 
-  def trips_with_times(
-        %__MODULE__{source_workbook_data: workbook_data} = replacement_service,
-        service_type_atom
-      ) do
+  defp trips_with_times(
+         %__MODULE__{source_workbook_data: workbook_data} = replacement_service,
+         service_type_atom
+       ) do
     service_type_abbreviation = Map.get(@service_type_to_workbook_abbreviation, service_type_atom)
 
     if day_of_week_data =
@@ -233,9 +233,7 @@ defmodule Arrow.Disruptions.ReplacementService do
            ]}
       end)
 
-    %{
-      stop_times: stop_times
-    }
+    stop_times
   end
 
   defp do_make_trip_start_times(

--- a/lib/arrow_web/controllers/api/shuttle_controller.ex
+++ b/lib/arrow_web/controllers/api/shuttle_controller.ex
@@ -13,9 +13,10 @@ defmodule ArrowWeb.API.ShuttleController do
         where: s.status == :active,
         join: r in assoc(s, :routes),
         join: rs in assoc(r, :route_stops),
+        join: sh in assoc(r, :shape),
         left_join: gs in assoc(rs, :gtfs_stop),
         left_join: st in assoc(rs, :stop),
-        preload: [routes: {r, route_stops: {rs, [:gtfs_stop, :stop]}}]
+        preload: [routes: {r, route_stops: {rs, [:gtfs_stop, :stop]}, shape: sh}]
       )
       |> Repo.all()
 

--- a/lib/arrow_web/controllers/api_html/shuttle_route_view.ex
+++ b/lib/arrow_web/controllers/api_html/shuttle_route_view.ex
@@ -2,9 +2,13 @@ defmodule ArrowWeb.API.ShuttleRouteView do
   use ArrowWeb, :html
   use JaSerializer.PhoenixView
 
-  attributes([:suffix, :destination, :direction_id, :direction_desc, :waypoint])
+  attributes([:suffix, :destination, :direction_id, :direction_desc, :waypoint, :shape_id])
 
   has_many :route_stops,
     serializer: ArrowWeb.API.ShuttleRouteStopView,
     include: true
+
+  def shape_id(route, _conn) do
+    route.shape.path |> String.split("/") |> List.last("") |> String.replace(".kml", "")
+  end
 end

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -86,7 +86,7 @@ defmodule ArrowWeb.Router do
   end
 
   scope "/api", as: :api, alias: ArrowWeb.API do
-    pipe_through([:redirect_prod_http, :json_api])
+    pipe_through([:redirect_prod_http, :json_api, :authenticate_api])
 
     get("/replacement-service", ReplacementServiceController, :index)
     get("/shuttles", ShuttleController, :index)

--- a/test/arrow_web/controllers/api/replacement_service_controller_test.exs
+++ b/test/arrow_web/controllers/api/replacement_service_controller_test.exs
@@ -68,15 +68,13 @@ defmodule ArrowWeb.API.ReplacementServiceControllerTest do
                        "sunday" => nil,
                        "weekday" => %{
                          "0" => [
-                           %{
-                             "stop_times" => [
-                               %{
-                                 "stop_id" => shuttle_route_stop_id,
-                                 "stop_time" => shuttle_stop_time
-                               }
-                               | _
-                             ]
-                           }
+                           [
+                             %{
+                               "stop_id" => shuttle_route_stop_id,
+                               "stop_time" => shuttle_stop_time
+                             }
+                             | _
+                           ]
                            | _
                          ],
                          "1" => _

--- a/test/arrow_web/controllers/api/shuttle_controller_test.exs
+++ b/test/arrow_web/controllers/api/shuttle_controller_test.exs
@@ -96,6 +96,8 @@ defmodule ArrowWeb.API.ShuttleControllerTest do
           route = route_map[id |> String.to_integer()]
           assert to_string(route.destination) == attributes["destination"]
           assert to_string(route.direction_id) == attributes["direction_id"]
+          # Will always be disabled in test because we don't actually upload shape files
+          assert "disabled" == attributes["shape_id"]
 
         %{"type" => "gtfs_stop", "attributes" => attributes, "id" => id} ->
           stop = stop_map[id]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** ad-hoc

While working on the GTFS work for replacement services, I realized I didn't have access to route shapes for shuttles. Added an attribute to the API response to expose this. `gtfs_creator` turns kml file names into shape_ids so I did some formatting of the shape `path` with that in mind.

A couple of other tweaks in here:
1. Added back an auth plug that I think was unintentionally removed.
2. Reduced some nesting in the replacement service API response.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
