### PR TITLE
v1 Arrow API endpoint for active disruptions

### DIFF
--- a/lib/arrow_web/controllers/api/disruption_controller.ex
+++ b/lib/arrow_web/controllers/api/disruption_controller.ex
@@ -1,37 +1,46 @@
 defmodule ArrowWeb.API.DisruptionController do
   use ArrowWeb, :controller
-  alias Arrow.{Disruption, DisruptionRevision, Repo}
   import Ecto.Query
+  alias Arrow.{Disruption, DisruptionRevision, Repo}
+  alias ArrowWeb.API.Util
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def index(conn, _params) do
-    data =
-      from(d in Disruption,
-        join: dr in assoc(d, :revisions),
-        order_by: [d.id, dr.id],
-        where: dr.id >= d.published_revision_id or is_nil(d.published_revision_id),
-        preload: [revisions: {dr, ^DisruptionRevision.associations()}]
-      )
-      |> Repo.all()
+  def index(conn, params) do
+    with {:ok, start_date} <- parse_date_param(params, "start_date"),
+         {:ok, end_date} <- parse_date_param(params, "end_date"),
+         :ok <- Util.validate_date_order(start_date, end_date) do
+      data =
+        from(d in Disruption,
+          join: dr in assoc(d, :revisions),
+          order_by: [d.id, dr.id],
+          where: dr.id >= d.published_revision_id or is_nil(d.published_revision_id),
+          where: dr.is_active,
+          where: dr.start_date <= ^end_date and dr.end_date >= ^start_date,
+          preload: [revisions: {dr, ^DisruptionRevision.associations()}]
+        )
+        |> Repo.all()
 
-    render(conn, "index.json-api", data: data)
+      render(conn, "index.json-api", data: data)
+    else
+      {:error, :invalid_date_order} ->
+        conn
+        |> put_status(409)
+        |> json(%{error: "`end_date` must be after `start_date`"})
+
+      {{:error, :invalid_date}, name} ->
+        conn
+        |> put_status(400)
+        |> json(%{error: "`#{name}` is not a valid date"})
+    end
   end
 
-  @spec active(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def active(conn, _params) do
-    cutoff = Date.utc_today() |> Date.add(-7)
+  defp parse_date_param(params, name) do
+    case Util.parse_date(Map.get(params, name)) do
+      {:ok, date} ->
+        {:ok, date}
 
-    data =
-      from(d in Disruption,
-        join: dr in assoc(d, :revisions),
-        order_by: [d.id, dr.id],
-        where:
-          (dr.id >= d.published_revision_id or is_nil(d.published_revision_id)) and dr.is_active and
-            (is_nil(dr.end_date) or dr.end_date > ^cutoff),
-        preload: [revisions: {dr, ^DisruptionRevision.associations()}]
-      )
-      |> Repo.all()
-
-    render(conn, "index.json-api", data: data)
+      error ->
+        {error, name}
+    end
   end
 end

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -94,7 +94,6 @@ defmodule ArrowWeb.Router do
     get("/shuttles", ShuttleController, :index)
     get("/limits", LimitController, :index)
     get("/disruptions", DisruptionController, :index)
-    get("/active-disruptions", DisruptionController, :active)
     get("/adjustments", AdjustmentController, :index)
     get("/shuttle-stops", StopsController, :index)
 

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -93,9 +93,10 @@ defmodule ArrowWeb.Router do
     get("/replacement-service", ReplacementServiceController, :index)
     get("/shuttles", ShuttleController, :index)
     get("/limits", LimitController, :index)
-    resources("/disruptions", DisruptionController, only: [:index])
-    resources("/adjustments", AdjustmentController, only: [:index])
-    resources("/shuttle-stops", StopsController, only: [:index])
+    get("/disruptions", DisruptionController, :index)
+    get("/active-disruptions", DisruptionController, :active)
+    get("/adjustments", AdjustmentController, :index)
+    get("/shuttle-stops", StopsController, :index)
 
     get "/service-schedules", ServiceScheduleController, :index
   end

--- a/test/arrow_web/controllers/api/disruption_controller_test.exs
+++ b/test/arrow_web/controllers/api/disruption_controller_test.exs
@@ -7,12 +7,14 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
   describe "index/2" do
     @tag :authenticated
     test "non-admin user can access the disruptions API", %{conn: conn} do
-      assert %{status: 200} = get(conn, "/api/disruptions")
+      assert %{status: 200} =
+               get(conn, "/api/disruptions", start_date: "2019-10-01", end_date: "2019-12-01")
     end
 
     @tag :authenticated_admin
     test "returns 200", %{conn: conn} do
-      assert %{status: 200} = get(conn, "/api/disruptions")
+      assert %{status: 200} =
+               get(conn, "/api/disruptions", start_date: "2019-10-01", end_date: "2019-12-01")
     end
 
     @tag :authenticated_admin
@@ -48,7 +50,11 @@ defmodule ArrowWeb.API.DisruptionControllerTest do
 
       {:ok, _multi} = Disruption.update(d1.id, "author", %{end_date: ~D[2020-01-01]})
 
-      res = json_response(get(conn, "/api/disruptions"), 200)
+      res =
+        json_response(
+          get(conn, "/api/disruptions", start_date: "2019-10-01", end_date: "2019-12-01"),
+          200
+        )
 
       assert %{
                "data" => data,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** ad-hoc

In the current v1 Arrow disruptions endpoint, we return every disruptions whether it is active or not. This creates a lot of extra work for gtfs_creator because it applies all of these disruptions even though they will be truncated out for being outside the current rating. Adding this endpoint for gtfs_creator to use in an upcoming PR. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
