### PR TITLE
refactor: Timetable logic

### DIFF
--- a/lib/arrow/disruptions.ex
+++ b/lib/arrow/disruptions.ex
@@ -241,25 +241,6 @@ defmodule Arrow.Disruptions do
     |> Repo.all()
   end
 
-  @spec days_of_week_for_replacement_service(ReplacementService.t()) :: [String.t()]
-  def days_of_week_for_replacement_service(%ReplacementService{
-        source_workbook_data: source_workbook_data
-      }) do
-    source_workbook_data
-    |> Enum.map(fn {key, _data} ->
-      Regex.run(~r/(.*) headways and runtimes/, key, capture: :all_but_first)
-    end)
-    |> Enum.reject(&is_nil(&1))
-    |> List.flatten()
-    |> Enum.sort_by(fn day_of_week ->
-      case day_of_week do
-        "WKDY" -> 1
-        "SAT" -> 2
-        "SUN" -> 3
-      end
-    end)
-  end
-
   @spec replacement_service_trips_with_times(ReplacementService.t(), String.t()) :: map()
   def replacement_service_trips_with_times(
         %ReplacementService{source_workbook_data: source_workbook_data, shuttle: shuttle},

--- a/lib/arrow/disruptions/replacement_service.ex
+++ b/lib/arrow/disruptions/replacement_service.ex
@@ -15,11 +15,9 @@ defmodule Arrow.Disruptions.ReplacementService do
   alias Arrow.Shuttles.Shuttle
 
   @type stop_time :: %{stop_id: String.t(), stop_time: String.t()}
-  @type timetable :: %{
-          optional(:weekday) => stop_time(),
-          optional(:saturday) => stop_time(),
-          optional(:sunday) => stop_time()
-        }
+  @type direction_id :: String.t()
+  @type timetable ::
+          %{direction_id() => list(stop_time()), direction_id() => list(stop_time())} | nil
 
   @type t :: %__MODULE__{
           reason: String.t() | nil,
@@ -29,7 +27,7 @@ defmodule Arrow.Disruptions.ReplacementService do
           source_workbook_filename: String.t(),
           disruption: DisruptionV2.t() | Ecto.Association.NotLoaded.t(),
           shuttle: Shuttle.t() | Ecto.Association.NotLoaded.t(),
-          timetable: timetable() | nil
+          timetable: %{weekday: timetable(), saturday: timetable(), sunday: timetable()} | nil
         }
 
   @service_type_to_workbook_abbreviation %{

--- a/lib/arrow/disruptions/replacement_service.ex
+++ b/lib/arrow/disruptions/replacement_service.ex
@@ -14,6 +14,13 @@ defmodule Arrow.Disruptions.ReplacementService do
   alias Arrow.Shuttles
   alias Arrow.Shuttles.Shuttle
 
+  @type stop_time :: %{stop_id: String.t(), stop_time: String.t()}
+  @type timetable :: %{
+          optional(:weekday) => stop_time(),
+          optional(:saturday) => stop_time(),
+          optional(:sunday) => stop_time()
+        }
+
   @type t :: %__MODULE__{
           reason: String.t() | nil,
           start_date: Date.t() | nil,
@@ -22,7 +29,7 @@ defmodule Arrow.Disruptions.ReplacementService do
           source_workbook_filename: String.t(),
           disruption: DisruptionV2.t() | Ecto.Association.NotLoaded.t(),
           shuttle: Shuttle.t() | Ecto.Association.NotLoaded.t(),
-          timetable: map() | nil
+          timetable: timetable() | nil
         }
 
   @service_type_to_workbook_abbreviation %{
@@ -94,7 +101,7 @@ defmodule Arrow.Disruptions.ReplacementService do
       end)
       |> Enum.into(%{})
 
-    struct(replacement_service, timetable: timetable)
+    %__MODULE__{replacement_service | timetable: timetable}
   end
 
   @spec get_replacement_services_with_timetables(Date.t(), Date.t()) ::

--- a/lib/arrow_web/controllers/timetable_controller.ex
+++ b/lib/arrow_web/controllers/timetable_controller.ex
@@ -11,7 +11,9 @@ defmodule ArrowWeb.TimetableController do
       |> Disruptions.get_replacement_service!()
       |> ReplacementService.add_timetable()
 
-    available_days_of_week = Map.keys(replacement_service.timetable)
+    available_days_of_week =
+      ReplacementService.schedule_service_types()
+      |> Enum.filter(&(&1 in Map.keys(replacement_service.timetable)))
 
     day_of_week =
       if day_of_week = Map.get(params, "day_of_week") do

--- a/lib/arrow_web/controllers/timetable_controller.ex
+++ b/lib/arrow_web/controllers/timetable_controller.ex
@@ -13,7 +13,7 @@ defmodule ArrowWeb.TimetableController do
 
     available_days_of_week =
       ReplacementService.schedule_service_types()
-      |> Enum.filter(&(&1 in Map.keys(replacement_service.timetable)))
+      |> Enum.filter(&Map.has_key?(replacement_service.timetable, &1))
 
     day_of_week =
       if day_of_week = Map.get(params, "day_of_week") do

--- a/lib/arrow_web/controllers/timetable_controller.ex
+++ b/lib/arrow_web/controllers/timetable_controller.ex
@@ -13,7 +13,7 @@ defmodule ArrowWeb.TimetableController do
 
     available_days_of_week =
       ReplacementService.schedule_service_types()
-      |> Enum.filter(&Map.has_key?(replacement_service.timetable, &1))
+      |> Enum.reject(&is_nil(replacement_service.timetable[&1]))
 
     day_of_week =
       if day_of_week = Map.get(params, "day_of_week") do

--- a/lib/arrow_web/controllers/timetable_controller.ex
+++ b/lib/arrow_web/controllers/timetable_controller.ex
@@ -2,24 +2,30 @@ defmodule ArrowWeb.TimetableController do
   use ArrowWeb, :controller
 
   alias Arrow.Disruptions
+  alias Arrow.Disruptions.ReplacementService
   alias Arrow.Shuttles
 
   def show(conn, %{"replacement_service_id" => replacement_service_id} = params) do
-    replacement_service = Disruptions.get_replacement_service!(replacement_service_id)
+    replacement_service =
+      replacement_service_id
+      |> Disruptions.get_replacement_service!()
+      |> ReplacementService.add_timetable()
 
-    available_days_of_week = Disruptions.days_of_week_for_replacement_service(replacement_service)
+    available_days_of_week = Map.keys(replacement_service.timetable)
 
-    day_of_week = Map.get(params, "day_of_week", Enum.at(available_days_of_week, 0))
+    day_of_week =
+      if day_of_week = Map.get(params, "day_of_week") do
+        String.to_existing_atom(day_of_week)
+      else
+        Enum.at(available_days_of_week, 0)
+      end
 
-    trips_with_times =
-      Disruptions.replacement_service_trips_with_times(replacement_service, day_of_week)
-
+    trips_with_times = Map.get(replacement_service.timetable, day_of_week)
     direction_id = Map.get(params, "direction_id", "0")
-
     sample_trip = trips_with_times |> Map.get(direction_id) |> Enum.at(0)
 
     initial_stop_times_by_stop =
-      Enum.map(sample_trip.stop_times, fn stop_time ->
+      Enum.map(sample_trip, fn stop_time ->
         {stop_time.stop_id
          |> Shuttles.stop_or_gtfs_stop_for_stop_id()
          |> Shuttles.stop_display_name(), stop_time.stop_id, []}
@@ -29,7 +35,7 @@ defmodule ArrowWeb.TimetableController do
       trips_with_times
       |> Map.get(direction_id)
       |> Enum.reduce(initial_stop_times_by_stop, fn trip, times_by_stop ->
-        trip_stop_times_by_stop = Enum.group_by(trip.stop_times, & &1.stop_id)
+        trip_stop_times_by_stop = Enum.group_by(trip, & &1.stop_id)
 
         Enum.map(times_by_stop, fn {stop_display_name, stop_id, times} ->
           [trip_stop_time] = Map.get(trip_stop_times_by_stop, stop_id)
@@ -43,14 +49,14 @@ defmodule ArrowWeb.TimetableController do
     day_of_week_options =
       Enum.map(available_days_of_week, fn day_of_week ->
         case day_of_week do
-          "WKDY" -> {"WKDY", "Weekday"}
-          "SAT" -> {"SAT", "Saturday"}
-          "SUN" -> {"SUN", "Sunday"}
+          :weekday -> {:weekday, "Weekday"}
+          :saturday -> {:saturday, "Saturday"}
+          :sunday -> {:sunday, "Sunday"}
         end
       end)
 
     [first_stop, last_stop] =
-      [List.first(sample_trip.stop_times), List.last(sample_trip.stop_times)]
+      [List.first(sample_trip), List.last(sample_trip)]
       |> Enum.map(fn stop ->
         stop
         |> Map.get(:stop_id)

--- a/test/arrow/disruptions_test.exs
+++ b/test/arrow/disruptions_test.exs
@@ -178,15 +178,6 @@ defmodule Arrow.DisruptionsTest do
     end
   end
 
-  describe "days_of_week_for_replacement_service/1" do
-    test "returns pertinent day of week string keys" do
-      replacement_service = build(:replacement_service)
-
-      assert ["WKDY", "SAT"] =
-               Disruptions.days_of_week_for_replacement_service(replacement_service)
-    end
-  end
-
   describe "replacement_service_trips_with_times/2" do
     test "generates trip times" do
       shuttle = Arrow.ShuttlesFixtures.shuttle_fixture(%{}, true, true)

--- a/test/arrow_web/controllers/timetable_controller_test.exs
+++ b/test/arrow_web/controllers/timetable_controller_test.exs
@@ -20,11 +20,11 @@ defmodule ArrowWeb.TimetableControllerTest do
       assert response =~ "05:10"
 
       # can switch direction
-      assert response =~ "/timetable?day_of_week=WKDY&amp;direction_id=1"
+      assert response =~ "/timetable?day_of_week=weekday&amp;direction_id=1"
 
       # can switch day
-      assert response =~ "/timetable?day_of_week=WKDY&amp;direction_id=0"
-      assert response =~ "/timetable?day_of_week=SAT&amp;direction_id=0"
+      assert response =~ "/timetable?day_of_week=weekday&amp;direction_id=0"
+      assert response =~ "/timetable?day_of_week=saturday&amp;direction_id=0"
     end
 
     @tag :authenticated_admin
@@ -40,11 +40,11 @@ defmodule ArrowWeb.TimetableControllerTest do
       response = html_response(conn, 200)
 
       # can switch direction
-      assert response =~ "/timetable?day_of_week=WKDY&amp;direction_id=0"
+      assert response =~ "/timetable?day_of_week=weekday&amp;direction_id=0"
 
       # can switch day
-      assert response =~ "/timetable?day_of_week=WKDY&amp;direction_id=1"
-      assert response =~ "/timetable?day_of_week=SAT&amp;direction_id=1"
+      assert response =~ "/timetable?day_of_week=weekday&amp;direction_id=1"
+      assert response =~ "/timetable?day_of_week=saturday&amp;direction_id=1"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 🏹🐛 Fix replacement service timetable view](https://app.asana.com/0/584764604969369/1209732403584287/f)

While testing Arrow <-> gtfs-creator integration, we found a timetable view crash. While investigating, we realized that the `/api/replacement-service` endpoint was not showing the same issue. This is because it was using different logic for building the timetables. Seemed like a good opportunity to DRY the code up a bit and fix a bug at the same time. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
