### PR TITLE
feat(limits): Warn on days-of-week outside of the specified date range

### DIFF
--- a/lib/arrow_web/components/edit_limit_form.ex
+++ b/lib/arrow_web/components/edit_limit_form.ex
@@ -137,19 +137,13 @@ defmodule ArrowWeb.EditLimitForm do
                   </div>
                 </div>
               </div>
-            </.inputs_for>
-            <div
-              :if={not Enum.empty?(mismatches = mismatched_date_range_day_of_weeks(@limit_form))}
-              class="row"
-            >
-              <div class="col text-sm text-danger align-self-center">
-                {mismatches
-                |> Enum.map_join(", ", &String.capitalize(Atom.to_string(&1)))
-                |> then(
-                  &"The selected date range does not include the following day(s) of the week: #{&1}"
-                )}
+              <div :for={err <- f_day_of_week[:day_name].errors} class="row">
+                <div class="col text-sm text-danger mb-3">
+                  <.icon name="hero-exclamation-circle-mini" class="h-4 w-4" />
+                  {translate_error(err)}
+                </div>
               </div>
-            </div>
+            </.inputs_for>
           </div>
           <.error :for={err <- @limit_form[:limit_day_of_weeks].errors}>
             {translate_error(err)}
@@ -308,68 +302,5 @@ defmodule ArrowWeb.EditLimitForm do
     else
       ""
     end
-  end
-
-  @day_of_week_atoms ~w[monday tuesday wednesday thursday friday saturday sunday]a
-
-  defp mismatched_date_range_day_of_weeks(form) do
-    import Ecto.Changeset, only: [get_field: 3, fetch_field!: 2]
-
-    active_days =
-      case input_value(form, :limit_day_of_weeks) do
-        # Day of week inputs have not yet been interacted with,
-        # but we should still show the warning if editing an existing disruption with mismatched dates/days.
-        [%Arrow.Limits.LimitDayOfWeek{} | _] = day_of_weeks ->
-          for %{active?: true} = dow <- day_of_weeks, do: dow.day_name
-
-        [%Ecto.Changeset{} | _] = day_of_weeks ->
-          for cs <- day_of_weeks, get_field(cs, :active?, false), do: fetch_field!(cs, :day_name)
-
-        # For some reason it turns into a map sometimes??
-        %{} = day_of_weeks ->
-          for %{"active?" => "true"} = dow <- Map.values(day_of_weeks), do: dow["day_name"]
-      end
-      |> MapSet.new(&normalize_day_of_week/1)
-
-    days_in_range =
-      day_of_weeks_in_range(
-        normalize_date(input_value(form, :start_date)),
-        normalize_date(input_value(form, :end_date))
-      )
-
-    active_days_outside_range =
-      MapSet.difference(active_days, days_in_range)
-
-    Enum.filter(@day_of_week_atoms, &(&1 in active_days_outside_range))
-  end
-
-  defp day_of_weeks_in_range(first_date, last_date)
-
-  defp day_of_weeks_in_range(first_date, last_date)
-       when is_nil(first_date)
-       when is_nil(last_date),
-       do: MapSet.new(@day_of_week_atoms)
-
-  defp day_of_weeks_in_range(first_date, last_date) do
-    first_date
-    |> Stream.iterate(&Date.add(&1, 1))
-    |> Stream.take_while(&(Date.compare(&1, last_date) in [:lt, :eq]))
-    |> Stream.take(7)
-    |> MapSet.new(&normalize_day_of_week/1)
-  end
-
-  defp normalize_date(%Date{} = date), do: date
-  defp normalize_date(nil), do: nil
-  defp normalize_date(""), do: nil
-  defp normalize_date(timestamp) when is_binary(timestamp), do: Date.from_iso8601!(timestamp)
-
-  # Converts Dates, strings, and integers to atoms like :monday, :tuesday, etc.
-  defp normalize_day_of_week(%Date{} = date), do: normalize_day_of_week(Date.day_of_week(date))
-  defp normalize_day_of_week(atom) when atom in @day_of_week_atoms, do: atom
-
-  for {atom, int} <- Enum.with_index(@day_of_week_atoms, 1) do
-    str = Atom.to_string(atom)
-    defp normalize_day_of_week(unquote(int)), do: unquote(atom)
-    defp normalize_day_of_week(unquote(str)), do: unquote(atom)
   end
 end

