### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mbta/transit-data


### PR DESCRIPTION
This simple CODEOWNERS file will automatically request reviews from someone in the `@mbta/transit-data` team whenever a PR is opened and ready for review