### PR TITLE
fix: prevent creating limits with overlapping dates

### DIFF
--- a/lib/arrow/disruptions/limit.ex
+++ b/lib/arrow/disruptions/limit.ex
@@ -31,6 +31,7 @@ defmodule Arrow.Disruptions.Limit do
   schema "limits" do
     field :start_date, :date
     field :end_date, :date
+    field :check_for_overlap, :boolean, default: true
     field :editing?, :boolean, virtual: true, default: false
     belongs_to :disruption, Arrow.Disruptions.DisruptionV2
     belongs_to :route, Arrow.Gtfs.Route, type: :string
@@ -56,9 +57,14 @@ defmodule Arrow.Disruptions.Limit do
       :disruption_id,
       :editing?
     ])
+    |> put_change(:check_for_overlap, true)
     |> cast_assoc(:limit_day_of_weeks, with: &Arrow.Limits.LimitDayOfWeek.changeset/2)
     |> validate_required([:start_date, :end_date, :route_id, :start_stop_id, :end_stop_id])
     |> validate_start_date_before_end_date()
+    |> exclusion_constraint(:end_date,
+      name: :no_overlap,
+      message: "cannot overlap another limit"
+    )
     |> assoc_constraint(:route)
     |> assoc_constraint(:start_stop)
     |> assoc_constraint(:end_stop)

--- a/priv/repo/migrations/20250402181804_add_limit_exclusion_constraint.exs
+++ b/priv/repo/migrations/20250402181804_add_limit_exclusion_constraint.exs
@@ -1,0 +1,32 @@
+defmodule Arrow.Repo.Migrations.AddLimitExclusionConstraint do
+  use Ecto.Migration
+
+  def change do
+    alter table(:limits) do
+      add :check_for_overlap, :boolean
+    end
+
+    execute "update limits set check_for_overlap = false", ""
+
+    execute "alter table limits alter column check_for_overlap set default true",
+            "alter table limits alter column check_for_overlap drop default"
+
+    execute "alter table limits alter column check_for_overlap set not null",
+            "alter table limits alter column check_for_overlap drop not null"
+
+    execute "create extension if not exists btree_gist",
+            "drop extension if exists btree_gist"
+
+    create constraint(:limits, :no_overlap,
+             exclude: """
+             gist (
+               disruption_id with =,
+               route_id with =,
+               least(start_stop_id, end_stop_id) with =,
+               greatest(start_stop_id, end_stop_id) with =,
+               daterange(start_date, end_date, '[]') with &&
+             ) where (check_for_overlap = true)
+             """
+           )
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -17,6 +17,20 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: btree_gist; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS btree_gist WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION btree_gist; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION btree_gist IS 'support for indexing common datatypes in GiST';
+
+
+--
 -- Name: day_name; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -896,7 +910,8 @@ CREATE TABLE public.limits (
     start_stop_id character varying,
     end_stop_id character varying,
     inserted_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL
+    updated_at timestamp with time zone NOT NULL,
+    check_for_overlap boolean DEFAULT true NOT NULL
 );
 
 
@@ -1633,6 +1648,14 @@ ALTER TABLE ONLY public.limit_day_of_weeks
 
 ALTER TABLE ONLY public.limits
     ADD CONSTRAINT limits_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: limits no_overlap; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.limits
+    ADD CONSTRAINT no_overlap EXCLUDE USING gist (disruption_id WITH =, route_id WITH =, LEAST(start_stop_id, end_stop_id) WITH =, GREATEST(start_stop_id, end_stop_id) WITH =, daterange(start_date, end_date, '[]'::text) WITH &&) WHERE ((check_for_overlap = true));
 
 
 --
@@ -2394,3 +2417,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20250319170602);
 INSERT INTO public."schema_migrations" (version) VALUES (20250320151207);
 INSERT INTO public."schema_migrations" (version) VALUES (20250326151019);
 INSERT INTO public."schema_migrations" (version) VALUES (20250328193906);
+INSERT INTO public."schema_migrations" (version) VALUES (20250402181804);

--- a/test/arrow_web/controllers/api/limit_controller_test.exs
+++ b/test/arrow_web/controllers/api/limit_controller_test.exs
@@ -166,6 +166,7 @@ defmodule ArrowWeb.API.LimitControllerTest do
       route = insert(:gtfs_route)
       start_stop = insert(:gtfs_stop)
       end_stop = insert(:gtfs_stop)
+      end_stop_2 = insert(:gtfs_stop)
 
       # Limit that starts before and ends during range
       insert(:limit, %{
@@ -182,7 +183,7 @@ defmodule ArrowWeb.API.LimitControllerTest do
         disruption: disruption,
         route: route,
         start_stop: start_stop,
-        end_stop: end_stop,
+        end_stop: end_stop_2,
         start_date: ~D[2025-06-15],
         end_date: ~D[2025-07-15]
       })


### PR DESCRIPTION
Adds an [exclusion constraint] to the limits table that prevents inserting limits that are part of the same disruption, route, have the same boundary stops (regardless of order), and an overlapping date range.

Errors for this exclusion constraint are shown on the `end_date` field per a [Slack discussion with Firas][slack discussion].

[🏹🐛 Disallow users from creating limits with overlapping dates][asana]

[exclusion constraint]: https://postgresql.org/docs/17/interactive/sql-createtable.html#SQL-CREATETABLE-EXCLUDE
[asana]: https://app.asana.com/0/584764604969369/1209829602417088/f
[slack discussion]: https://mbta.slack.com/archives/C06R4UC5A0Y/p1743535027110439?thread_ts=1743529901.408249&cid=C06R4UC5A0Y

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