--- a/test/arrow/disruptions/limit_test.exs
+++ b/test/arrow/disruptions/limit_test.exs
@@ -1,0 +1,63 @@
+defmodule Arrow.Disruptions.LimitTest do
+  use Arrow.DataCase
+
+  alias Arrow.Disruptions.Limit
+
+  describe "changeset/2" do
+    test "adds errors to child LimitDayOfWeeks that are outside the date range" do
+      monday = ~D[2025-05-12]
+      thursday = ~D[2025-05-15]
+
+      initial_active_days =
+        [
+          monday: true,
+          tuesday: true,
+          wednesday: true,
+          thursday: true,
+          friday: false,
+          saturday: false,
+          sunday: false
+        ]
+
+      dows =
+        Enum.with_index(initial_active_days, fn {day_name, active?}, i ->
+          build(:limit_day_of_week, day_name: day_name, active?: active?, id: i)
+        end)
+
+      limit = build(:limit, start_date: monday, end_date: thursday, limit_day_of_weeks: dows)
+
+      dow_change_attrs =
+        initial_active_days
+        |> Keyword.replace!(:friday, true)
+        |> Keyword.replace!(:sunday, true)
+        # Let's make sure there are no issues with an _inactive_ day within the range.
+        |> Keyword.replace!(:tuesday, false)
+        |> Enum.with_index(fn {day_name, active?}, i ->
+          %{day_name: day_name, active?: active?, id: i}
+        end)
+
+      limit_changeset = Limit.changeset(limit, %{limit_day_of_weeks: dow_change_attrs})
+
+      dow_changesets = get_change(limit_changeset, :limit_day_of_weeks)
+
+      expected_error = fn day ->
+        day = day |> Atom.to_string() |> String.capitalize()
+        {:day_name, {"Dates specified above do not include a #{day}", []}}
+      end
+
+      [
+        tuesday: true,
+        friday: false,
+        sunday: false
+      ]
+      |> Enum.each(fn {day, valid?} ->
+        changeset = Enum.find(dow_changesets, &(get_field(&1, :day_name) == day))
+        assert changeset.valid? == valid?
+
+        if not valid? do
+          assert expected_error.(day) in changeset.errors
+        end
+      end)
+    end
+  end
+end

--- a/test/integration/disruptions_v2_test.exs
+++ b/test/integration/disruptions_v2_test.exs
@@ -9,10 +9,20 @@ defmodule Arrow.Integration.DisruptionsV2Test do
 
   feature "can view disruption on home page", %{session: session} do
     disruption =
-      create_disruption(%{start_date: ~D[2024-12-31], end_date: ~D[2025-01-01]}, %{
-        start_date: ~D[2024-01-01],
-        end_date: ~D[2024-12-01]
-      })
+      create_disruption(
+        %{
+          start_date: ~D[2024-12-31],
+          end_date: ~D[2025-01-01],
+          limit_day_of_weeks: [
+            %{active?: true, day_name: :tuesday, start_time: "14:00", end_time: "15:00"},
+            %{active?: true, day_name: :wednesday, start_time: "14:00", end_time: "15:00"}
+          ]
+        },
+        %{
+          start_date: ~D[2024-01-01],
+          end_date: ~D[2024-12-01]
+        }
+      )
 
     session
     |> visit("/")

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -77,6 +77,7 @@ defmodule Arrow.Factory do
     %Arrow.Limits.LimitDayOfWeek{
       day_name: :monday,
       active?: true,
+      all_day?: true,
       limit: build(:limit)
     }
   end

--- a/test/support/fixtures/limits_fixtures.ex
+++ b/test/support/fixtures/limits_fixtures.ex
@@ -17,8 +17,8 @@ defmodule Arrow.LimitsFixtures do
     {:ok, limit} =
       attrs
       |> Enum.into(%{
-        end_date: ~D[2025-01-09],
-        start_date: ~D[2025-01-08],
+        end_date: ~D[2025-01-06],
+        start_date: ~D[2025-01-10],
         start_stop_id: start_stop.id,
         end_stop_id: end_stop.id,
         route_id: route.id,

--- a/test/support/fixtures/limits_fixtures.ex
+++ b/test/support/fixtures/limits_fixtures.ex
@@ -17,8 +17,8 @@ defmodule Arrow.LimitsFixtures do
     {:ok, limit} =
       attrs
       |> Enum.into(%{
-        end_date: ~D[2025-01-06],
-        start_date: ~D[2025-01-10],
+        start_date: ~D[2025-01-06],
+        end_date: ~D[2025-01-10],
         start_stop_id: start_stop.id,
         end_stop_id: end_stop.id,
         route_id: route.id,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹💅🏻🇵🇱 [Limit Create/Edit] Warn on user selecting out-of-range dates/days-of-week](🏹💅🏻🇵🇱 [Limit Create/Edit] Warn on user selecting out-of-range dates/days-of-week)

User is now prevented from saving a limit if it has an active day outside of its specified date range.

<details>
<summary>Demo of the validation in create workflow</summary>

https://github.com/user-attachments/assets/a377038d-6c7d-4648-b5db-85ef52b15fcc
</details>

<details>
<summary>Demo of the validation in edit workflow</summary>

https://github.com/user-attachments/assets/b1ffbcf0-f800-45b2-a2e7-16cbb923518d
</details>

---

**I did a slightly non-standard thing for this:**

I wanted the error message to appear under the offending day-of-week row(s), but the error applies to the entire day-of-week and not a specific one of its fields.

So, I applied the error to the `:day_name` field and added a custom div below the row that displays the error (since the input for that field is hidden).

I'm open to suggestions for a better way to do this!

---

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
