### PR TITLE
deps: update mix installed npm deps in package-lock.json

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -54,26 +54,28 @@
       }
     },
     "../deps/live_select": {
-      "version": "1.4.3",
+      "version": "1.5.2",
       "license": "Apache License 2.0"
     },
     "../deps/phoenix": {
-      "version": "1.7.14",
+      "version": "1.7.18",
       "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "4.1.0"
+      "version": "4.2.0"
     },
     "../deps/phoenix_live_react": {
       "version": "0.4.2",
       "license": "MIT"
     },
     "../deps/phoenix_live_view": {
-      "version": "0.20.17",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@playwright/test": "^1.43.1",
-        "monocart-reporter": "^2.3.1"
+        "@eslint/js": "^9.10.0",
+        "@playwright/test": "^1.47.1",
+        "eslint-plugin-playwright": "^2.1.0",
+        "monocart-reporter": "^2.8.0"
       }
     },
     "../deps/react_phoenix": {


### PR DESCRIPTION
Running `npm install` produced these changes likely because these are from mix dependencies that have been updated since the last time we touched `assets/package.json`.