### PR TITLE
fix(navbar): resolve header jitter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           name: elixir-lcov
           path: cover/
-      - uses: mbta/actions/dialyzer@v1
+      - uses: mbta/actions/dialyzer@v2
 
   elixir-integration:
     name: Elixir integration tests

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -64,7 +64,3 @@ fieldset fieldset legend {
   font-size: 100%;
   margin-left: 0;
 }
-
-.max-content {
-  width: max-content;
-}

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -64,3 +64,7 @@ fieldset fieldset legend {
   font-size: 100%;
   margin-left: 0;
 }
+
+.max-content {
+  width: max-content;
+}

--- a/assets/css/navbar.css
+++ b/assets/css/navbar.css
@@ -1,3 +1,8 @@
 .navbar-current-page {
   pointer-events: none;
+  width: 19%;
+}
+
+.navbar-other-page {
+  width: 19%;
 }

--- a/lib/arrow_web/components/core_components.ex
+++ b/lib/arrow_web/components/core_components.ex
@@ -599,12 +599,12 @@ defmodule ArrowWeb.CoreComponents do
   def navbar(assigns) do
     pages = [
       {~p"/disruptionsv2", "Disruptions"},
-      {~p"/shuttles", "Shuttle definitions"},
+      {~p"/shuttles", "Shuttles"},
       {~p"/shapes", "Shuttle shapes"},
       {~p"/stops", "Shuttle stops"}
     ]
 
-    if assigns[:page] not in Enum.map(pages, &elem(&1, 0)) do
+    if not Enum.any?(pages, fn {page, _title} -> String.starts_with?(assigns[:page], page) end) do
       raise "navbar component used on an unrecognized page: #{assigns[:page]}"
     end
 
@@ -614,12 +614,20 @@ defmodule ArrowWeb.CoreComponents do
     assigns = assign(assigns, pages: pages, homepage?: homepage?)
 
     ~H"""
-    <div class="col">
+    <div class="col-9">
       <%= if @homepage? do %>
-        <a :if={@create_disruption_permission?} class="btn btn-primary" href={~p"/disruptionsv2/new"}>
+        <a
+          :if={@create_disruption_permission?}
+          class="btn btn-primary navbar-other-page"
+          href={~p"/disruptionsv2/new"}
+        >
           + Create new
         </a>
-        <a :if={not @create_disruption_permission?} class="btn btn-primary" href={~p"/disruptionsv2"}>
+        <a
+          :if={not @create_disruption_permission?}
+          class="btn btn-primary navbar-other-page"
+          href={~p"/disruptionsv2"}
+        >
           Disruptions
         </a>
       <% end %>
@@ -628,9 +636,11 @@ defmodule ArrowWeb.CoreComponents do
         <a :if={current?} class="btn btn-secondary navbar-current-page" aria-disabled="true">
           {label}
         </a>
-        <a :if={not current?} class="btn btn-outline-secondary" href={page}>{label}</a>
+        <a :if={not current?} class="btn btn-outline-secondary navbar-other-page" href={page}>
+          {label}
+        </a>
       <% end %>
-      <a class="btn btn-warning" href={~p"/"}>Switch to Arrow v1</a>
+      <a class="btn btn-warning navbar-other-page" href={~p"/"}>Switch to V1</a>
     </div>
     """
   end

--- a/lib/arrow_web/controllers/disruption_html/index.html.heex
+++ b/lib/arrow_web/controllers/disruption_html/index.html.heex
@@ -1,9 +1,9 @@
 <div class="row my-3">
   <div class="col">
     <%= if Permissions.authorize?(:create_disruption, @user) do %>
-      <a class="btn btn-primary" href="/disruptions/new">+ create new</a>
+      <a class="btn btn-primary" href="/disruptions/new">+ Create new</a>
     <% end %>
-    <a class="btn btn-warning" href="/disruptionsv2">Switch to Arrow v2</a>
+    <a class="btn btn-warning" href="/disruptionsv2">Switch to V2</a>
   </div>
 
   <%= form_tag(Controller.current_path(@conn), method: "get", class: "col-3") do %>

--- a/lib/arrow_web/controllers/shape_html/index.html.heex
+++ b/lib/arrow_web/controllers/shape_html/index.html.heex
@@ -6,7 +6,7 @@
   Listing Shapes
   <:actions>
     <.link href={~p"/shapes_upload"}>
-      <.button class="btn-primary">New Shape</.button>
+      <.button class="btn-primary">New shape</.button>
     </.link>
   </:actions>
 </.header>

--- a/lib/arrow_web/controllers/shuttle_html/index.html.heex
+++ b/lib/arrow_web/controllers/shuttle_html/index.html.heex
@@ -6,7 +6,7 @@
   shuttles
   <:actions>
     <.link href={~p"/shuttles/new"}>
-      <.button>New Shuttle</.button>
+      <.button class="btn btn-primary">New shuttle</.button>
     </.link>
   </:actions>
 </.header>

--- a/lib/arrow_web/controllers/stop_html/index.html.heex
+++ b/lib/arrow_web/controllers/stop_html/index.html.heex
@@ -6,7 +6,7 @@
   Listing Stops
   <:actions>
     <.link href={~p"/stops/new"}>
-      <.button class="btn-primary">New Stop</.button>
+      <.button class="btn-primary">New stop</.button>
     </.link>
   </:actions>
 </.header>

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 15.12 (Postgres.app)
--- Dumped by pg_dump version 15.12 (Postgres.app)
+-- Dumped from database version 15.10 (Debian 15.10-1.pgdg120+1)
+-- Dumped by pg_dump version 15.12 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/test/arrow_web/components/core_components_test.exs
+++ b/test/arrow_web/components/core_components_test.exs
@@ -18,7 +18,7 @@ defmodule ArrowWeb.CoreComponentsTest do
 
       assert [current_page_link] = current_page_links
 
-      assert Floki.text(current_page_link) =~ "Shuttle definitions"
+      assert Floki.text(current_page_link) =~ "Shuttles"
       assert Floki.attribute(current_page_link, "href") == []
     end
 
@@ -87,7 +87,7 @@ defmodule ArrowWeb.CoreComponentsTest do
 
       assert [warning_button] = warning_buttons
 
-      assert Floki.text(warning_button) == "Switch to Arrow v1"
+      assert Floki.text(warning_button) == "Switch to V1"
     end
 
     test "raises an exception if @page is unrecognized" do

--- a/test/integration/disruptions_test.exs
+++ b/test/integration/disruptions_test.exs
@@ -33,7 +33,7 @@ defmodule Arrow.Integration.DisruptionsTest do
     disruption_id =
       session
       |> visit("/")
-      |> click(link("create new"))
+      |> click(link("Create new"))
       |> assert_text("create new disruption")
       |> click(text("Pending"))
       |> click(text("Subway"))


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 🏹💅🏻🇵🇱  Prevent header jitter](https://app.asana.com/0/584764604969369/1209389762315006/f)

Problem:
The navbar tends to "jitter" (more precisely, there is layout shift) when switching pages on the new DisruptionsV2 home view. See the video attached in the Asana ticket I've linked.

Solution:
Set navbar buttons to a fixed width so that their size doesn't change whenever the text within them is rendered. Also revised some stylistic issues with buttons on other pages, and fixed a bug that was breaking sorting for the stops page. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
