### PR TITLE
polish: Differentiate Arrow stops on maps

### DIFF
--- a/assets/src/components/ShapeStopViewMap.tsx
+++ b/assets/src/components/ShapeStopViewMap.tsx
@@ -155,7 +155,12 @@ const MapLayer = ({
                   stop.stop_source
                 )}
               >
-                <Popup>{stop.stop_name}</Popup>
+                <Popup>
+                  <div>{stop.stop_name}</div>
+                  <div>
+                    source: {stop.stop_source === "gtfs" ? "GTFS" : "Arrow"}
+                  </div>
+                </Popup>
               </Marker>
             )
         )}

--- a/assets/src/components/ShapeStopViewMap.tsx
+++ b/assets/src/components/ShapeStopViewMap.tsx
@@ -29,6 +29,7 @@ interface Stop {
   stop_lat: number
   stop_lon: number
   stop_sequence: number
+  stop_source: "arrow" | "gtfs"
 }
 
 interface Layer {

--- a/assets/src/components/ShapeStopViewMap.tsx
+++ b/assets/src/components/ShapeStopViewMap.tsx
@@ -58,16 +58,20 @@ const COLORS = [
   "52bbc5",
 ]
 
-const genIcon = (color: string, text: string) => {
-  const markerHtmlStyles = `
+const genIcon = (color: string, text: string, source: "arrow" | "gtfs") => {
+  let markerHtmlStyles = `
   background-color: #${color};
   display: block;
   width: 30px;
   height: 30px;
-  border-radius: 50% 50% 50% 0;
   position: relative;
   transform: rotate(-45deg);
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);`
+
+  if (source === "gtfs") {
+    markerHtmlStyles = `${markerHtmlStyles}
+  border-radius: 50% 50% 50% 0;`
+  }
 
   const innerCircleStyles = `
   width: 18px;
@@ -145,7 +149,11 @@ const MapLayer = ({
               <Marker
                 key={stop.stop_id}
                 position={[stop.stop_lat, stop.stop_lon]}
-                icon={genIcon(colorValue, stop.stop_sequence.toString())}
+                icon={genIcon(
+                  colorValue,
+                  stop.stop_sequence.toString(),
+                  stop.stop_source
+                )}
               >
                 <Popup>{stop.stop_name}</Popup>
               </Marker>

--- a/lib/arrow_web/controllers/shape_html.ex
+++ b/lib/arrow_web/controllers/shape_html.ex
@@ -96,7 +96,8 @@ defmodule ArrowWeb.ShapeView do
         stop_name: route_stop.stop.stop_name,
         stop_desc: route_stop.stop.stop_desc,
         stop_lat: route_stop.stop.stop_lat,
-        stop_lon: route_stop.stop.stop_lon
+        stop_lon: route_stop.stop.stop_lon,
+        stop_source: :arrow
       }
     end
   end
@@ -116,7 +117,8 @@ defmodule ArrowWeb.ShapeView do
         stop_name: route_stop.gtfs_stop.name,
         stop_desc: route_stop.gtfs_stop.desc,
         stop_lat: route_stop.gtfs_stop.lat,
-        stop_lon: route_stop.gtfs_stop.lon
+        stop_lon: route_stop.gtfs_stop.lon,
+        stop_source: :gtfs
       }
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹💅🏻🇵🇱 [Map Views] Change icon shapes based on stop source (GTFS vs. Arrow)](https://app.asana.com/1/15492006741476/project/584764604969369/task/1208977594353101?focus=true)

Changed icons for Arrow stops. Went the easy route and just removed the border-radius for Arrow stops. They'll look like diamonds instead of the normal circle. Making additional legends seem tricky in react-leaflet so I added the source to the popup instead.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
