### PR TITLE
feat: add download of list of trips/services with missing shapes

### DIFF
--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -23,6 +23,37 @@ declare global {
   }
 }
 
+interface DownloadFileEventDetails {
+  base64?: boolean
+  filename: string
+  content_type: string
+  contents: string
+}
+
+window.addEventListener("phx:download-file", (event: unknown) => {
+  if (event == null || typeof event != "object" || !("detail" in event)) {
+    throw new Error(`download-file event missing 'detail'`)
+  }
+
+  const {
+    base64 = false,
+    filename,
+    content_type: contentType,
+    contents,
+  } = event.detail as DownloadFileEventDetails
+  const encodedContents = encodeURIComponent(contents)
+  const element = document.createElement("a")
+  element.setAttribute(
+    "href",
+    `data:${contentType}${base64 ? ";base64" : ""},${encodedContents}`
+  )
+  element.setAttribute("download", filename)
+  element.style.display = "none"
+  document.body.appendChild(element)
+  element.click()
+  document.body.removeChild(element)
+})
+
 const sortable = {
   mounted() {
     new Sortable(this.el, {


### PR DESCRIPTION
Updates the edit hastus export form to special case when a hastus export has trips with invalid or missing shapes.

Also adds a new `send_download` function in `CoreComponents` which uses a new client-side event handler to send data over the existing LiveSocket connection and trigger a client-side download of that data. This makes sending one-off files from a LiveView much easier than the alternative of creating a separate controller to send the file.

[Asana task](https://app.asana.com/1/15492006741476/project/584764604969369/task/1210125477521799?focus=true)