### PR TITLE
chore: create/edit disruption pages ui polish

### DIFF
--- a/lib/arrow_web/components/hastus_export_section.ex
+++ b/lib/arrow_web/components/hastus_export_section.ex
@@ -33,7 +33,7 @@ defmodule ArrowWeb.HastusExportSection do
 
   def render(assigns) do
     ~H"""
-    <section id={@id}>
+    <section id={@id} class="py-4 my-4">
       <h3>HASTUS Service Schedules</h3>
       <%= if Ecto.assoc_loaded?(@disruption.hastus_exports) and Enum.any?(@disruption.hastus_exports) do %>
         <div
@@ -226,7 +226,7 @@ defmodule ArrowWeb.HastusExportSection do
                 <div class="col-lg-1"></div>
                 <%= if f_date.index == 0 do %>
                   <div class="col-lg-1">
-                    <.label for={f_service[:import?].id}>import?</.label>
+                    <.label for={f_service[:import?].id}>activate?</.label>
                     <.input
                       class="ml-4"
                       field={f_service[:import?]}
@@ -413,7 +413,7 @@ defmodule ArrowWeb.HastusExportSection do
                | "s3_path" => s3_path
              }) do
         send(self(), :update_disruption)
-        send(self(), {:put_flash, :info, "HASTUS export created successfully"})
+        send(self(), {:put_flash, :info, "HASTUS service schedules imported successfully!"})
 
         {:noreply,
          socket
@@ -446,7 +446,7 @@ defmodule ArrowWeb.HastusExportSection do
       case Hastus.update_export(export, export_params) do
         {:ok, _} ->
           send(self(), :update_disruption)
-          send(self(), {:put_flash, :info, "HASTUS export updated successfully"})
+          send(self(), {:put_flash, :info, "HASTUS service schedules updated successfully!"})
 
           {:noreply,
            socket

--- a/lib/arrow_web/components/limit_section.ex
+++ b/lib/arrow_web/components/limit_section.ex
@@ -21,7 +21,7 @@ defmodule ArrowWeb.LimitSection do
 
   def render(assigns) do
     ~H"""
-    <section id={@id}>
+    <section id={@id} class="py-4 my-4">
       <h3>Limits</h3>
       <%= if Ecto.assoc_loaded?(@disruption.limits) and (Enum.any?(@disruption.limits) or Enum.any?(@disruption.hastus_exports)) do %>
         <div class="mb-3 border-2 border-dashed border-secondary border-mb-3 p-3">

--- a/lib/arrow_web/components/replacement_service_section.ex
+++ b/lib/arrow_web/components/replacement_service_section.ex
@@ -24,7 +24,7 @@ defmodule ArrowWeb.ReplacementServiceSection do
 
   def render(assigns) do
     ~H"""
-    <section id={@id}>
+    <section id={@id} class="py-4 my-4">
       <h3>Replacement Service</h3>
       <%= if Ecto.assoc_loaded?(@disruption.replacement_services) and Enum.any?(@disruption.replacement_services) do %>
         <div
@@ -56,37 +56,39 @@ defmodule ArrowWeb.ReplacementServiceSection do
             </div>
           </div>
           <div class="row mt-3">
-            <div class="col-lg-11">
-              <.button
-                class="btn-link btn-sm pl-0"
-                disabled={!is_nil(@form) or @disabled?}
-                id={"edit_replacement_service-#{replacement_service.id}"}
-                type="button"
-                phx-click="edit_replacement_service"
-                phx-value-replacement_service={replacement_service.id}
-              >
-                <.icon name="hero-pencil-solid" class="bg-primary" /> Edit/Manage Activation
-              </.button>
-              <a
-                class="btn-link btn-sm pl-0"
-                href={~p"/replacement_services/#{replacement_service.id}/timetable"}
-                target="_blank"
-              >
-                <.icon name="hero-table-cells" class="bg-primary" /> View Parsed Timetables
-              </a>
-            </div>
-            <div class="col-lg-1">
-              <.button
-                class="btn-sm"
-                disabled={!is_nil(@form) or @disabled?}
-                type="button"
-                phx-click="delete_replacement_service"
-                phx-value-replacement_service={replacement_service.id}
-                phx-target={@myself}
-                data-confirm="Are you sure you want to delete this replacement service?"
-              >
-                <.icon name="hero-trash-solid" class="bg-primary" />
-              </.button>
+            <div class="flex justify-between w-full px-3 py-2">
+              <div>
+                <.button
+                  class="btn-link btn-sm pl-0"
+                  disabled={!is_nil(@form) or @disabled?}
+                  id={"edit_replacement_service-#{replacement_service.id}"}
+                  type="button"
+                  phx-click="edit_replacement_service"
+                  phx-value-replacement_service={replacement_service.id}
+                >
+                  <.icon name="hero-pencil-solid" class="bg-primary" /> Edit/Manage Activation
+                </.button>
+                <a
+                  class="btn-link btn-sm pl-0"
+                  href={~p"/replacement_services/#{replacement_service.id}/timetable"}
+                  target="_blank"
+                >
+                  <.icon name="hero-table-cells" class="bg-primary" /> View Parsed Timetables
+                </a>
+              </div>
+              <div>
+                <.button
+                  class="btn-sm"
+                  disabled={!is_nil(@form) or @disabled?}
+                  type="button"
+                  phx-click="delete_replacement_service"
+                  phx-value-replacement_service={replacement_service.id}
+                  phx-target={@myself}
+                  data-confirm="Are you sure you want to delete this replacement service?"
+                >
+                  <.icon name="hero-trash-solid" class="bg-primary" />
+                </.button>
+              </div>
             </div>
           </div>
         </div>

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -134,7 +134,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
         disabled?={not is_nil(@hastus_export_in_form) or not is_nil(@limit_in_form)}
       />
 
-      <div class="d-flex justify-content-center">
+      <div class="d-flex justify-content-center py-4 mb-5">
         <div class="w-25 mr-2">
           <.button
             type="submit"


### PR DESCRIPTION
- moves the delete icon to the bottom right corner of the replacement service section
- add vertical padding around each section on the disruptions v2 page
- update copy in service schedules section

[🏹💅🏻🇵🇱 Create/Edit disruption Pages UI polish](https://app.asana.com/1/15492006741476/project/584764604969369/task/1209777154957386?focus=true)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
