### PR TITLE
feat: HASTUS export form submission

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -41,7 +41,8 @@ config :arrow,
   hastus_export_storage_enabled?: false,
   hastus_export_storage_bucket: "mbta-arrow",
   hastus_export_storage_prefix: "hastus-export-uploads/",
-  hastus_export_storage_request_fn: {ExAws, :request}
+  hastus_export_storage_request_fn: {ExAws, :request},
+  use_username_prefix?: false
 
 # Addresses an issue with Oban
 # https://github.com/oban-bg/oban/issues/493#issuecomment-1187001822

--- a/config/config.exs
+++ b/config/config.exs
@@ -37,7 +37,11 @@ config :arrow,
   gtfs_archive_storage_enabled?: false,
   gtfs_archive_storage_bucket: "mbta-arrow",
   gtfs_archive_storage_prefix: "gtfs-archive-uploads/",
-  gtfs_archive_storage_request_fn: {ExAws, :request}
+  gtfs_archive_storage_request_fn: {ExAws, :request},
+  hastus_export_storage_enabled?: false,
+  hastus_export_storage_bucket: "mbta-arrow",
+  hastus_export_storage_prefix: "hastus-export-uploads/",
+  hastus_export_storage_request_fn: {ExAws, :request}
 
 # Addresses an issue with Oban
 # https://github.com/oban-bg/oban/issues/493#issuecomment-1187001822

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -81,7 +81,8 @@ config :arrow,
   gtfs_archive_storage_enabled?: true,
   gtfs_archive_storage_prefix_env: "dev/local/",
   hastus_export_storage_enabled?: true,
-  hastus_export_storage_prefix_env: "dev/local/"
+  hastus_export_storage_prefix_env: "dev/local/",
+  use_username_prefix?: true
 
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -79,7 +79,9 @@ config :arrow,
   shape_storage_enabled?: true,
   shape_storage_prefix_env: "dev/local/",
   gtfs_archive_storage_enabled?: true,
-  gtfs_archive_storage_prefix_env: "dev/local/"
+  gtfs_archive_storage_prefix_env: "dev/local/",
+  hastus_export_storage_enabled?: true,
+  hastus_export_storage_prefix_env: "dev/local/"
 
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,7 +12,8 @@ import Config
 
 config :arrow,
   shape_storage_enabled?: true,
