### PR TITLE
fix: handle errors when a shape file is missing

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -55,28 +55,43 @@
       }
     },
     "../deps/live_select": {
-      "version": "1.5.2",
+      "version": "1.6.0",
       "license": "Apache License 2.0"
     },
     "../deps/phoenix": {
-      "version": "1.7.18",
+      "version": "1.7.21",
       "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "4.2.0"
+      "version": "4.2.1"
     },
     "../deps/phoenix_live_react": {
       "version": "0.4.2",
       "license": "MIT"
     },
     "../deps/phoenix_live_view": {
-      "version": "1.0.1",
+      "version": "1.0.9",
       "license": "MIT",
+      "dependencies": {
+        "morphdom": "2.7.4"
+      },
       "devDependencies": {
-        "@eslint/js": "^9.10.0",
-        "@playwright/test": "^1.47.1",
+        "@babel/cli": "7.26.4",
+        "@babel/core": "7.26.0",
+        "@babel/preset-env": "7.26.0",
+        "@eslint/js": "^9.18.0",
+        "@playwright/test": "^1.49.1",
+        "@stylistic/eslint-plugin-js": "^2.12.1",
+        "css.escape": "^1.5.1",
+        "eslint": "9.18.0",
+        "eslint-plugin-jest": "28.10.0",
         "eslint-plugin-playwright": "^2.1.0",
-        "monocart-reporter": "^2.8.0"
+        "globals": "^15.14.0",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "jest-monocart-coverage": "^1.1.1",
+        "monocart-reporter": "^2.9.13",
+        "phoenix": "1.7.18"
       }
     },
     "../deps/react_phoenix": {

--- a/assets/src/components/ShapeViewMap.tsx
+++ b/assets/src/components/ShapeViewMap.tsx
@@ -17,6 +17,7 @@ interface Shape {
 interface ShapeViewMapProps {
   shapes: Shape[]
 }
+type ShapeViewMapContainerProps = ShapeViewMapProps | { error: string }
 
 const COLORS = [
   "da291c",
@@ -141,4 +142,10 @@ const ShapeViewMap = ({ shapes }: ShapeViewMapProps) => {
   )
 }
 
-export default ShapeViewMap
+const ShapeViewMapContainer = (props: ShapeViewMapContainerProps) => {
+  if ("error" in props)
+    return <p className="text-red-500">Error: {props.error}</p>
+  return <ShapeViewMap {...props} />
+}
+
+export default ShapeViewMapContainer

--- a/lib/arrow/shuttles.ex
+++ b/lib/arrow/shuttles.ex
@@ -81,14 +81,14 @@ defmodule Arrow.Shuttles do
   ## Examples
 
       iex> get_shapes_upload(%Shape{})
-      %ShapesUpload{}
+      {:ok, %Ecto.Changeset{data: %ShapesUpload{}}
   """
   def get_shapes_upload(%Shape{} = shape) do
     with true <- Application.get_env(:arrow, :shape_storage_enabled?),
          {:ok, %{body: shapes_kml}} <- get_shape_file(shape),
          {:ok, parsed_shapes} <- ShapesUpload.parse_kml(shapes_kml),
          {:ok, shapes} <- ShapesUpload.shapes_from_kml(parsed_shapes) do
-      ShapesUpload.changeset(%ShapesUpload{}, %{filename: shape.name, shapes: shapes})
+      {:ok, ShapesUpload.changeset(%ShapesUpload{}, %{filename: shape.name, shapes: shapes})}
     else
       false -> {:ok, :disabled}
       error -> error

--- a/lib/arrow_web/controllers/shape_controller.ex
+++ b/lib/arrow_web/controllers/shape_controller.ex
@@ -108,7 +108,13 @@ defmodule ArrowWeb.ShapeController do
 
   def show(conn, %{"name" => name}) do
     shape = Shuttles.get_shape_by_name!(name)
-    shape_upload = Shuttles.get_shapes_upload(shape)
+
+    shape_upload =
+      case Shuttles.get_shapes_upload(shape) do
+        {:ok, shape_upload} -> shape_upload
+        _ -> nil
+      end
+
     render(conn, :show, shape: shape, shape_upload: shape_upload)
   end
 

--- a/lib/arrow_web/controllers/shape_html.ex
+++ b/lib/arrow_web/controllers/shape_html.ex
@@ -24,6 +24,8 @@ defmodule ArrowWeb.ShapeView do
 
   def shapes_map_view({:ok, :disabled}), do: %{}
 
+  def shapes_map_view(_), do: %{error: "Failed to load shape file"}
+
   defp shape_map_view(%{coordinates: coordinates, name: name}) do
     %{
       coordinates: map_coordinates(coordinates),
@@ -73,11 +75,16 @@ defmodule ArrowWeb.ShapeView do
   defp shape_to_shapeview(%Shape{bucket: "disabled"}), do: nil
 
   defp shape_to_shapeview(%Shape{} = shape) do
-    shape
-    |> Shuttles.get_shapes_upload()
-    |> shapes_map_view()
-    |> Map.get(:shapes)
-    |> List.first()
+    case Shuttles.get_shapes_upload(shape) do
+      {:ok, shapes_upload} ->
+        shapes_upload
+        |> shapes_map_view()
+        |> Map.get(:shapes)
+        |> List.first()
+
+      {:error, _} ->
+        nil
+    end
   end
 
   defp shape_to_shapeview(_), do: nil

--- a/test/arrow/shuttles_test.exs
+++ b/test/arrow/shuttles_test.exs
@@ -49,7 +49,7 @@ defmodule Arrow.ShuttlesTest do
 
       new_shape = s3_mocked_shape_fixture()
       shape = Shuttles.get_shape!(new_shape.id)
-      assert %Ecto.Changeset{valid?: true} = Shuttles.get_shapes_upload(shape)
+      assert {:ok, %Ecto.Changeset{valid?: true}} = Shuttles.get_shapes_upload(shape)
     end
   end
 


### PR DESCRIPTION
Updates some codepaths to prevent 500 errors on pages that reference a broken shape.

Viewing a broken shape will flag that the shape is broken. Viewing a shuttle that references a broken shape will simply not have any shapes to render (the failure is silent).

[Asana task](https://app.asana.com/1/15492006741476/project/584764604969369/task/1210046524302364?focus=true)
