### PR TITLE
fix(shuttle): reject shuttles without a route shape

### DIFF
--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -41,8 +41,6 @@ defmodule Arrow.Shuttles.Shuttle do
     status = get_field(changeset, :status)
     # Set error on status field for now
 
-    dbg()
-
     case status do
       :active ->
         routes = get_assoc(changeset, :routes)
@@ -61,7 +59,7 @@ defmodule Arrow.Shuttles.Shuttle do
             )
 
           routes
-          |> Enum.any?(fn route -> !route.shape end) ->
+          |> Enum.any?(fn route -> is_nil(route.data.shape) end) ->
             add_error(
               changeset,
               :status,

--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -41,6 +41,8 @@ defmodule Arrow.Shuttles.Shuttle do
     status = get_field(changeset, :status)
     # Set error on status field for now
 
+    dbg()
+
     case status do
       :active ->
         routes = get_assoc(changeset, :routes)
@@ -56,6 +58,14 @@ defmodule Arrow.Shuttles.Shuttle do
               changeset,
               :status,
               "all stops except the last in each direction must have a time to next stop"
+            )
+
+          routes
+          |> Enum.any?(fn route -> !route.shape end) ->
+            add_error(
+              changeset,
+              :status,
+              "all routes must have an associated shape"
             )
 
           true ->

--- a/test/arrow/shuttle/shuttle_test.exs
+++ b/test/arrow/shuttle/shuttle_test.exs
@@ -18,6 +18,104 @@ defmodule Arrow.Shuttles.ShuttleTest do
              } = changeset
     end
 
+    test "cannot mark a shuttle as active without every route having a shape" do
+      shuttle = shuttle_fixture()
+      [route0, route1] = shuttle.routes
+
+      [stop1, stop2, stop3, stop4] = insert_list(4, :gtfs_stop)
+
+      route0
+      |> Arrow.Shuttles.Route.changeset(%{
+        "route_stops" => [
+          %{
+            "direction_id" => "0",
+            "stop_sequence" => "1",
+            "display_stop_id" => stop1.id,
+            "time_to_next_stop" => 30.0
+          },
+          %{
+            "direction_id" => "0",
+            "stop_sequence" => "2",
+            "display_stop_id" => stop2.id
+          }
+        ],
+        "shape_id" => nil
+      })
+      |> Arrow.Repo.update()
+
+      route1
+      |> Arrow.Shuttles.Route.changeset(%{
+        "route_stops" => [
+          %{
+            "direction_id" => "1",
+            "stop_sequence" => "1",
+            "display_stop_id" => stop3.id,
+            "time_to_next_stop" => 30.0
+          },
+          %{
+            "direction_id" => "0",
+            "stop_sequence" => "2",
+            "display_stop_id" => stop4.id
+          }
+        ]
+      })
+      |> Arrow.Repo.update()
+
+      shuttle = Arrow.Shuttles.get_shuttle!(shuttle.id)
+
+      changeset =
+        Shuttle.changeset(shuttle, %{
+          status: :active,
+          routes: [
+            %{
+              id: route0.id,
+              destination: "Harvard",
+              direction_id: :"0",
+              direction_desc: "South",
+              waypoint: "Brattle",
+              route_stops: [
+                %{
+                  direction_id: :"0",
+                  stop_sequence: 1,
+                  display_stop_id: stop1.id,
+                  time_to_next_stop: 60.0
+                },
+                %{
+                  direction_id: :"0",
+                  stop_sequence: 2,
+                  display_stop_id: stop2.id
+                }
+              ]
+            },
+            %{
+              id: route1.id,
+              destination: "Alewife",
+              direction_id: :"1",
+              direction_desc: "North",
+              waypoint: "Brattle",
+              route_stops: [
+                %{
+                  direction_id: :"1",
+                  stop_sequence: 1,
+                  display_stop_id: stop3.id,
+                  time_to_next_stop: 60.0
+                },
+                %{
+                  direction_id: :"0",
+                  stop_sequence: 1,
+                  display_stop_id: stop4.id
+                }
+              ]
+            }
+          ]
+        })
+
+      assert %Ecto.Changeset{
+               valid?: false,
+               errors: [status: {"all routes must have an associated shape", []}]
+             } = changeset
+    end
+
     test "cannot mark a shuttle as active without times to next stop on applicable stops" do
       shuttle = shuttle_fixture()
       [route0, route1] = shuttle.routes


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 🏹🐛 Some shuttle definitions are marked as active without required fields](https://app.asana.com/0/584764604969369/1209881923550837/f)

Problem:
You can make a shuttle active without the shuttle having a shape for its route.

Solution:
Prevent users from setting a shuttle to active if its route doesn't have a valid shape

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
