### PR TITLE
fix: check changesets correctly when verifying for time to next stop

### DIFF
--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -87,6 +87,8 @@ defmodule Arrow.Shuttles.Shuttle do
   @spec route_stops_missing_time_to_next_stop?([Arrow.Shuttles.RouteStop.t()]) :: boolean()
   defp route_stops_missing_time_to_next_stop?(route_stops) do
     route_stops
+    |> Enum.filter(&(&1.action not in [:replace, :delete]))
+    |> Enum.sort_by(&get_field(&1, :stop_sequence))
     |> Enum.slice(0..-2//1)
     |> Enum.any?(&(&1 |> get_field(:time_to_next_stop) |> is_nil()))
   end

--- a/test/arrow/shuttle/shuttle_test.exs
+++ b/test/arrow/shuttle/shuttle_test.exs
@@ -61,7 +61,8 @@ defmodule Arrow.Shuttles.ShuttleTest do
 
       shuttle = Arrow.Shuttles.get_shuttle!(shuttle.id)
 
-      changeset = Shuttle.changeset(shuttle, %{status: :active})
+      changeset =
+        Shuttle.changeset(shuttle, %{status: :active})
 
       assert %Ecto.Changeset{
                valid?: false,
@@ -117,7 +118,56 @@ defmodule Arrow.Shuttles.ShuttleTest do
 
       shuttle = Arrow.Shuttles.get_shuttle!(shuttle.id)
 
-      changeset = Shuttle.changeset(shuttle, %{status: :active})
+      # Update the route_stops to trigger replacement and verify that
+      # the validation handles that correctly
+      changeset =
+        Shuttle.changeset(shuttle, %{
+          status: :active,
+          routes: [
+            %{
+              id: route0.id,
+              shape_id: route0.shape_id,
+              destination: "Harvard",
+              direction_id: :"0",
+              direction_desc: "South",
+              waypoint: "Brattle",
+              route_stops: [
+                %{
+                  direction_id: :"0",
+                  stop_sequence: 1,
+                  display_stop_id: stop1.id,
+                  time_to_next_stop: 60.0
+                },
+                %{
+                  direction_id: :"0",
+                  stop_sequence: 2,
+                  display_stop_id: stop2.id
+                }
+              ]
+            },
+            %{
+              id: route1.id,
+              shape_id: route1.shape_id,
+              destination: "Alewife",
+              direction_id: :"1",
+              direction_desc: "North",
+              waypoint: "Brattle",
+              route_stops: [
+                %{
+                  direction_id: :"1",
+                  stop_sequence: 1,
+                  display_stop_id: stop3.id,
+                  time_to_next_stop: 60.0
+                },
+                %{
+                  direction_id: :"0",
+                  stop_sequence: 1,
+                  display_stop_id: stop4.id
+                }
+              ]
+            }
+          ]
+        })
 
       assert %Ecto.Changeset{valid?: true} = changeset
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 🏹🐛 Shuttle Definitions page doesn't register existing "time to next stop" values when shuttle status is changed from inactive -> active](https://app.asana.com/0/584764604969369/1209773527666853/f)

The root cause of this bug is that replacing the route stops actually results in two changesets, a `:replace` changeset for the old route stop being removed and an `:insert` changeset for the new one. The validation was just looking at all changesets, so it was seeing two with a time to next stop of nil rather than the expected one. This just updates the logic to filter out `:replace` and `:delete` changesets and also make sure that the list is sorted by stop sequence before validating.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
