### PR TITLE
Fix: Shuttle Stop Reordering

### DIFF
--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -33,13 +33,15 @@ const sortable = {
       ghostClass: "drag-ghost",
       forceFallback: true,
       onEnd: (e) => {
-        const params = {
-          old: e.oldDraggableIndex,
-          new: e.newDraggableIndex,
-          ...e.item.dataset,
-          ...this.el.dataset,
+        if (e.oldDraggableIndex && e.newDraggableIndex) {
+          const params = {
+            old: e.oldDraggableIndex - 1,
+            new: e.newDraggableIndex - 1,
+            ...e.item.dataset,
+            ...this.el.dataset,
+          }
+          this.pushEventTo(this.el, "reorder_stops", params)
         }
-        this.pushEventTo(this.el, "reorder_stops", params)
       },
     })
   },


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** ad-hoc

`oldDraggableIndex` and `newDraggableIndex` appear to be one-indexed instead of zero-indexed. This causes an `Enum.at/2` call in `shuttle_live.ex` to return `nil` instead of the moved stop struct. Subtracting one from each allows the reordering to work as expected.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
