### PR TITLE
Don't allow draft shuttles as replacement service

### DIFF
--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -2,6 +2,10 @@ defmodule Arrow.Shuttles.Shuttle do
   @moduledoc "schema for a shuttle for the db"
   use Ecto.Schema
   import Ecto.Changeset
+  import Ecto.Query
+
+  alias Arrow.Disruptions.ReplacementService
+  alias Arrow.Repo
 
   @type id :: integer
   @type t :: %__MODULE__{
@@ -59,7 +63,24 @@ defmodule Arrow.Shuttles.Shuttle do
         end
 
       _ ->
-        changeset
+        id = get_field(changeset, :id)
+
+        replacement_services =
+          if is_nil(id) do
+            []
+          else
+            Repo.all(from r in ReplacementService, where: r.shuttle_id == ^id)
+          end
+
+        if length(replacement_services) > 0 do
+          add_error(
+            changeset,
+            :status,
+            "cannot set to a non-active status while in use as a replacement servie"
+          )
+        else
+          changeset
+        end
     end
   end
 

--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -76,7 +76,7 @@ defmodule Arrow.Shuttles.Shuttle do
           add_error(
             changeset,
             :status,
-            "cannot set to a non-active status while in use as a replacement servie"
+            "cannot set to a non-active status while in use as a replacement service"
           )
         else
           changeset

--- a/lib/arrow_web/components/core_components.ex
+++ b/lib/arrow_web/components/core_components.ex
@@ -511,6 +511,7 @@ defmodule ArrowWeb.CoreComponents do
   attr :field, :any, required: true, doc: "Field for `shuttle_id` value"
 
   attr :shuttle, :any, required: true, doc: "Currently selected shuttle, if any"
+  attr :only_approved?, :boolean, default: false
 
   attr :label, :string, default: "Stop ID"
   attr :class, :string, default: nil
@@ -527,6 +528,7 @@ defmodule ArrowWeb.CoreComponents do
       id={@id}
       field={@field}
       shuttle={@shuttle}
+      only_approved?={@only_approved?}
       class={@class}
     />
     """

--- a/lib/arrow_web/components/replacement_service_section.ex
+++ b/lib/arrow_web/components/replacement_service_section.ex
@@ -116,7 +116,11 @@ defmodule ArrowWeb.ReplacementServiceSection do
               do: "add new replacement service component",
               else: "edit disruption replacement service component"}
           </h4>
-          <.shuttle_input field={@form[:shuttle_id]} shuttle={input_value(@form, :shuttle)} />
+          <.shuttle_input
+            field={@form[:shuttle_id]}
+            shuttle={input_value(@form, :shuttle)}
+            only_approved?={true}
+          />
           <div :if={not empty_input_value?(@form[:shuttle_id].value)} class="row relative z-0">
             <div class="col p-0">
               {live_react_component(

--- a/lib/arrow_web/components/shuttle_input.ex
+++ b/lib/arrow_web/components/shuttle_input.ex
@@ -13,6 +13,7 @@ defmodule ArrowWeb.ShuttleInput do
   attr :id, :string, required: true
   attr :field, :any, required: true
   attr :shuttle, :any, required: true
+  attr :only_approved?, :boolean, default: false
   attr :label, :string, default: "select shuttle route"
   attr :class, :string, default: nil
 
@@ -22,7 +23,9 @@ defmodule ArrowWeb.ShuttleInput do
         assigns,
         :options,
         if is_nil(assigns.shuttle) || !Ecto.assoc_loaded?(assigns.shuttle) do
-          Shuttles.list_shuttles() |> Enum.map(&option_for_shuttle/1)
+          Shuttles.list_shuttles()
+          |> filter_only_approved(assigns.only_approved?)
+          |> Enum.map(&option_for_shuttle/1)
         else
           [option_for_shuttle(assigns.shuttle)]
         end
@@ -47,9 +50,14 @@ defmodule ArrowWeb.ShuttleInput do
   def handle_event("live_select_change", %{"id" => live_select_id, "text" => text}, socket) do
     new_opts =
       if String.length(text) == 0 do
-        Shuttles.list_shuttles() |> Enum.map(&option_for_shuttle/1)
+        Shuttles.list_shuttles()
+        |> filter_only_approved(socket.assigns.only_approved?)
+        |> Enum.map(&option_for_shuttle/1)
       else
-        text |> Shuttles.shuttles_by_search_string() |> Enum.map(&option_for_shuttle/1)
+        text
+        |> Shuttles.shuttles_by_search_string()
+        |> filter_only_approved(socket.assigns.only_approved?)
+        |> Enum.map(&option_for_shuttle/1)
       end
 
     send_update(LiveSelect.Component, id: live_select_id, options: new_opts)
@@ -80,5 +88,12 @@ defmodule ArrowWeb.ShuttleInput do
   @spec option_for_shuttle(Shuttle.t()) :: {String.t(), integer()}
   defp option_for_shuttle(%Shuttle{id: id, shuttle_name: shuttle_name}) do
     {shuttle_name, id}
+  end
+
+  @spec filter_only_approved([Shuttle.t()], boolean()) :: [Shuttle.t()]
+  defp filter_only_approved(shuttles, false), do: shuttles
+
+  defp filter_only_approved(shuttles, true) do
+    Enum.filter(shuttles, fn shuttle -> shuttle.status == :active end)
   end
 end

--- a/test/arrow/shuttle/shuttle_test.exs
+++ b/test/arrow/shuttle/shuttle_test.exs
@@ -178,7 +178,7 @@ defmodule Arrow.Shuttles.ShuttleTest do
                valid?: false,
                errors: [
                  status:
-                   {"cannot set to a non-active status while in use as a replacement servie", []}
+                   {"cannot set to a non-active status while in use as a replacement service", []}
                ]
              } = changeset
     end

--- a/test/arrow/shuttle/shuttle_test.exs
+++ b/test/arrow/shuttle/shuttle_test.exs
@@ -121,5 +121,119 @@ defmodule Arrow.Shuttles.ShuttleTest do
 
       assert %Ecto.Changeset{valid?: true} = changeset
     end
+
+    test "cannot mark a shuttle as inactive when in use by a replacement service" do
+      shuttle = shuttle_fixture()
+      [route0, route1] = shuttle.routes
+
+      [stop1, stop2, stop3, stop4] = insert_list(4, :gtfs_stop)
+
+      route0
+      |> Arrow.Shuttles.Route.changeset(%{
+        "route_stops" => [
+          %{
+            "direction_id" => "0",
+            "stop_sequence" => "1",
+            "display_stop_id" => stop1.id,
+            "time_to_next_stop" => 30.0
+          },
+          %{
+            "direction_id" => "0",
+            "stop_sequence" => "2",
+            "display_stop_id" => stop2.id
+          }
+        ]
+      })
+      |> Arrow.Repo.update()
+
+      route1
+      |> Arrow.Shuttles.Route.changeset(%{
+        "route_stops" => [
+          %{
+            "direction_id" => "1",
+            "stop_sequence" => "1",
+            "display_stop_id" => stop3.id,
+            "time_to_next_stop" => 30.0
+          },
+          %{
+            "direction_id" => "0",
+            "stop_sequence" => "2",
+            "display_stop_id" => stop4.id
+          }
+        ]
+      })
+      |> Arrow.Repo.update()
+
+      {:ok, shuttle} =
+        shuttle.id
+        |> Arrow.Shuttles.get_shuttle!()
+        |> Shuttle.changeset(%{status: :active})
+        |> Arrow.Repo.update()
+
+      insert(:replacement_service, shuttle: shuttle)
+
+      changeset = Shuttle.changeset(shuttle, %{status: :draft})
+
+      assert %Ecto.Changeset{
+               valid?: false,
+               errors: [
+                 status:
+                   {"cannot set to a non-active status while in use as a replacement servie", []}
+               ]
+             } = changeset
+    end
+
+    test "can mark a shuttle as inactive when not in use by a replacement service" do
+      shuttle = shuttle_fixture()
+      [route0, route1] = shuttle.routes
+
+      [stop1, stop2, stop3, stop4] = insert_list(4, :gtfs_stop)
+
+      route0
+      |> Arrow.Shuttles.Route.changeset(%{
+        "route_stops" => [
+          %{
+            "direction_id" => "0",
+            "stop_sequence" => "1",
+            "display_stop_id" => stop1.id,
+            "time_to_next_stop" => 30.0
+          },
+          %{
+            "direction_id" => "0",
+            "stop_sequence" => "2",
+            "display_stop_id" => stop2.id
+          }
+        ]
+      })
+      |> Arrow.Repo.update()
+
+      route1
+      |> Arrow.Shuttles.Route.changeset(%{
+        "route_stops" => [
+          %{
+            "direction_id" => "1",
+            "stop_sequence" => "1",
+            "display_stop_id" => stop3.id,
+            "time_to_next_stop" => 30.0
+          },
+          %{
+            "direction_id" => "0",
+            "stop_sequence" => "2",
+            "display_stop_id" => stop4.id
+          }
+        ]
+      })
+      |> Arrow.Repo.update()
+
+      {:ok, shuttle} =
+        shuttle.id
+        |> Arrow.Shuttles.get_shuttle!()
+        |> Shuttle.changeset(%{status: :active})
+        |> Arrow.Repo.update()
+
+      changeset = Shuttle.changeset(shuttle, %{status: :draft})
+
+      assert %Ecto.Changeset{valid?: true} = changeset
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹🐛 [extra] Arrow allows draft shuttles to be selected as replacement service](https://app.asana.com/0/584764604969369/1209486270766204)

Unfortunately I still don't see a great way of testing the LiveSelect behavior in unit tests, but I am open to suggestions and I have performed manual testing.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
