### PR TITLE
Don't fail if not given any revision_ids.

### DIFF
--- a/lib/arrow_web/controllers/api/notice_controller.ex
+++ b/lib/arrow_web/controllers/api/notice_controller.ex
@@ -6,6 +6,10 @@ defmodule ArrowWeb.API.NoticeController do
   plug(Authorize, :publish_notice)
 
   @spec publish(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def publish(conn, %{"revision_ids" => ""}) do
+    send_resp(conn, 200, "")
+  end
+
   def publish(conn, params) do
     revision_ids = params["revision_ids"] |> String.split(",") |> Enum.map(&String.to_integer/1)
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** ad-hoc

This failure didn't pop up until running the prod deploy. Now that there is a good chance we won't process any v1 disruptions, we should handle an empty list of `revision_ids`.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
