### PR TITLE
polish: Set default radio button values

### DIFF
--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -1,5 +1,6 @@
 defmodule ArrowWeb.DisruptionV2ViewLive do
   use ArrowWeb, :live_view
+  import Phoenix.HTML.Form
 
   alias Arrow.{Adjustment, Disruptions}
   alias Arrow.Disruptions.{DisruptionV2, Limit, ReplacementService}
@@ -8,14 +9,14 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
   @spec disruption_status_labels :: map()
   def disruption_status_labels, do: %{Approved: true, Pending: false}
 
-  @spec mode_labels :: map()
+  @spec mode_labels :: list(tuple())
   def mode_labels,
-    do: %{
-      Subway: :subway,
-      "Commuter Rail": :commuter_rail,
-      Bus: :bus,
-      "Silver Line": :silver_line
-    }
+    do: [
+      {"Subway/Light Rail", :subway},
+      {"Commuter Rail", :commuter_rail},
+      {"Bus", :bus},
+      {"Silver Line", :silver_line}
+    ]
 
   attr :id, :string
   attr :form, :any, required: true
@@ -39,16 +40,19 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
           </fieldset>
           <fieldset class="w-50 ml-20">
             <legend>Approval Status</legend>
-            <div :for={{{status, value}, idx} <- Enum.with_index(disruption_status_labels())} %>
-              <label class="form-check form-check-label">
-                <input
-                  name={@form[:is_active].name}
-                  id={"#{@form[:is_active].id}-#{idx}"}
-                  class="form-check-input"
-                  type="radio"
-                  checked={to_string(@form[:is_active].value) == to_string(value)}
-                  value={to_string(value)}
-                />
+            <div
+              :for={{{status, value}, idx} <- Enum.with_index(disruption_status_labels())}
+              class="form-check"
+            >
+              <input
+                name={@form[:is_active].name}
+                id={"#{@form[:is_active].id}-#{idx}"}
+                class="form-check-input"
+                type="radio"
+                checked={to_string(@form[:is_active].value) == to_string(value)}
+                value={to_string(value)}
+              />
+              <label for={"#{@form[:is_active].id}-#{idx}"} class="form-check-label">
                 {status}
               </label>
             </div>
@@ -56,17 +60,17 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
         </div>
         <fieldset>
           <legend>Mode</legend>
-          <div :for={{{mode, value}, idx} <- Enum.with_index(mode_labels())}>
-            <label class="form-check form-check-label">
-              <input
-                name={@form[:mode].name}
-                id={"#{@form[:mode].id}-#{idx}"}
-                class="form-check-input"
-                type="radio"
-                checked={to_string(@form[:mode].value) == to_string(value)}
-                value={to_string(value)}
-              />
-
+          <div :for={{{mode, value}, idx} <- Enum.with_index(mode_labels())} class="form-check">
+            <input
+              name={@form[:mode].name}
+              id={"#{@form[:mode].id}-#{idx}"}
+              class="form-check-input"
+              type="radio"
+              checked={input_value(@form, :mode) == value}
+              disabled={value != :subway}
+              value={value}
+            />
+            <label for={"#{@form[:mode].id}-#{idx}"} class="form-check-label">
               <span
                 class="m-icon m-icon-sm mr-1"
                 style={"background-image: url('#{Map.get(@icon_paths, value)}');"}

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -45,6 +45,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
                 type="radio"
                 checked={normalize_value("checkbox", input_value(@form, :is_active))}
                 value="true"
+                disabled={@action == :create}
               />
               <label for="status-approved" class="form-check-label">
                 Approved
@@ -177,7 +178,11 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
   @impl true
   def mount(%{} = _params, session, socket) do
     disruption = DisruptionV2.new()
-    form = disruption |> Disruptions.change_disruption_v2() |> to_form()
+
+    form =
+      disruption
+      |> Disruptions.change_disruption_v2(%{is_active: false, mode: :subway})
+      |> to_form()
 
     socket =
       socket

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -6,9 +6,6 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
   alias Arrow.Disruptions.{DisruptionV2, Limit, ReplacementService}
   alias Arrow.Hastus.Export
 
-  @spec disruption_status_labels :: map()
-  def disruption_status_labels, do: %{Approved: true, Pending: false}
-
   @spec mode_labels :: list(tuple())
   def mode_labels,
     do: [
@@ -40,20 +37,30 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
           </fieldset>
           <fieldset class="w-50 ml-20">
             <legend>Approval Status</legend>
-            <div
-              :for={{{status, value}, idx} <- Enum.with_index(disruption_status_labels())}
-              class="form-check"
-            >
+            <div class="form-check">
               <input
                 name={@form[:is_active].name}
-                id={"#{@form[:is_active].id}-#{idx}"}
+                id="status-approved"
                 class="form-check-input"
                 type="radio"
-                checked={to_string(@form[:is_active].value) == to_string(value)}
-                value={to_string(value)}
+                checked={normalize_value("checkbox", input_value(@form, :is_active))}
+                value="true"
               />
-              <label for={"#{@form[:is_active].id}-#{idx}"} class="form-check-label">
-                {status}
+              <label for="status-approved" class="form-check-label">
+                Approved
+              </label>
+            </div>
+            <div class="form-check">
+              <input
+                name={@form[:is_active].name}
+                id="status-pending"
+                class="form-check-input"
+                type="radio"
+                checked={!normalize_value("checkbox", input_value(@form, :is_active))}
+                value="false"
+              />
+              <label for="status-pending" class="form-check-label">
+                Pending
               </label>
             </div>
           </fieldset>

--- a/test/arrow_web/live/disruption_v2_live_test.exs
+++ b/test/arrow_web/live/disruption_v2_live_test.exs
@@ -9,8 +9,8 @@ defmodule ArrowWeb.DisruptionV2LiveTest do
 
   @create_attrs %{
     title: "the great molasses disruption of 2025",
-    mode: "commuter_rail",
-    is_active: true,
+    mode: "subway",
+    is_active: false,
     description: nil
   }
   @update_attrs %{
@@ -21,8 +21,8 @@ defmodule ArrowWeb.DisruptionV2LiveTest do
   }
   @invalid_attrs %{
     title: nil,
-    mode: "silver_line",
-    is_active: true,
+    mode: "subway",
+    is_active: false,
     description: "foobar"
   }
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Set base disruption status and mode values when creating a disruption](https://app.asana.com/0/1206766411887385/1209773527666857/f)

Disruptions are not allowed to be active unless they already exist. `Pending` will now be the default and only option under "Approval Status" for new disruptions.

Arrow v2 MVP will only allow subway disruptions. Other options are disabled until implemented.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
