### PR TITLE
Move suffix from shuttle_routes to shuttles.

### DIFF
--- a/lib/arrow/shuttles/route.ex
+++ b/lib/arrow/shuttles/route.ex
@@ -17,7 +17,6 @@ defmodule Arrow.Shuttles.Route do
     do: @direction_1_desc_values
 
   @type t :: %__MODULE__{
-          suffix: String.t(),
           destination: String.t(),
           direction_id: :"0" | :"1",
           direction_desc: :Inbound | :Outbound | :North | :South | :East | :West,
@@ -28,7 +27,6 @@ defmodule Arrow.Shuttles.Route do
         }
 
   schema "shuttle_routes" do
-    field :suffix, :string
     field :destination, :string
     field :direction_id, Ecto.Enum, values: [:"0", :"1"]
     field :direction_desc, Ecto.Enum, values: @direction_0_desc_values ++ @direction_1_desc_values
@@ -47,7 +45,7 @@ defmodule Arrow.Shuttles.Route do
   @doc false
   def changeset(route, attrs) do
     route
-    |> cast(attrs, [:direction_id, :direction_desc, :destination, :waypoint, :suffix, :shape_id])
+    |> cast(attrs, [:direction_id, :direction_desc, :destination, :waypoint, :shape_id])
     |> cast_assoc(:route_stops,
       with: &Arrow.Shuttles.RouteStop.changeset/2,
       sort_param: :route_stops_sort,

--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -12,13 +12,15 @@ defmodule Arrow.Shuttles.Shuttle do
           id: id,
           status: :draft | :active | :inactive,
           shuttle_name: String.t(),
-          disrupted_route_id: String.t()
+          disrupted_route_id: String.t(),
+          suffix: String.t()
         }
 
   schema "shuttles" do
     field :status, Ecto.Enum, values: [:draft, :active, :inactive]
     field :shuttle_name, :string
     field :disrupted_route_id, :string
+    field :suffix, :string
 
     has_many :routes, Arrow.Shuttles.Route, preload_order: [asc: :direction_id]
 
@@ -28,7 +30,7 @@ defmodule Arrow.Shuttles.Shuttle do
   @doc false
   def changeset(shuttle, attrs) do
     shuttle
-    |> cast(attrs, [:shuttle_name, :disrupted_route_id, :status])
+    |> cast(attrs, [:shuttle_name, :disrupted_route_id, :status, :suffix])
     |> cast_assoc(:routes, with: &Arrow.Shuttles.Route.changeset/2)
     |> validate_required([:shuttle_name, :status])
     |> validate_required_for(:status)

--- a/lib/arrow_web/controllers/api_json/shuttle_route_view.ex
+++ b/lib/arrow_web/controllers/api_json/shuttle_route_view.ex
@@ -2,7 +2,7 @@ defmodule ArrowWeb.API.ShuttleRouteView do
   use ArrowWeb, :html
   use JaSerializer.PhoenixView
 
-  attributes([:suffix, :destination, :direction_id, :direction_desc, :waypoint, :shape_id])
+  attributes([:destination, :direction_id, :direction_desc, :waypoint, :shape_id])
 
   has_many :route_stops,
     serializer: ArrowWeb.API.ShuttleRouteStopView,

--- a/lib/arrow_web/controllers/api_json/shuttle_view.ex
+++ b/lib/arrow_web/controllers/api_json/shuttle_view.ex
@@ -2,7 +2,7 @@ defmodule ArrowWeb.API.ShuttleView do
   use ArrowWeb, :html
   use JaSerializer.PhoenixView
 
-  attributes([:status, :shuttle_name, :disrupted_route_id])
+  attributes([:status, :shuttle_name, :disrupted_route_id, :suffix])
 
   has_many :routes,
     serializer: ArrowWeb.API.ShuttleRouteView,

--- a/lib/arrow_web/live/shuttle_live/shuttle_live.ex
+++ b/lib/arrow_web/live/shuttle_live/shuttle_live.ex
@@ -57,6 +57,9 @@ defmodule ArrowWeb.ShuttleViewLive do
             options={Ecto.Enum.values(Arrow.Shuttles.Shuttle, :status)}
           />
         </div>
+        <div class="col">
+          <.input field={@form[:suffix]} type="text" label="Suffix" />
+        </div>
       </div>
       <div class="row mb-3">
         <div class="col">
