### PR TITLE
feat: Limit time input masking

### DIFF
--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -45,11 +45,23 @@ const sortable = {
   },
 } as ViewHook
 
+const LimitTime = {
+  mounted() {
+    this.el.addEventListener("input", (_e) => {
+      let match = this.el.value.match(/^(\d{2})(\d{2})$/)
+      if (match) {
+        this.el.value = `${match[1]}:${match[2]}`
+      }
+    })
+  },
+} as ViewHook
+
 // https://github.com/fidr/phoenix_live_react
 const hooks = {
   LiveReact,
   sortable,
   ...live_select,
+  LimitTime,
 }
 
 const csrfToken = document

--- a/lib/arrow_web/components/limit_section.ex
+++ b/lib/arrow_web/components/limit_section.ex
@@ -159,6 +159,7 @@ defmodule ArrowWeb.LimitSection do
                     :if={normalize_value("checkbox", input_value(f_day_of_week, :active?))}
                     field={f_day_of_week[:start_time]}
                     disabled={normalize_value("checkbox", input_value(f_day_of_week, :all_day?))}
+                    phx-hook="LimitTime"
                   />
                 </div>
                 <div class="col col-lg-3">
@@ -166,6 +167,7 @@ defmodule ArrowWeb.LimitSection do
                     :if={normalize_value("checkbox", input_value(f_day_of_week, :active?))}
                     field={f_day_of_week[:end_time]}
                     disabled={normalize_value("checkbox", input_value(f_day_of_week, :all_day?))}
+                    phx-hook="LimitTime"
                   />
                 </div>
                 <div class="col">


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Implement time autocomplete/formatting in create/edit disruption pages](https://app.asana.com/0/584764604969369/1209292019824565)

Added input masks for limit times. If the input sees 4 consecutive integers, it updates the value with a `:` in the middle. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
