### PR TITLE
feat: Derive disruption limits from HASTUS exports

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -18,6 +18,7 @@
 @import "./footer.css";
 @import "./header.css";
 @import "./icon.css";
+@import "./limit_section.css";
 @import "./navbar.css";
 @import "./notes.css";
 @import "./shapes.css";

--- a/assets/css/limit_section.css
+++ b/assets/css/limit_section.css
@@ -1,0 +1,4 @@
+.derived_limit--not-imported * {
+  color: gray;
+  filter: grayscale(100%);
+}

--- a/lib/arrow/disruptions.ex
+++ b/lib/arrow/disruptions.ex
@@ -14,7 +14,7 @@ defmodule Arrow.Disruptions do
   @preloads [
     limits: [:route, :start_stop, :end_stop, :limit_day_of_weeks],
     replacement_services: [shuttle: [routes: [route_stops: [:stop]]]],
-    hastus_exports: [:line, services: [:service_dates]]
+    hastus_exports: [:line, services: [:service_dates], derived_limits: [:start_stop, :end_stop]]
   ]
 
   @doc """

--- a/lib/arrow/gtfs/line.ex
+++ b/lib/arrow/gtfs/line.ex
@@ -27,6 +27,8 @@ defmodule Arrow.Gtfs.Line do
     field :color, :string
     field :text_color, :string
     field :sort_order, :integer
+
+    has_many :routes, Arrow.Gtfs.Route
   end
 
   def changeset(line, attrs) do

--- a/lib/arrow/gtfs/route.ex
+++ b/lib/arrow/gtfs/route.ex
@@ -22,7 +22,8 @@ defmodule Arrow.Gtfs.Route do
           fare_class: String.t(),
           line: Arrow.Gtfs.Line.t() | Ecto.Association.NotLoaded.t(),
           listed_route: atom,
-          network_id: String.t()
+          network_id: String.t(),
+          route_patterns: list(Arrow.Gtfs.RoutePattern.t()) | Ecto.Association.NotLoaded.t()
         }
 
   @route_type_values Enum.with_index(~w[light_rail heavy_rail commuter_rail bus ferry]a)
@@ -46,6 +47,7 @@ defmodule Arrow.Gtfs.Route do
 
     has_many :directions, Arrow.Gtfs.Direction
     has_many :trips, Arrow.Gtfs.Trip
+    has_many :route_patterns, Arrow.Gtfs.RoutePattern
   end
 
   def changeset(route, attrs) do

--- a/lib/arrow/hastus.ex
+++ b/lib/arrow/hastus.ex
@@ -7,7 +7,13 @@ defmodule Arrow.Hastus do
 
   alias Arrow.Repo
 
-  @preloads [:line, :disruption, :trip_route_directions, services: [:service_dates]]
+  @preloads [
+    :line,
+    :disruption,
+    :trip_route_directions,
+    services: [:service_dates],
+    derived_limits: [:start_stop, :end_stop]
+  ]
 
   alias Arrow.Hastus.Export
 

--- a/lib/arrow/hastus/derived_limit.ex
+++ b/lib/arrow/hastus/derived_limit.ex
@@ -1,0 +1,57 @@
+defmodule Arrow.Hastus.DerivedLimit do
+  @moduledoc "schema for a disruption limit derived from a HASTUS export"
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Arrow.Gtfs.Stop
+  alias Arrow.Hastus.Export
+
+  @type t :: %__MODULE__{
+          id: integer,
+          export: Export.t() | Ecto.Association.NotLoaded.t(),
+          export_id: integer,
+          service_name: String.t(),
+          start_stop: Stop.t() | Ecto.Association.NotLoaded.t(),
+          start_stop_id: String.t(),
+          end_stop: Stop.t() | Ecto.Association.NotLoaded.t(),
+          end_stop_id: String.t(),
+          start_date: Date.t(),
+          end_date: Date.t()
+        }
+
+  schema "hastus_derived_limits" do
+    belongs_to :export, Arrow.Hastus.Export
+    field :service_name, :string
+
+    belongs_to :start_stop, Arrow.Gtfs.Stop, type: :string
+    belongs_to :end_stop, Arrow.Gtfs.Stop, type: :string
+    field :start_date, :date
+    field :end_date, :date
+
+    # Needed?
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(hastus_limit, attrs) do
+    hastus_limit
+    |> cast(attrs, [
+      :service_name,
+      :start_stop_id,
+      :end_stop_id,
+      :start_date,
+      :end_date
+    ])
+    |> validate_required([
+      :service_name,
+      :start_stop_id,
+      :end_stop_id,
+      :start_date,
+      :end_date
+    ])
+    |> assoc_constraint(:export)
+    |> assoc_constraint(:start_stop)
+    |> assoc_constraint(:end_stop)
+  end
+end

--- a/lib/arrow/hastus/export.ex
+++ b/lib/arrow/hastus/export.ex
@@ -7,26 +7,30 @@ defmodule Arrow.Hastus.Export do
 
   alias Arrow.Disruptions.DisruptionV2
   alias Arrow.Gtfs.Line
+  alias Arrow.Hastus.DerivedLimit
   alias Arrow.Hastus.Service
   alias Arrow.Hastus.TripRouteDirection
 
   @type t :: %__MODULE__{
           s3_path: String.t(),
-          services: list(Service) | Ecto.Association.NotLoaded.t(),
+          services: list(Service.t()) | Ecto.Association.NotLoaded.t(),
+          derived_limits: list(DerivedLimit.t()) | Ecto.Association.NotLoaded.t(),
+          trip_route_directions: list(TripRouteDirection.t()) | Ecto.Association.NotLoaded.t(),
           line: Line.t() | Ecto.Association.NotLoaded.t(),
           disruption: DisruptionV2.t() | Ecto.Association.NotLoaded.t()
         }
 
   schema "hastus_exports" do
     field :s3_path, :string
-    has_many :services, Arrow.Hastus.Service, on_replace: :delete, foreign_key: :export_id
+    has_many :services, Service, on_replace: :delete, foreign_key: :export_id
+    has_many :derived_limits, DerivedLimit, foreign_key: :export_id
 
-    has_many :trip_route_directions, Arrow.Hastus.TripRouteDirection,
+    has_many :trip_route_directions, TripRouteDirection,
       on_delete: :delete_all,
       foreign_key: :hastus_export_id
 
-    belongs_to :line, Arrow.Gtfs.Line, type: :string
-    belongs_to :disruption, Arrow.Disruptions.DisruptionV2
+    belongs_to :line, Line, type: :string
+    belongs_to :disruption, DisruptionV2
 
     timestamps(type: :utc_datetime)
   end
@@ -37,6 +41,7 @@ defmodule Arrow.Hastus.Export do
     |> cast(attrs, [:s3_path, :line_id, :disruption_id])
     |> validate_required([:s3_path])
     |> cast_assoc(:services, with: &Service.changeset/2, required: true)
+    |> cast_assoc(:derived_limits, with: &DerivedLimit.changeset/2, required: true)
     |> cast_assoc(:trip_route_directions, with: &TripRouteDirection.changeset/2)
     |> assoc_constraint(:line)
     |> assoc_constraint(:disruption)

--- a/lib/arrow_web/components/hastus_export_section.ex
+++ b/lib/arrow_web/components/hastus_export_section.ex
@@ -192,6 +192,13 @@ defmodule ArrowWeb.HastusExportSection do
             <.input field={f_trip_route_directions[:avi_code]} type="text" class="hidden" />
             <.input field={f_trip_route_directions[:route_id]} type="text" class="hidden" />
           </.inputs_for>
+          <.inputs_for :let={f_derived_limit} field={@form[:derived_limits]}>
+            <.input field={f_derived_limit[:service_name]} type="text" class="hidden" />
+            <.input field={f_derived_limit[:start_stop_id]} type="text" class="hidden" />
+            <.input field={f_derived_limit[:end_stop_id]} type="text" class="hidden" />
+            <.input field={f_derived_limit[:start_date]} type="date" class="hidden" />
+            <.input field={f_derived_limit[:end_date]} type="date" class="hidden" />
+          </.inputs_for>
           <div class="text-success mb-3">
             <strong>
               <i>Successfully imported export {@uploaded_file_name}!</i>
@@ -602,6 +609,7 @@ defmodule ArrowWeb.HastusExportSection do
           socket.assigns.export
           |> Hastus.change_export(%{
             "services" => export_data.services,
+            "derived_limits" => export_data.derived_limits,
             "trip_route_directions" => export_data.trip_route_directions,
             "line_id" => export_data.line_id,
             "s3_path" => client_name,

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -396,7 +396,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
     socket =
       socket
       |> clear_flash()
-      |> assign(:hastus_export_in_form, %Export{services: []})
+      |> assign(:hastus_export_in_form, %Export{services: [], derived_limits: []})
 
     {:noreply, socket}
   end

--- a/priv/repo/migrations/20250423184215_add_hastus_derived_limits.exs
+++ b/priv/repo/migrations/20250423184215_add_hastus_derived_limits.exs
@@ -1,0 +1,20 @@
+defmodule Arrow.Repo.Migrations.AddHastusDerivedLimits do
+  use Ecto.Migration
+
+  def change do
+    create table(:hastus_derived_limits) do
+      add :export_id, references(:hastus_exports, on_delete: :delete_all), null: false
+
+      add :start_stop_id, references(:gtfs_stops, type: :string), null: false
+      add :end_stop_id, references(:gtfs_stops, type: :string), null: false
+
+      add :start_date, :date, null: false
+      add :end_date, :date, null: false
+
+      add :service_name, :string, null: false
+
+      # Does it need this?
+      timestamps(type: :timestamptz)
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 HASTUS-export derived limits, take 2](https://app.asana.com/1/15492006741476/project/584764604969369/task/1210015466473149?focus=true)

At a high level, and ignoring some details:
Limits are derived by collecting all stops visited by trips in a service per 15-minute[^1] window, then comparing those against canonical subway stop sequences to find "holes" in service.
We need to collect trips like this because there are some cases where remaining service in a disruption is formed by multiple trips—e.g. when service is suspended in the downtown core but there is still train service on either end of a line.

[^1]: This window size is arbitrary, might be safe (and a bit faster) to use 30 or 60 minutes instead.

Remaining changes:
- [ ] Finish updating and adding tests
- [ ] Address remaining TODO comments
- [ ] See if it's possible to make the export file name a clickable "link" that scrolls the page to and/or highlights the referenced export (maybe without opening it for editing, since that would require saving work in another open sub-form) - a request from Firas

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
