### PR TITLE
fix: error when attempting to delete shapes that are used by shuttles

### DIFF
--- a/lib/arrow_web/controllers/shape_controller.ex
+++ b/lib/arrow_web/controllers/shape_controller.ex
@@ -132,11 +132,27 @@ defmodule ArrowWeb.ShapeController do
 
   def delete(conn, %{"name" => name}) do
     shape = Shuttles.get_shape_by_name!(name)
-    {:ok, _shape} = Shuttles.delete_shape(shape)
 
-    conn
-    |> put_flash(:info, "Shape deleted successfully.")
-    |> redirect(to: ~p"/shapes")
+    case Shuttles.delete_shape(shape) do
+      {:ok, _shape} ->
+        conn
+        |> put_flash(:info, "Shape deleted successfully.")
+        |> redirect(to: ~p"/shapes")
+
+      {:error, error} ->
+        message =
+          case error do
+            error when is_binary(error) ->
+              error
+
+            error ->
+              inspect(error)
+          end
+
+        conn
+        |> put_flash(:error, message)
+        |> redirect(to: ~p"/shapes")
+    end
   end
 
   defp reset_upload do


### PR DESCRIPTION
Shape deletion would sometimes leave things in a broken state. If a shape was used by a shuttle the delete operation would first delete the saved shape file and then fail to delete the database record because of the foreign key constraint on `shuttle_routes`. This change refactors that code to prevent this broken state and provide better feedback to the user.

- Reorders the database and saved shape file deletion so that the database delete happens _before_ the saved shape file delete. This ensures that if a database operation fails the saved shape file isn't deleted (this is what was causing the 500 errors).
- Wraps the delete in the database and the delete of the saved shape in a database transaction to ensure that a failure to delete the remote shape does not delete the database record
- Adds a check to the `delete_shape` method to check for shuttles that are using the shape. Returns an error including a message that lists the shuttles using that shape if the shape is currently in use.
- Displays the new error message as an error flash if deleting a shape fails

Note: this does not fix any shapes that were broken by the old behavior.


https://github.com/user-attachments/assets/cb15a97f-23df-4c0c-92fe-75139e46fff8

[Asana task](https://app.asana.com/1/15492006741476/project/584764604969369/task/1210046524302364?focus=true)