### PR TITLE
docs: correct order of setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@
 - `mix deps.get`
 - `mix esbuild.install`
 - `npm install --prefix assets`
-- `direnv allow`
 - `cp .envrc.example .envrc`
 - Update `.envrc` with your local Postgres username and password
 - Update `.envrc` with your AWS credentials or ensure they are available in your shell
 - Update `.envrc` with OpenRouteService setup
 - Update `.envrc` with the Arrow Dev Keycloak client secret (found in 1Password)
+- `direnv allow`
 - `mix ecto.setup`
 - `brew install chromedriver`
 - Add your Arrow API key from https://arrow.mbta.com/mytoken to `.envrc`


### PR DESCRIPTION
Running `direnv allow` needs to happen _after_ copying `.envrc.example` to `.envrc` and updating that file with all of the relevant secrets.