@@ -112,11 +115,6 @@ defmodule ArrowWeb.ShuttleViewLive do
               </div>
               <div class="col">
                 <.input field={f_route[:waypoint]} type="text" label="Waypoint" />
-              </div>
-            </div>
-            <div class="row">
-              <div class="col">
-                <.input field={f_route[:suffix]} type="text" label="Suffix" />
               </div>
             </div>
           </div>

--- a/priv/repo/migrations/20250501125059_move_shuttle_suffix_column.exs
+++ b/priv/repo/migrations/20250501125059_move_shuttle_suffix_column.exs
@@ -1,0 +1,13 @@
+defmodule Arrow.Repo.Migrations.MoveShuttleSuffixColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table(:shuttles) do
+      add :suffix, :string
+    end
+
+    alter table(:shuttle_routes) do
+      remove :suffix
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -1129,7 +1129,6 @@ CREATE TABLE public.shuttle_routes (
     direction_desc character varying(255),
     destination character varying(255),
     waypoint character varying(255),
-    suffix character varying(255),
     shuttle_id bigint,
     shape_id bigint,
     inserted_at timestamp with time zone NOT NULL,
@@ -1166,7 +1165,8 @@ CREATE TABLE public.shuttles (
     disrupted_route_id character varying,
     status character varying(255),
     inserted_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL
+    updated_at timestamp with time zone NOT NULL,
+    suffix character varying(255)
 );
 
 
@@ -2420,3 +2420,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20250328193906);
 INSERT INTO public."schema_migrations" (version) VALUES (20250402181804);
 INSERT INTO public."schema_migrations" (version) VALUES (20250403191728);
 INSERT INTO public."schema_migrations" (version) VALUES (20250410180228);
+INSERT INTO public."schema_migrations" (version) VALUES (20250501125059);

--- a/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
+++ b/test/arrow_web/live/shuttle_live/shuttle_live_test.exs
@@ -10,6 +10,7 @@ defmodule ArrowWeb.ShuttleLiveTest do
 
   @create_attrs %{
     disrupted_route_id: "",
+    suffix: "",
     routes: %{
       "0" => %{
         :_persistent_id => "0",
@@ -17,7 +18,6 @@ defmodule ArrowWeb.ShuttleLiveTest do
         direction_desc: "South",
         direction_id: "0",
         shape_id: "",
-        suffix: "",
         waypoint: ""
       },
       "1" => %{
@@ -26,7 +26,6 @@ defmodule ArrowWeb.ShuttleLiveTest do
         direction_desc: "North",
         direction_id: "1",
         shape_id: "",
-        suffix: "",
         waypoint: ""
       }
     },
@@ -36,13 +35,13 @@ defmodule ArrowWeb.ShuttleLiveTest do
 
   @update_attrs %{
     disrupted_route_id: "",
+    suffix: "",
     routes: %{
       "0" => %{
         :_persistent_id => "0",
         destination: "Broadway",
         direction_desc: "Outbound",
         direction_id: "0",
-        suffix: "",
         waypoint: ""
       },
       "1" => %{
@@ -50,7 +49,6 @@ defmodule ArrowWeb.ShuttleLiveTest do
         destination: "Harvard",
         direction_desc: "North",
         direction_id: "1",
-        suffix: "",
         waypoint: ""
       }
     },
@@ -242,7 +240,6 @@ defmodule ArrowWeb.ShuttleLiveTest do
             destination: "Broadway",
             direction_desc: "South",
             direction_id: "0",
-            suffix: "",
             waypoint: "",
             route_stops: %{
               "0" => %{

--- a/test/support/fixtures/shuttles_fixtures.ex
+++ b/test/support/fixtures/shuttles_fixtures.ex
@@ -124,7 +124,6 @@ defmodule Arrow.ShuttlesFixtures do
         destination: "Harvard",
         direction_id: :"0",
         direction_desc: :South,
-        suffix: nil,
         waypoint: "Brattle",
         route_stops: route_stops
       },
@@ -134,7 +133,6 @@ defmodule Arrow.ShuttlesFixtures do
         destination: "Alewife",
         direction_id: :"1",
         direction_desc: :North,
-        suffix: nil,
         waypoint: "Brattle",
         route_stops: route_stops
       }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** ad-hoc

We are adding Local and Express shuttles to Arrow for the first time and found that suffixes aren't being applied to the shuttle routes correctly. This lead me to realize that this field is associated with the wrong model. There should be a single `Suffix` input for each shuttle instead of one for each shuttle direction.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
