### PR TITLE
chore: Pin asdf to 0.15.0 to avoid notice about 0.16 Go rewrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       # only run `asdf install` if we didn't hit the cache
       - uses: asdf-vm/actions/install@v1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
+        with:
+          asdf_branch: v0.15.0
 
   build:
     name: Build Elixir


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** ad hoc
(analogue to [this ticket for gtfs_creator](https://app.asana.com/0/584764604969369/1209642274390141/f))

This prevents asdf from printing notices about the v0.16 Go rewrite every time it runs (i.e., between every single shell command issued during CI)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
