### PR TITLE
fix: prevent saving limit without weekday/time-of-day completed

### DIFF
--- a/lib/arrow/disruptions/limit.ex
+++ b/lib/arrow/disruptions/limit.ex
@@ -69,6 +69,14 @@ defmodule Arrow.Disruptions.Limit do
     |> assoc_constraint(:start_stop)
     |> assoc_constraint(:end_stop)
     |> assoc_constraint(:disruption)
+    |> validate_change(:limit_day_of_weeks, fn
+      :limit_day_of_weeks, value when is_list(value) ->
+        if Enum.any?(value, &get_field(&1, :active?, false)) do
+          []
+        else
+          [limit_day_of_weeks: "at least one day of week must be active"]
+        end
+    end)
   end
 
   @spec validate_start_date_before_end_date(Ecto.Changeset.t(t())) :: Ecto.Changeset.t(t())

--- a/test/support/fixtures/limits_fixtures.ex
+++ b/test/support/fixtures/limits_fixtures.ex
@@ -22,7 +22,9 @@ defmodule Arrow.LimitsFixtures do
         start_stop_id: start_stop.id,
         end_stop_id: end_stop.id,
         route_id: route.id,
-        limit_day_of_weeks: []
+        limit_day_of_weeks: [
+          %{active?: true, day_name: :friday, start_time: "14:00", end_time: "15:00"}
+        ]
       })
       |> Arrow.Limits.create_limit()
 


### PR DESCRIPTION
Adds a validation to the limit changeset to ensure at least one of the limit day of weeks is active. Also handles showing this in the UI either on submission or if the inputs of the day of weeks have changed.

[🏹🐛 Users can save a limit with no days selected](https://app.asana.com/0/584764604969369/1209887002402269/f)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
