### PR TITLE
chore: update sha256 checksum of aws cert bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mix local.hex --force && \
   mix local.rebar --force
 
 ADD \
-  --checksum=sha256:05c6b4a9bf4daa95c888711481e19cc8e2e11aed4de8db759f51f4a6fce64917 \
+  --checksum=sha256:5fa49cac7e6e9202ef85331c6f83377a71339d692d5644c9417a2d81406f0c03 \
   https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
   /root/aws-cert-bundle.pem
 


### PR DESCRIPTION
the aws cert bundle changes from time-to-time. this updates the checksum to reflect the most recent changes

deploys are currently failing because of this mismatch: https://github.com/mbta/arrow/actions/runs/14178625606/job/39719395790

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
