### PR TITLE
chore: Only run CI on pushes to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 5 * * *'


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** ad-hoc

CI is doing double work on PRs right now because both the `push` and `pull_request` actions are firing. We really only need to run on `push` when we push to the main branch. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
