### PR TITLE
fix: Don't change is_active on page load.

### DIFF
--- a/lib/arrow_web/components/edit_disruption_form.ex
+++ b/lib/arrow_web/components/edit_disruption_form.ex
@@ -139,7 +139,7 @@ defmodule ArrowWeb.EditDisruptionForm do
       assign(socket,
         form:
           assigns[:disruption]
-          |> Disruptions.change_disruption_v2(%{is_active: false, mode: :subway})
+          |> Disruptions.change_disruption_v2(%{mode: :subway})
           |> to_form(),
         icon_paths: assigns[:icon_paths],
         disruption: assigns[:disruption]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹🐛 [Edit Disruption] Editing disruption fundamentals changes approval status](https://app.asana.com/1/15492006741476/project/584764604969369/task/1210251521149558?focus=true)

I think this is left over from pre-refactor. We only want to hardcode the value of `is_active` for new disruptions. On this edit page, just use the value the disruption already has.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
