### PR TITLE
chore: Use recommended Endpoint config

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -14,17 +14,6 @@ config :arrow,
   shape_storage_enabled?: true,
   gtfs_archive_storage_enabled?: true
 
-config :arrow, :websocket_check_origin, [
-  "https://*.mbta.com",
-  "https://*.mbtace.com"
-]
-
-config :arrow, ArrowWeb.Endpoint,
-  http: [:inet6, port: 4000],
-  url: [host: "example.com", port: 80],
-  cache_static_manifest: "priv/static/cache_manifest.json",
-  server: true
-
 config :arrow, ArrowWeb.AuthManager, secret_key: {System, :get_env, ["ARROW_AUTH_SECRET"]}
 
 # Do not print debug messages in production

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -59,7 +59,12 @@ if config_env() == :prod do
       capture_log_messages: true
   end
 
-  config :arrow, ArrowWeb.Endpoint, secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
+  config :arrow, ArrowWeb.Endpoint,
+    http: [:inet6, port: System.get_env("PORT", "4000")],
+    url: [host: System.get_env("HOST"), port: 443, scheme: "https"],
+    cache_static_manifest: "priv/static/cache_manifest.json",
+    server: true,
+    secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
 
   pool_size =
     case System.get_env("DATABASE_POOL_SIZE") do

--- a/lib/arrow_web/endpoint.ex
+++ b/lib/arrow_web/endpoint.ex
@@ -9,18 +9,16 @@ defmodule ArrowWeb.Endpoint do
   @session_options [
     store: :cookie,
     key: "_arrow_key",
-    signing_salt: "35DDvOCJ"
+    signing_salt: "35DDvOCJ",
+    same_site: "Lax"
   ]
 
   socket "/socket", ArrowWeb.UserSocket,
-    websocket: [check_origin: Application.compile_env(:arrow, :websocket_check_origin, false)],
+    websocket: true,
     longpoll: false
 
   socket "/live", Phoenix.LiveView.Socket,
-    websocket: [
-      connect_info: [session: @session_options],
-      check_origin: Application.compile_env(:arrow, :websocket_check_origin, false)
-    ],
+    websocket: [connect_info: [session: @session_options]],
     longpoll: [connect_info: [session: @session_options]]
 
   # Serve at "/" the static files from "priv/static" directory.


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** ad-hoc

Something about socket connections in dev causes LiveView forms to break every once in a while. After some discussion in Slack, we aren't exactly configuring our `Endpoint` in the [recommended way](https://github.com/phoenixframework/phoenix/blob/487618b272d694388c323a676c2335cf7fa972e0/lib/phoenix/socket/transport.ex#L367).  Instead of setting `check_origin`, we should set `[url: [host: ...]]` correctly. I added `HOST` to the ENV of all Arrow environments. 

This branch is currently on dev and forms are working fine. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
