### PR TITLE
polish: Shuttle stops headers

### DIFF
--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -176,6 +176,14 @@ defmodule ArrowWeb.ShuttleViewLive do
     ~H"""
     <div id={"stops-dir-#{@direction_id}"} phx-hook="sortable" data-direction_id={@direction_id}>
       <h4>direction {@direction_id}</h4>
+      <div
+        :if={is_list(@f[:route_stops].value) and Enum.any?(@f[:route_stops].value)}
+        class="row item align-items-center mt-3"
+      >
+        <div class="col-lg-1"></div>
+        <div class="col-lg-6">Stop ID</div>
+        <div class="col-lg-4">Time to next stop</div>
+      </div>
       <.inputs_for :let={f_route_stop} field={@f[:route_stops]}>
         <div
           class="row item align-items-center"
@@ -191,13 +199,9 @@ defmodule ArrowWeb.ShuttleViewLive do
                 Phoenix.HTML.Form.input_value(f_route_stop, :gtfs_stop)
             }
             class="col-lg-6"
+            label=""
           />
-          <.input
-            field={f_route_stop[:time_to_next_stop]}
-            type="number"
-            label="Time to next stop"
-            class="col-lg-4"
-          />
+          <.input field={f_route_stop[:time_to_next_stop]} type="number" label="" class="col-lg-4" />
           <button
             class="btn"
             type="button"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹💅🏻🇵🇱 [Shuttle Definitions] In create/edit pages, make stop definition section table with header (don't repeat labels)](https://app.asana.com/1/15492006741476/project/584764604969369/task/1209883863923171?focus=true)

Headers currently show above each row. We only want those headers to show above the first row.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