-  gtfs_archive_storage_enabled?: true
+  gtfs_archive_storage_enabled?: true,
+  hastus_export_storage_enabled?: true
 
 config :arrow, :websocket_check_origin, [
   "https://*.mbta.com",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -82,5 +82,6 @@ if config_env() == :prod do
 
   config :arrow,
     shape_storage_prefix_env: System.get_env("S3_PREFIX"),
-    gtfs_archive_storage_prefix_env: System.get_env("S3_PREFIX")
+    gtfs_archive_storage_prefix_env: System.get_env("S3_PREFIX"),
+    hastus_export_storage_prefix_env: System.get_env("S3_PREFIX")
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,7 +4,9 @@ config :arrow,
   shape_storage_enabled?: false,
   shape_storage_request_fn: {Arrow.Mock.ExAws.Request, :request},
   gtfs_archive_storage_enabled?: false,
-  gtfs_archive_storage_request_fn: {Arrow.Mock.ExAws.Request, :request}
+  gtfs_archive_storage_request_fn: {Arrow.Mock.ExAws.Request, :request},
+  hastus_export_storage_enabled?: false,
+  hastus_export_storage_request_fn: {Arrow.Mock.ExAws.Request, :request}
 
 # Configure your database
 config :arrow, Arrow.Repo,

--- a/lib/arrow/disruptions/disruption_v2.ex
+++ b/lib/arrow/disruptions/disruption_v2.ex
@@ -35,6 +35,10 @@ defmodule Arrow.Disruptions.DisruptionV2 do
       foreign_key: :disruption_id,
       on_replace: :delete
 
+    has_many :hastus_exports, Arrow.Hastus.Export,
+      foreign_key: :disruption_id,
+      on_replace: :delete
+
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/arrow/hastus.ex
+++ b/lib/arrow/hastus.ex
@@ -6,6 +6,8 @@ defmodule Arrow.Hastus do
   import Ecto.Query, warn: false
   alias Arrow.Repo
 
+  @preloads [:line, :disruption, services: [:service_dates]]
+
   alias Arrow.Hastus.Export
 
   @doc """
@@ -18,7 +20,7 @@ defmodule Arrow.Hastus do
 
   """
   def list_exports do
-    Repo.all(Export)
+    Export |> Repo.all() |> Repo.preload(@preloads)
   end
 
   @doc """
@@ -35,7 +37,7 @@ defmodule Arrow.Hastus do
       ** (Ecto.NoResultsError)
 
   """
-  def get_export!(id), do: Repo.get!(Export, id)
+  def get_export!(id), do: Export |> Repo.get!(id) |> Repo.preload(@preloads)
 
   @doc """
   Creates a export.

--- a/lib/arrow/hastus.ex
+++ b/lib/arrow/hastus.ex
@@ -1,0 +1,296 @@
+defmodule Arrow.Hastus do
+  @moduledoc """
+  The Hastus context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Arrow.Repo
+
+  alias Arrow.Hastus.Export
+
+  @doc """
+  Returns the list of exports.
+
+  ## Examples
+
+      iex> list_exports()
+      [%Export{}, ...]
+
+  """
+  def list_exports do
+    Repo.all(Export)
+  end
+
+  @doc """
+  Gets a single export.
+
+  Raises `Ecto.NoResultsError` if the Export does not exist.
+
+  ## Examples
+
+      iex> get_export!(123)
+      %Export{}
+
+      iex> get_export!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_export!(id), do: Repo.get!(Export, id)
+
+  @doc """
+  Creates a export.
+
+  ## Examples
+
+      iex> create_export(%{field: value})
+      {:ok, %Export{}}
+
+      iex> create_export(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_export(attrs \\ %{}) do
+    %Export{}
+    |> Export.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a export.
+
+  ## Examples
+
+      iex> update_export(export, %{field: new_value})
+      {:ok, %Export{}}
+
+      iex> update_export(export, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_export(%Export{} = export, attrs) do
+    export
+    |> Export.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a export.
+
+  ## Examples
+
+      iex> delete_export(export)
+      {:ok, %Export{}}
+
+      iex> delete_export(export)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_export(%Export{} = export) do
+    Repo.delete(export)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking export changes.
+
+  ## Examples
+
+      iex> change_export(export)
+      %Ecto.Changeset{data: %Export{}}
+
+  """
+  def change_export(%Export{} = export, attrs \\ %{}) do
+    Export.changeset(export, attrs)
+  end
+
+  alias Arrow.Hastus.Service
+
+  @doc """
+  Returns the list of hastus_services.
+
+  ## Examples
+
+      iex> list_hastus_services()
+      [%Service{}, ...]
+
+  """
+  def list_hastus_services do
+    Repo.all(Service)
+  end
+
+  @doc """
+  Gets a single service.
+
+  Raises `Ecto.NoResultsError` if the Service does not exist.
+
+  ## Examples
+
+      iex> get_service!(123)
+      %Service{}
+
+      iex> get_service!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_service!(id), do: Repo.get!(Service, id)
+
+  @doc """
+  Creates a service.
+
+  ## Examples
+
+      iex> create_service(%{field: value})
+      {:ok, %Service{}}
+
+      iex> create_service(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_service(attrs \\ %{}) do
+    %Service{}
+    |> Service.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a service.
+
+  ## Examples
+
+      iex> update_service(service, %{field: new_value})
+      {:ok, %Service{}}
+
+      iex> update_service(service, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_service(%Service{} = service, attrs) do
+    service
+    |> Service.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a service.
+
+  ## Examples
+
+      iex> delete_service(service)
+      {:ok, %Service{}}
+
+      iex> delete_service(service)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_service(%Service{} = service) do
+    Repo.delete(service)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking service changes.
+
+  ## Examples
+
+      iex> change_service(service)
+      %Ecto.Changeset{data: %Service{}}
+
+  """
+  def change_service(%Service{} = service, attrs \\ %{}) do
+    Service.changeset(service, attrs)
+  end
+
+  alias Arrow.Hastus.ServiceDate
+
+  @doc """
+  Returns the list of hastus_service_dates.
+
+  ## Examples
+
+      iex> list_hastus_service_dates()
+      [%ServiceDate{}, ...]
+
+  """
+  def list_hastus_service_dates do
+    Repo.all(ServiceDate)
+  end
+
+  @doc """
+  Gets a single service_date.
+
+  Raises `Ecto.NoResultsError` if the Service date does not exist.
+
+  ## Examples
+
+      iex> get_service_date!(123)
+      %ServiceDate{}
+
+      iex> get_service_date!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_service_date!(id), do: Repo.get!(ServiceDate, id)
+
+  @doc """
+  Creates a service_date.
+
+  ## Examples
+
+      iex> create_service_date(%{field: value})
+      {:ok, %ServiceDate{}}
+
+      iex> create_service_date(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_service_date(attrs \\ %{}) do
+    %ServiceDate{}
+    |> ServiceDate.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a service_date.
+
+  ## Examples
+
+      iex> update_service_date(service_date, %{field: new_value})
+      {:ok, %ServiceDate{}}
+
+      iex> update_service_date(service_date, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_service_date(%ServiceDate{} = service_date, attrs) do
+    service_date
+    |> ServiceDate.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a service_date.
+
+  ## Examples
+
+      iex> delete_service_date(service_date)
+      {:ok, %ServiceDate{}}
+
+      iex> delete_service_date(service_date)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_service_date(%ServiceDate{} = service_date) do
+    Repo.delete(service_date)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking service_date changes.
+
+  ## Examples
+
+      iex> change_service_date(service_date)
+      %Ecto.Changeset{data: %ServiceDate{}}
+
+  """
+  def change_service_date(%ServiceDate{} = service_date, attrs \\ %{}) do
+    ServiceDate.changeset(service_date, attrs)
+  end
+end

--- a/lib/arrow/hastus/export.ex
+++ b/lib/arrow/hastus/export.ex
@@ -18,7 +18,7 @@ defmodule Arrow.Hastus.Export do
 
   schema "hastus_exports" do
     field :s3_path, :string
-    has_many :services, Arrow.Hastus.Service
+    has_many :services, Arrow.Hastus.Service, on_delete: :delete_all
     belongs_to :line, Arrow.Gtfs.Line, type: :string
     belongs_to :disruption, Arrow.Disruptions.DisruptionV2
 

--- a/lib/arrow/hastus/export.ex
+++ b/lib/arrow/hastus/export.ex
@@ -5,25 +5,31 @@ defmodule Arrow.Hastus.Export do
 
   import Ecto.Changeset
 
+  alias Arrow.Disruptions.DisruptionV2
   alias Arrow.Gtfs.Line
   alias Arrow.Hastus.Service
 
   @type t :: %__MODULE__{
-          source_export_filename: String.t(),
+          s3_path: String.t(),
           services: list(Service) | Ecto.Association.NotLoaded.t(),
-          line: Line.t() | Ecto.Association.NotLoaded.t()
+          line: Line.t() | Ecto.Association.NotLoaded.t(),
+          disruption: DisruptionV2.t() | Ecto.Association.NotLoaded.t()
         }
 
-  schema "hastus_export" do
-    field :source_export_filename, :string
+  schema "hastus_exports" do
+    field :s3_path, :string
     has_many :services, Arrow.Hastus.Service
-    belongs_to :line, Arrow.Gtfs.Line
+    belongs_to :line, Arrow.Gtfs.Line, type: :string
+    belongs_to :disruption, Arrow.Disruptions.DisruptionV2
+
+    timestamps(type: :utc_datetime)
   end
 
   @doc false
-  def changeset(hastus_export, attrs) do
-    hastus_export
-    |> cast(attrs, [:source_export_filename])
+  def changeset(export, attrs) do
+    export
+    |> cast(attrs, [:s3_path])
+    |> validate_required([:s3_path])
     |> cast_assoc(:services, with: &Service.changeset/2)
   end
 end

--- a/lib/arrow/hastus/export.ex
+++ b/lib/arrow/hastus/export.ex
@@ -30,7 +30,7 @@ defmodule Arrow.Hastus.Export do
     export
     |> cast(attrs, [:s3_path, :line_id, :disruption_id])
     |> validate_required([:s3_path])
-    |> cast_assoc(:services, with: &Service.changeset/2)
+    |> cast_assoc(:services, with: &Service.changeset/2, required: true)
     |> assoc_constraint(:line)
     |> assoc_constraint(:disruption)
   end

--- a/lib/arrow/hastus/export.ex
+++ b/lib/arrow/hastus/export.ex
@@ -28,8 +28,10 @@ defmodule Arrow.Hastus.Export do
   @doc false
   def changeset(export, attrs) do
     export
-    |> cast(attrs, [:s3_path])
+    |> cast(attrs, [:s3_path, :line_id, :disruption_id])
     |> validate_required([:s3_path])
     |> cast_assoc(:services, with: &Service.changeset/2)
+    |> assoc_constraint(:line)
+    |> assoc_constraint(:disruption)
   end
 end

--- a/lib/arrow/hastus/export_upload.ex
+++ b/lib/arrow/hastus/export_upload.ex
@@ -163,14 +163,14 @@ defmodule Arrow.Hastus.ExportUpload do
     do: Regex.run(~r/^(\d{4})(\d{2})(\d{2})/, date_string, capture: :all_but_first)
 
   defp add_or_update_list([], new_service_id, new_date),
-    do: [%{name: new_service_id, service_dates: [new_date]}]
+    do: [%{name: new_service_id, service_dates: [new_date], import?: true}]
 
   defp add_or_update_list(
          [h = %{service_id: service_id, service_dates: existing_dates} | t],
          service_id,
          new_date
        ),
-       do: [%{h | service_dates: existing_dates ++ [new_date]} | t]
+       do: [%{h | service_dates: existing_dates ++ [new_date], import?: true} | t]
 
   defp add_or_update_list([h | t], new_service_id, new_date),
     do: [h | add_or_update_list(t, new_service_id, new_date)]

--- a/lib/arrow/hastus/export_upload.ex
+++ b/lib/arrow/hastus/export_upload.ex
@@ -220,5 +220,8 @@ defmodule Arrow.Hastus.ExportUpload do
   defp add_or_update_list([h | t], new_service_id, new_date),
     do: [h | add_or_update_list(t, new_service_id, new_date)]
 
-  defp revenue_trip?(%{"route_id" => route_id}), do: Regex.match?(~r/^\d+_*-.+$/, route_id)
+  defp revenue_trip?(%{"route_id" => route_id, "trp_is_in_service" => "X"}),
+    do: Regex.match?(~r/^\d+_*-.+$/, route_id)
+
+  defp revenue_trip?(_), do: false
 end

--- a/lib/arrow/hastus/export_upload.ex
+++ b/lib/arrow/hastus/export_upload.ex
@@ -165,7 +165,7 @@ defmodule Arrow.Hastus.ExportUpload do
     do: Regex.run(~r/^(\d{4})(\d{2})(\d{2})/, date_string, capture: :all_but_first)
 
   defp add_or_update_list([], new_service_id, new_date),
-    do: [%Service{service_id: new_service_id, service_dates: [new_date]}]
+    do: [%Service{name: new_service_id, service_dates: [new_date]}]
 
   defp add_or_update_list(
          [h = %{service_id: service_id, service_dates: existing_dates} | t],

--- a/lib/arrow/hastus/export_upload.ex
+++ b/lib/arrow/hastus/export_upload.ex
@@ -5,8 +5,6 @@ defmodule Arrow.Hastus.ExportUpload do
 
   import Ecto.Query, only: [from: 2]
 
-  alias Arrow.Hastus.{Service, ServiceDate}
-
   require Logger
 
   @type error_message :: String.t()
@@ -137,7 +135,7 @@ defmodule Arrow.Hastus.ExportUpload do
           [start_year, start_month, start_day] = extract_date_parts(start_date_string)
           [end_year, end_month, end_day] = extract_date_parts(end_date_string)
 
-          date = %ServiceDate{
+          date = %{
             start_date: Date.from_iso8601!("#{start_year}-#{start_month}-#{start_day}"),
             end_date: Date.from_iso8601!("#{end_year}-#{end_month}-#{end_day}")
           }
@@ -148,7 +146,7 @@ defmodule Arrow.Hastus.ExportUpload do
         %{"service_id" => service_id, "date" => date_string}, acc ->
           [year, month, day] = extract_date_parts(date_string)
 
-          date = %ServiceDate{
+          date = %{
             start_date: Date.from_iso8601!("#{year}-#{month}-#{day}"),
             end_date: Date.from_iso8601!("#{year}-#{month}-#{day}")
           }
@@ -165,7 +163,7 @@ defmodule Arrow.Hastus.ExportUpload do
     do: Regex.run(~r/^(\d{4})(\d{2})(\d{2})/, date_string, capture: :all_but_first)
 
   defp add_or_update_list([], new_service_id, new_date),
-    do: [%Service{name: new_service_id, service_dates: [new_date]}]
+    do: [%{name: new_service_id, service_dates: [new_date]}]
 
   defp add_or_update_list(
          [h = %{service_id: service_id, service_dates: existing_dates} | t],

--- a/lib/arrow/hastus/service.ex
+++ b/lib/arrow/hastus/service.ex
@@ -16,7 +16,7 @@ defmodule Arrow.Hastus.Service do
   schema "hastus_services" do
     field :name, :string
     field :import?, :boolean, virtual: true
-    has_many :service_dates, Arrow.Hastus.ServiceDate
+    has_many :service_dates, Arrow.Hastus.ServiceDate, on_delete: :delete_all
     belongs_to :export, Arrow.Hastus.Service
 
     timestamps(type: :utc_datetime)

--- a/lib/arrow/hastus/service.ex
+++ b/lib/arrow/hastus/service.ex
@@ -7,23 +7,26 @@ defmodule Arrow.Hastus.Service do
   alias Arrow.Hastus.{Export, ServiceDate}
 
   @type t :: %__MODULE__{
-          service_id: String.t(),
+          name: String.t(),
           service_dates: list(ServiceDate) | Ecto.Association.NotLoaded.t(),
           import?: boolean(),
           export: Export.t() | Ecto.Association.NotLoaded.t()
         }
 
-  embedded_schema do
-    field :service_id, :string
+  schema "hastus_services" do
+    field :name, :string
     field :import?, :boolean, virtual: true
     has_many :service_dates, Arrow.Hastus.ServiceDate
     belongs_to :export, Arrow.Hastus.Service
+
+    timestamps(type: :utc_datetime)
   end
 
   @doc false
   def changeset(service, attrs) do
     service
-    |> cast(attrs, [:service_id])
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
     |> cast_assoc(:service_dates, with: &ServiceDate.changeset/2)
     |> assoc_constraint(:export)
   end

--- a/lib/arrow/hastus/service.ex
+++ b/lib/arrow/hastus/service.ex
@@ -25,7 +25,7 @@ defmodule Arrow.Hastus.Service do
   @doc false
   def changeset(service, attrs) do
     service
-    |> cast(attrs, [:name])
+    |> cast(attrs, [:name, :export_id])
     |> validate_required([:name])
     |> cast_assoc(:service_dates, with: &ServiceDate.changeset/2)
     |> assoc_constraint(:export)

--- a/lib/arrow/hastus/service_date.ex
+++ b/lib/arrow/hastus/service_date.ex
@@ -23,7 +23,7 @@ defmodule Arrow.Hastus.ServiceDate do
   @doc false
   def changeset(service_date, attrs) do
     service_date
-    |> cast(attrs, [:start_date, :end_date])
+    |> cast(attrs, [:start_date, :end_date, :service_id])
     |> validate_required([:start_date, :end_date])
     |> assoc_constraint(:service)
   end

--- a/lib/arrow/hastus/service_date.ex
+++ b/lib/arrow/hastus/service_date.ex
@@ -15,7 +15,7 @@ defmodule Arrow.Hastus.ServiceDate do
   schema "hastus_service_dates" do
     field :start_date, :date
     field :end_date, :date
-    belongs_to :service, Arrow.Hastus.Service
+    belongs_to :service, Arrow.Hastus.Service, on_replace: :delete
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/arrow/hastus/service_date.ex
+++ b/lib/arrow/hastus/service_date.ex
@@ -25,6 +25,24 @@ defmodule Arrow.Hastus.ServiceDate do
     service_date
     |> cast(attrs, [:start_date, :end_date, :service_id])
     |> validate_required([:start_date, :end_date])
+    |> validate_start_date_before_end_date()
     |> assoc_constraint(:service)
+  end
+
+  @spec validate_start_date_before_end_date(Ecto.Changeset.t(t())) :: Ecto.Changeset.t(t())
+  defp validate_start_date_before_end_date(changeset) do
+    start_date = get_field(changeset, :start_date)
+    end_date = get_field(changeset, :end_date)
+
+    cond do
+      is_nil(start_date) or is_nil(end_date) ->
+        changeset
+
+      Date.compare(start_date, end_date) not in [:lt, :eq] ->
+        add_error(changeset, :start_date, "start date must be less than or equal to end date")
+
+      true ->
+        changeset
+    end
   end
 end

--- a/lib/arrow/hastus/service_date.ex
+++ b/lib/arrow/hastus/service_date.ex
@@ -38,7 +38,7 @@ defmodule Arrow.Hastus.ServiceDate do
       is_nil(start_date) or is_nil(end_date) ->
         changeset
 
-      Date.compare(start_date, end_date) not in [:lt, :eq] ->
+      Date.compare(start_date, end_date) == :gt ->
         add_error(changeset, :start_date, "start date must be less than or equal to end date")
 
       true ->

--- a/lib/arrow/hastus/service_date.ex
+++ b/lib/arrow/hastus/service_date.ex
@@ -12,16 +12,19 @@ defmodule Arrow.Hastus.ServiceDate do
           service: Service.t() | Ecto.Association.NotLoaded.t()
         }
 
-  embedded_schema do
+  schema "hastus_service_dates" do
     field :start_date, :date
     field :end_date, :date
     belongs_to :service, Arrow.Hastus.Service
+
+    timestamps(type: :utc_datetime)
   end
 
   @doc false
-  def changeset(date, attrs) do
-    date
+  def changeset(service_date, attrs) do
+    service_date
     |> cast(attrs, [:start_date, :end_date])
+    |> validate_required([:start_date, :end_date])
     |> assoc_constraint(:service)
   end
 end

--- a/lib/arrow_web/components/hastus_export_section.ex
+++ b/lib/arrow_web/components/hastus_export_section.ex
@@ -474,4 +474,5 @@ defmodule ArrowWeb.HastusExportSection do
 
   defp error_to_string(:too_large), do: "File is too large. Maximum size is 8MB"
   defp error_to_string(:not_accepted), do: "You have selected an unacceptable file type"
+  defp error_to_string(_), do: "Upload failed. Please try again or contact an engineer"
 end

--- a/lib/arrow_web/components/hastus_export_section.ex
+++ b/lib/arrow_web/components/hastus_export_section.ex
@@ -281,8 +281,18 @@ defmodule ArrowWeb.HastusExportSection do
      |> assign(show_service_import_form: false)}
   end
 
-  def handle_event("validate", _, socket) do
+  # validate upload in handle_progress/3
+  def handle_event("validate", %{"_target" => ["hastus_export"]}, socket) do
     {:noreply, socket}
+  end
+
+  def handle_event("validate", %{"export" => export_params}, socket) do
+    form =
+      socket.assigns.hastus_export
+      |> Hastus.change_export(export_params)
+      |> to_form(action: :validate)
+
+    {:noreply, assign(socket, form: form)}
   end
 
   def handle_event("add_timeframe", %{"value" => index}, socket) do

--- a/lib/arrow_web/components/hastus_export_section.ex
+++ b/lib/arrow_web/components/hastus_export_section.ex
@@ -166,7 +166,7 @@ defmodule ArrowWeb.HastusExportSection do
                 </div>
                 <div
                   :if={Enum.count(f_service[:service_dates].value) > 1}
-                  class="col align-self-center mt-3"
+                  class="col-auto align-self-center mt-3"
                 >
                   <.button
                     type="button"

--- a/lib/arrow_web/components/hastus_export_section.ex
+++ b/lib/arrow_web/components/hastus_export_section.ex
@@ -244,10 +244,7 @@ defmodule ArrowWeb.HastusExportSection do
            |> assign(show_service_import_form: false)}
 
         {:error, changeset} ->
-          {:noreply,
-           assign(socket,
-             form: to_form(changeset)
-           )}
+          {:noreply, assign(socket, form: to_form(changeset))}
       end
     end
   end

--- a/lib/arrow_web/components/hastus_export_section.ex
+++ b/lib/arrow_web/components/hastus_export_section.ex
@@ -25,7 +25,8 @@ defmodule ArrowWeb.HastusExportSection do
     "line-Blue" => :blue_line,
     "line-Green" => :green_line,
     "line-Orange" => :orange_line,
-    "line-Red" => :red_line
+    "line-Red" => :red_line,
+    "line-Mattapan" => :mattapan_line
   }
 
   def render(assigns) do
@@ -264,12 +265,17 @@ defmodule ArrowWeb.HastusExportSection do
     if imported_services == %{} do
       {:noreply, assign(socket, error: "You must import at least one service")}
     else
-      with {:ok, _} <-
+      with {:ok, s3_path} <-
              ExportUpload.upload_to_s3(
                socket.assigns.uploaded_file_data,
                socket.assigns.uploaded_file_name
              ),
-           {:ok, _} <- Hastus.create_export(%{export_params | "services" => imported_services}) do
+           {:ok, _} <-
+             Hastus.create_export(%{
+               export_params
+               | "services" => imported_services,
+                 "s3_path" => s3_path
+             }) do
         send(self(), :update_disruption)
         send(self(), {:put_flash, :info, "HASTUS export created successfully"})
 

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -104,6 +104,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
       <.live_component
         id="hastus_export_section"
         module={ArrowWeb.HastusExportSection}
+        icon_paths={@icon_paths}
         hastus_export={@hastus_export_in_form}
         user_id={@user_id}
       />

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -30,7 +30,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
 
   def disruption_form(assigns) do
     ~H"""
-    <div class="w-75">
+    <div>
       <.simple_form for={@form} id="disruption_v2-form" phx-submit={@action} phx-change="validate">
         <div class="flex flex-row">
           <fieldset class="w-50">

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -106,6 +106,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
         module={ArrowWeb.HastusExportSection}
         icon_paths={@icon_paths}
         hastus_export={@hastus_export_in_form}
+        disruption={@disruption_v2}
         user_id={@user_id}
       />
 

--- a/priv/repo/migrations/20250312170355_create_hastus_export_tables.exs
+++ b/priv/repo/migrations/20250312170355_create_hastus_export_tables.exs
@@ -1,0 +1,35 @@
+defmodule Arrow.Repo.Migrations.CreateHastusExportTables do
+  use Ecto.Migration
+
+  def change do
+    create table(:hastus_exports) do
+      add :s3_path, :string
+      add :line_id, references(:gtfs_lines, type: :varchar, on_delete: :nothing)
+      add :disruption_id, references(:disruptionsv2, on_delete: :nothing)
+
+      timestamps(type: :timestamptz)
+    end
+
+    create index(:hastus_exports, [:line_id])
+    create index(:hastus_exports, [:disruption_id])
+
+    create table(:hastus_services) do
+      add :name, :string
+      add :export_id, references(:hastus_exports, on_delete: :nothing)
+
+      timestamps(type: :timestamptz)
+    end
+
+    create index(:hastus_services, [:export_id])
+
+    create table(:hastus_service_dates) do
+      add :start_date, :date
+      add :end_date, :date
+      add :service_id, references(:hastus_services, on_delete: :nothing)
+
+      timestamps(type: :timestamptz)
+    end
+
+    create index(:hastus_service_dates, [:service_id])
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -714,6 +714,104 @@ CREATE TABLE public.gtfs_trips (
 
 
 --
+-- Name: hastus_exports; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.hastus_exports (
+    id bigint NOT NULL,
+    s3_path character varying(255),
+    line_id character varying,
+    disruption_id bigint,
+    inserted_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: hastus_exports_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.hastus_exports_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: hastus_exports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.hastus_exports_id_seq OWNED BY public.hastus_exports.id;
+
+
+--
+-- Name: hastus_service_dates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.hastus_service_dates (
+    id bigint NOT NULL,
+    start_date date,
+    end_date date,
+    service_id bigint,
+    inserted_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: hastus_service_dates_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.hastus_service_dates_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: hastus_service_dates_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.hastus_service_dates_id_seq OWNED BY public.hastus_service_dates.id;
+
+
+--
+-- Name: hastus_services; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.hastus_services (
+    id bigint NOT NULL,
+    name character varying(255),
+    export_id bigint,
+    inserted_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: hastus_services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.hastus_services_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: hastus_services_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.hastus_services_id_seq OWNED BY public.hastus_services.id;
+
+
+--
 -- Name: limit_day_of_weeks; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1155,6 +1253,27 @@ ALTER TABLE ONLY public.disruptionsv2 ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: hastus_exports id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hastus_exports ALTER COLUMN id SET DEFAULT nextval('public.hastus_exports_id_seq'::regclass);
+
+
+--
+-- Name: hastus_service_dates id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hastus_service_dates ALTER COLUMN id SET DEFAULT nextval('public.hastus_service_dates_id_seq'::regclass);
+
+
+--
+-- Name: hastus_services id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hastus_services ALTER COLUMN id SET DEFAULT nextval('public.hastus_services_id_seq'::regclass);
+
+
+--
 -- Name: limit_day_of_weeks id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1426,6 +1545,30 @@ ALTER TABLE ONLY public.gtfs_trips
 
 
 --
+-- Name: hastus_exports hastus_exports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hastus_exports
+    ADD CONSTRAINT hastus_exports_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: hastus_service_dates hastus_service_dates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hastus_service_dates
+    ADD CONSTRAINT hastus_service_dates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: hastus_services hastus_services_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hastus_services
+    ADD CONSTRAINT hastus_services_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: limit_day_of_weeks limit_day_of_weeks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1596,6 +1739,34 @@ CREATE INDEX gtfs_stop_times_stop_id_index ON public.gtfs_stop_times USING btree
 --
 
 CREATE INDEX gtfs_stops_lat_lon_vehicle_type_id_index ON public.gtfs_stops USING btree (lat, lon, vehicle_type, id);
+
+
+--
+-- Name: hastus_exports_disruption_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hastus_exports_disruption_id_index ON public.hastus_exports USING btree (disruption_id);
+
+
+--
+-- Name: hastus_exports_line_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hastus_exports_line_id_index ON public.hastus_exports USING btree (line_id);
+
+
+--
+-- Name: hastus_service_dates_service_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hastus_service_dates_service_id_index ON public.hastus_service_dates USING btree (service_id);
+
+
+--
+-- Name: hastus_services_export_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hastus_services_export_id_index ON public.hastus_services USING btree (export_id);
 
 
 --
@@ -1955,6 +2126,38 @@ ALTER TABLE ONLY public.gtfs_trips
 
 
 --
+-- Name: hastus_exports hastus_exports_disruption_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hastus_exports
+    ADD CONSTRAINT hastus_exports_disruption_id_fkey FOREIGN KEY (disruption_id) REFERENCES public.disruptionsv2(id);
+
+
+--
+-- Name: hastus_exports hastus_exports_line_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hastus_exports
+    ADD CONSTRAINT hastus_exports_line_id_fkey FOREIGN KEY (line_id) REFERENCES public.gtfs_lines(id);
+
+
+--
+-- Name: hastus_service_dates hastus_service_dates_service_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hastus_service_dates
+    ADD CONSTRAINT hastus_service_dates_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.hastus_services(id);
+
+
+--
+-- Name: hastus_services hastus_services_export_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hastus_services
+    ADD CONSTRAINT hastus_services_export_id_fkey FOREIGN KEY (export_id) REFERENCES public.hastus_exports(id);
+
+
+--
 -- Name: limit_day_of_weeks limit_day_of_weeks_limit_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2112,3 +2315,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20250121165457);
 INSERT INTO public."schema_migrations" (version) VALUES (20250122200835);
 INSERT INTO public."schema_migrations" (version) VALUES (20250122204118);
 INSERT INTO public."schema_migrations" (version) VALUES (20250312131506);
+INSERT INTO public."schema_migrations" (version) VALUES (20250312170355);

--- a/test/arrow/hastus/export_upload_test.exs
+++ b/test/arrow/hastus/export_upload_test.exs
@@ -51,7 +51,7 @@ defmodule Arrow.Hastus.ExportUploadTest do
     test "gives validation errors for invalid exports", %{export: export} do
       data = ExportUpload.extract_data_from_upload(%{path: "#{@export_dir}/#{export}"}, "uid")
 
-      assert {:ok, {:error, "Trips found with invalid shapes"}} = data
+      assert {:ok, {:error, "Export does not contain any valid routes"}} = data
     end
   end
 end

--- a/test/arrow/hastus/export_upload_test.exs
+++ b/test/arrow/hastus/export_upload_test.exs
@@ -4,7 +4,7 @@ defmodule Arrow.Hastus.ExportUploadTest do
 
   import Arrow.Factory
 
-  alias Arrow.Hastus.{ExportUpload, Service}
+  alias Arrow.Hastus.ExportUpload
 
   @export_dir "test/support/fixtures/hastus"
 
@@ -40,10 +40,10 @@ defmodule Arrow.Hastus.ExportUploadTest do
       assert {:ok,
               {:ok,
                [
-                 %Service{service_id: "RTL12025-hmb15wg1-Weekday-01"},
-                 %Service{service_id: "RTL12025-hmb15016-Saturday-01"},
-                 %Service{service_id: "RTL12025-hmb15017-Sunday-01"},
-                 %Service{service_id: "RTL12025-hmb15mo1-Weekday-01"}
+                 %{name: "RTL12025-hmb15wg1-Weekday-01"},
+                 %{name: "RTL12025-hmb15016-Saturday-01"},
+                 %{name: "RTL12025-hmb15017-Sunday-01"},
+                 %{name: "RTL12025-hmb15mo1-Weekday-01"}
                ], "line-Blue"}} = data
     end
 

--- a/test/arrow/hastus/export_upload_test.exs
+++ b/test/arrow/hastus/export_upload_test.exs
@@ -44,7 +44,7 @@ defmodule Arrow.Hastus.ExportUploadTest do
                  %{name: "RTL12025-hmb15016-Saturday-01"},
                  %{name: "RTL12025-hmb15017-Sunday-01"},
                  %{name: "RTL12025-hmb15mo1-Weekday-01"}
-               ], "line-Blue"}} = data
+               ], "line-Blue", _}} = data
     end
 
     @tag export: "trips_no_shapes.zip"

--- a/test/arrow/hastus_test.exs
+++ b/test/arrow/hastus_test.exs
@@ -21,7 +21,7 @@ defmodule Arrow.HastusTest do
     end
 
     test "create_export/1 with valid data creates a export" do
-      valid_attrs = %{s3_path: "some s3_path"}
+      valid_attrs = %{s3_path: "some s3_path", services: [%{name: "some name"}]}
 
       assert {:ok, %Export{} = export} = Hastus.create_export(valid_attrs)
       assert export.s3_path == "some s3_path"
@@ -129,11 +129,11 @@ defmodule Arrow.HastusTest do
     end
 
     test "create_service_date/1 with valid data creates a service_date" do
-      valid_attrs = %{start_date: ~U[2025-03-11 17:17:00Z], end_date: ~U[2025-03-11 17:17:00Z]}
+      valid_attrs = %{start_date: ~D[2025-03-11], end_date: ~D[2025-03-11]}
 
       assert {:ok, %ServiceDate{} = service_date} = Hastus.create_service_date(valid_attrs)
-      assert service_date.start_date == ~U[2025-03-11 17:17:00Z]
-      assert service_date.end_date == ~U[2025-03-11 17:17:00Z]
+      assert service_date.start_date == ~D[2025-03-11]
+      assert service_date.end_date == ~D[2025-03-11]
     end
 
     test "create_service_date/1 with invalid data returns error changeset" do
@@ -142,16 +142,21 @@ defmodule Arrow.HastusTest do
 
     test "update_service_date/2 with valid data updates the service_date" do
       service_date = service_date_fixture()
-      update_attrs = %{start_date: ~U[2025-03-12 17:17:00Z], end_date: ~U[2025-03-12 17:17:00Z]}
+      update_attrs = %{start_date: ~D[2025-03-12], end_date: ~D[2025-03-12]}
 
-      assert {:ok, %ServiceDate{} = service_date} = Hastus.update_service_date(service_date, update_attrs)
-      assert service_date.start_date == ~U[2025-03-12 17:17:00Z]
-      assert service_date.end_date == ~U[2025-03-12 17:17:00Z]
+      assert {:ok, %ServiceDate{} = service_date} =
+               Hastus.update_service_date(service_date, update_attrs)
+
+      assert service_date.start_date == ~D[2025-03-12]
+      assert service_date.end_date == ~D[2025-03-12]
     end
 
     test "update_service_date/2 with invalid data returns error changeset" do
       service_date = service_date_fixture()
-      assert {:error, %Ecto.Changeset{}} = Hastus.update_service_date(service_date, @invalid_attrs)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Hastus.update_service_date(service_date, @invalid_attrs)
+
       assert service_date == Hastus.get_service_date!(service_date.id)
     end
 

--- a/test/arrow/hastus_test.exs
+++ b/test/arrow/hastus_test.exs
@@ -1,0 +1,169 @@
+defmodule Arrow.HastusTest do
+  use Arrow.DataCase
+
+  alias Arrow.Hastus
+
+  describe "exports" do
+    alias Arrow.Hastus.Export
+
+    import Arrow.HastusFixtures
+
+    @invalid_attrs %{s3_path: nil}
+
+    test "list_exports/0 returns all exports" do
+      export = export_fixture()
+      assert Hastus.list_exports() == [export]
+    end
+
+    test "get_export!/1 returns the export with given id" do
+      export = export_fixture()
+      assert Hastus.get_export!(export.id) == export
+    end
+
+    test "create_export/1 with valid data creates a export" do
+      valid_attrs = %{s3_path: "some s3_path"}
+
+      assert {:ok, %Export{} = export} = Hastus.create_export(valid_attrs)
+      assert export.s3_path == "some s3_path"
+    end
+
+    test "create_export/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Hastus.create_export(@invalid_attrs)
+    end
+
+    test "update_export/2 with valid data updates the export" do
+      export = export_fixture()
+      update_attrs = %{s3_path: "some updated s3_path"}
+
+      assert {:ok, %Export{} = export} = Hastus.update_export(export, update_attrs)
+      assert export.s3_path == "some updated s3_path"
+    end
+
+    test "update_export/2 with invalid data returns error changeset" do
+      export = export_fixture()
+      assert {:error, %Ecto.Changeset{}} = Hastus.update_export(export, @invalid_attrs)
+      assert export == Hastus.get_export!(export.id)
+    end
+
+    test "delete_export/1 deletes the export" do
+      export = export_fixture()
+      assert {:ok, %Export{}} = Hastus.delete_export(export)
+      assert_raise Ecto.NoResultsError, fn -> Hastus.get_export!(export.id) end
+    end
+
+    test "change_export/1 returns a export changeset" do
+      export = export_fixture()
+      assert %Ecto.Changeset{} = Hastus.change_export(export)
+    end
+  end
+
+  describe "hastus_services" do
+    alias Arrow.Hastus.Service
+
+    import Arrow.HastusFixtures
+
+    @invalid_attrs %{name: nil}
+
+    test "list_hastus_services/0 returns all hastus_services" do
+      service = service_fixture()
+      assert Hastus.list_hastus_services() == [service]
+    end
+
+    test "get_service!/1 returns the service with given id" do
+      service = service_fixture()
+      assert Hastus.get_service!(service.id) == service
+    end
+
+    test "create_service/1 with valid data creates a service" do
+      valid_attrs = %{name: "some name"}
+
+      assert {:ok, %Service{} = service} = Hastus.create_service(valid_attrs)
+      assert service.name == "some name"
+    end
+
+    test "create_service/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Hastus.create_service(@invalid_attrs)
+    end
+
+    test "update_service/2 with valid data updates the service" do
+      service = service_fixture()
+      update_attrs = %{name: "some updated name"}
+
+      assert {:ok, %Service{} = service} = Hastus.update_service(service, update_attrs)
+      assert service.name == "some updated name"
+    end
+
+    test "update_service/2 with invalid data returns error changeset" do
+      service = service_fixture()
+      assert {:error, %Ecto.Changeset{}} = Hastus.update_service(service, @invalid_attrs)
+      assert service == Hastus.get_service!(service.id)
+    end
+
+    test "delete_service/1 deletes the service" do
+      service = service_fixture()
+      assert {:ok, %Service{}} = Hastus.delete_service(service)
+      assert_raise Ecto.NoResultsError, fn -> Hastus.get_service!(service.id) end
+    end
+
+    test "change_service/1 returns a service changeset" do
+      service = service_fixture()
+      assert %Ecto.Changeset{} = Hastus.change_service(service)
+    end
+  end
+
+  describe "hastus_service_dates" do
+    alias Arrow.Hastus.ServiceDate
+
+    import Arrow.HastusFixtures
+
+    @invalid_attrs %{start_date: nil, end_date: nil}
+
+    test "list_hastus_service_dates/0 returns all hastus_service_dates" do
+      service_date = service_date_fixture()
+      assert Hastus.list_hastus_service_dates() == [service_date]
+    end
+
+    test "get_service_date!/1 returns the service_date with given id" do
+      service_date = service_date_fixture()
+      assert Hastus.get_service_date!(service_date.id) == service_date
+    end
+
+    test "create_service_date/1 with valid data creates a service_date" do
+      valid_attrs = %{start_date: ~U[2025-03-11 17:17:00Z], end_date: ~U[2025-03-11 17:17:00Z]}
+
+      assert {:ok, %ServiceDate{} = service_date} = Hastus.create_service_date(valid_attrs)
+      assert service_date.start_date == ~U[2025-03-11 17:17:00Z]
+      assert service_date.end_date == ~U[2025-03-11 17:17:00Z]
+    end
+
+    test "create_service_date/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Hastus.create_service_date(@invalid_attrs)
+    end
+
+    test "update_service_date/2 with valid data updates the service_date" do
+      service_date = service_date_fixture()
+      update_attrs = %{start_date: ~U[2025-03-12 17:17:00Z], end_date: ~U[2025-03-12 17:17:00Z]}
+
+      assert {:ok, %ServiceDate{} = service_date} = Hastus.update_service_date(service_date, update_attrs)
+      assert service_date.start_date == ~U[2025-03-12 17:17:00Z]
+      assert service_date.end_date == ~U[2025-03-12 17:17:00Z]
+    end
+
+    test "update_service_date/2 with invalid data returns error changeset" do
+      service_date = service_date_fixture()
+      assert {:error, %Ecto.Changeset{}} = Hastus.update_service_date(service_date, @invalid_attrs)
+      assert service_date == Hastus.get_service_date!(service_date.id)
+    end
+
+    test "delete_service_date/1 deletes the service_date" do
+      service_date = service_date_fixture()
+      assert {:ok, %ServiceDate{}} = Hastus.delete_service_date(service_date)
+      assert_raise Ecto.NoResultsError, fn -> Hastus.get_service_date!(service_date.id) end
+    end
+
+    test "change_service_date/1 returns a service_date changeset" do
+      service_date = service_date_fixture()
+      assert %Ecto.Changeset{} = Hastus.change_service_date(service_date)
+    end
+  end
+end

--- a/test/integration/disruptionsv2/hastus_export_section_test.exs
+++ b/test/integration/disruptionsv2/hastus_export_section_test.exs
@@ -56,7 +56,7 @@ defmodule Arrow.Integration.Disruptionsv2.HastusExportSectionTest do
     |> attach_file(file_field("hastus_export", visible: false),
       path: "test/support/fixtures/hastus/trips_no_shapes.zip"
     )
-    |> assert_text("Trips found with invalid shapes")
+    |> assert_text("Export does not contain any valid routes")
   end
 
   defp scroll_down(parent) do

--- a/test/integration/disruptionsv2/hastus_export_section_test.exs
+++ b/test/integration/disruptionsv2/hastus_export_section_test.exs
@@ -1,0 +1,65 @@
+defmodule Arrow.Integration.Disruptionsv2.HastusExportSectionTest do
+  use ExUnit.Case
+  use Wallaby.Feature
+  import Wallaby.Browser, except: [text: 1]
+  import Wallaby.Query
+  import Arrow.DisruptionsFixtures
+  import Arrow.Factory
+
+  @moduletag :integration
+
+  feature "can upload a HASTUS export", %{session: session} do
+    disruption = disruption_v2_fixture()
+    line = insert(:gtfs_line, id: "line-Blue")
+    route = insert(:gtfs_route, id: "Blue", line_id: line.id)
+
+    direction = insert(:gtfs_direction, direction_id: 0, route_id: route.id, route: route)
+
+    route_pattern =
+      insert(:gtfs_route_pattern,
+        route_id: route.id,
+        route: route,
+        representative_trip_id: "Test",
+        direction_id: 0
+      )
+
+    insert(:gtfs_stop_time,
+      trip:
+        insert(:gtfs_trip,
+          id: "Test",
+          route: route,
+          route_pattern_id: route_pattern.id,
+          directions: [direction]
+        ),
+      stop: insert(:gtfs_stop, id: "70054")
+    )
+
+    session
+    |> visit("/disruptionsv2/#{disruption.id}/edit")
+    |> scroll_down()
+    |> click(text("upload HASTUS export"))
+    |> assert_text("add a new service schedule")
+    |> attach_file(file_field("hastus_export", visible: false),
+      path: "test/support/fixtures/hastus/example.zip"
+    )
+    |> assert_text("Successfully imported export example.zip!")
+  end
+
+  feature "shows validation error for bad exports", %{session: session} do
+    disruption = disruption_v2_fixture()
+
+    session
+    |> visit("/disruptionsv2/#{disruption.id}/edit")
+    |> scroll_down()
+    |> click(text("upload HASTUS export"))
+    |> assert_text("add a new service schedule")
+    |> attach_file(file_field("hastus_export", visible: false),
+      path: "test/support/fixtures/hastus/trips_no_shapes.zip"
+    )
+    |> assert_text("Trips found with invalid shapes")
+  end
+
+  defp scroll_down(parent) do
+    execute_script(parent, "window.scrollBy(0, 400)")
+  end
+end

--- a/test/support/fixtures/hastus_fixtures.ex
+++ b/test/support/fixtures/hastus_fixtures.ex
@@ -4,6 +4,8 @@ defmodule Arrow.HastusFixtures do
   entities via the `Arrow.Hastus` context.
   """
 
+  @preloads [:line, :disruption, services: [:service_dates]]
+
   @doc """
   Generate a export.
   """
@@ -11,11 +13,12 @@ defmodule Arrow.HastusFixtures do
     {:ok, export} =
       attrs
       |> Enum.into(%{
-        s3_path: "some s3_path"
+        s3_path: "some s3_path",
+        services: [%{name: "some service"}]
       })
       |> Arrow.Hastus.create_export()
 
-    export
+    Arrow.Repo.preload(export, @preloads)
   end
 
   @doc """
@@ -39,8 +42,8 @@ defmodule Arrow.HastusFixtures do
     {:ok, service_date} =
       attrs
       |> Enum.into(%{
-        end_date: ~U[2025-03-11 17:17:00Z],
-        start_date: ~U[2025-03-11 17:17:00Z]
+        end_date: ~D[2025-03-11],
+        start_date: ~D[2025-03-11]
       })
       |> Arrow.Hastus.create_service_date()
 

--- a/test/support/fixtures/hastus_fixtures.ex
+++ b/test/support/fixtures/hastus_fixtures.ex
@@ -1,0 +1,49 @@
+defmodule Arrow.HastusFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Arrow.Hastus` context.
+  """
+
+  @doc """
+  Generate a export.
+  """
+  def export_fixture(attrs \\ %{}) do
+    {:ok, export} =
+      attrs
+      |> Enum.into(%{
+        s3_path: "some s3_path"
+      })
+      |> Arrow.Hastus.create_export()
+
+    export
+  end
+
+  @doc """
+  Generate a service.
+  """
+  def service_fixture(attrs \\ %{}) do
+    {:ok, service} =
+      attrs
+      |> Enum.into(%{
+        name: "some name"
+      })
+      |> Arrow.Hastus.create_service()
+
+    service
+  end
+
+  @doc """
+  Generate a service_date.
+  """
+  def service_date_fixture(attrs \\ %{}) do
+    {:ok, service_date} =
+      attrs
+      |> Enum.into(%{
+        end_date: ~U[2025-03-11 17:17:00Z],
+        start_date: ~U[2025-03-11 17:17:00Z]
+      })
+      |> Arrow.Hastus.create_service_date()
+
+    service_date
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Implement HASTUS import forms (post-parse)](https://app.asana.com/1/15492006741476/project/584764604969369/task/1209538099020504)

This PRs finishes the form submission that saves HASTUS exports to the DB and S3. Follows the same S3 uploading pattern as Shapes. There is not currently a way to view existing exports so easiest way to test is locally. After saving, `hastus_exports`, `hastus_services`, and `hastus_service_dates` rows should be created and S3 should contain the uploaded file.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
