### PR TITLE
feat: Show error when uploading export with trip with no block_id

### DIFF
--- a/lib/arrow/hastus/export_upload.ex
+++ b/lib/arrow/hastus/export_upload.ex
@@ -50,6 +50,7 @@ defmodule Arrow.Hastus.ExportUpload do
          {:ok, zip_bin, file_map, amended?} <- amend_service_ids(zip_bin, file_map, tmp_dir),
          revenue_trips <- Stream.filter(file_map["all_trips.txt"], &revenue_trip?/1),
          :ok <- validate_trip_shapes(revenue_trips, file_map["all_shapes.txt"]),
+         :ok <- validate_trip_blocks(revenue_trips),
          {:ok, line_id} <- infer_line(revenue_trips, file_map["all_stop_times.txt"]),
          {:ok, trip_route_directions} <-
            infer_green_line_branches(line_id, revenue_trips, file_map["all_stop_times.txt"]) do
@@ -258,6 +259,18 @@ defmodule Arrow.Hastus.ExportUpload do
 
       [_ | _] = trips_with_invalid_shapes ->
         {:error, {:trips_with_invalid_shapes, trips_with_invalid_shapes}}
+    end
+  end
+
+  defp validate_trip_blocks(revenue_trips) do
+    case revenue_trips
+         |> Stream.filter(&(&1["block_id"] in [nil, ""]))
+         |> Enum.map(& &1["trip_id"]) do
+      [] ->
+        :ok
+
+      [_ | _] = trips_with_invalid_blocks ->
+        {:error, {:trips_with_invalid_blocks, trips_with_invalid_blocks}}
     end
   end
 

--- a/lib/arrow_web/components/edit_hastus_export_form.ex
+++ b/lib/arrow_web/components/edit_hastus_export_form.ex
@@ -74,13 +74,13 @@ defmodule ArrowWeb.EditHastusExportForm do
               {@error}
             </p>
           </div>
-          <div :if={not is_nil(@trips_with_invalid_shapes)} class="mt-3">
+          <div :if={not is_nil(@invalid_export_trips)} class="mt-3">
             <p class="alert alert-danger m-0">
-              Some trips have invalid or missing shapes.
+              {get_invalid_trips_error_message(@invalid_export_trips)}
               <.button
                 type="button"
                 class="alert-danger"
-                phx-click="download_trips_with_invalid_shapes"
+                phx-click="download_invalid_export_trips"
                 phx-target={@myself}
               >
                 Download list of invalid trips
@@ -275,7 +275,7 @@ defmodule ArrowWeb.EditHastusExportForm do
       |> assign(:show_service_import_form, false)
       |> assign(:form, nil)
       |> assign(:error, nil)
-      |> assign(:trips_with_invalid_shapes, nil)
+      |> assign(:invalid_export_trips, nil)
       |> allow_upload(:hastus_export,
         accept: ~w(.zip),
         progress: &handle_progress/3,
@@ -391,14 +391,24 @@ defmodule ArrowWeb.EditHastusExportForm do
     {:noreply, assign(socket, confirming_dup_service_ids?: false)}
   end
 
-  def handle_event("download_trips_with_invalid_shapes", _params, socket) do
-    contents =
-      if trips_with_invalid_shapes = socket.assigns.trips_with_invalid_shapes do
-        Enum.join(trips_with_invalid_shapes, "\n")
-      end
-
+  def handle_event(
+        "download_invalid_export_trips",
+        _params,
+        %{assigns: %{invalid_export_trips: {error, invalid_trips}}} = socket
+      ) do
     socket =
-      send_download(socket, "trips_with_invalid_shapes.txt", contents, content_type: "text/plain")
+      send_download(
+        socket,
+        get_invalid_trips_file_name(error),
+        Enum.join(invalid_trips, "\n"),
+        content_type: "text/plain"
+      )
+
+    {:noreply, socket}
+  end
+
+  def handle_event("download_invalid_export_trips", _params, socket) do
+    socket = send_download(socket, "invalid_trips.txt", "", content_type: "text/plain")
 
     {:noreply, socket}
   end
@@ -478,8 +488,8 @@ defmodule ArrowWeb.EditHastusExportForm do
            entry,
            &ExportUpload.extract_data_from_upload(&1, socket.assigns.user_id)
          ) do
-      {:error, {:trips_with_invalid_shapes, trips_with_invalid_shapes}} ->
-        {:noreply, assign(socket, trips_with_invalid_shapes: trips_with_invalid_shapes)}
+      {:error, {_, _} = invalid_export_trips} ->
+        {:noreply, assign(socket, invalid_export_trips: invalid_export_trips)}
 
       {:error, error} ->
         {:noreply, assign(socket, error: error)}
@@ -562,4 +572,16 @@ defmodule ArrowWeb.EditHastusExportForm do
   defp error_to_string(:too_large), do: "File is too large. Maximum size is 8MB"
   defp error_to_string(:not_accepted), do: "You have selected an unacceptable file type"
   defp error_to_string(_), do: "Upload failed. Please try again or contact an engineer"
+
+  defp get_invalid_trips_file_name(:trips_with_invalid_shapes),
+    do: "trips_with_invalid_shapes.txt"
+
+  defp get_invalid_trips_file_name(:trips_with_invalid_blocks),
+    do: "trips_with_invalid_blocks.txt"
+
+  defp get_invalid_trips_error_message({:trips_with_invalid_shapes, _}),
+    do: "Some trips have invalid or missing shapes."
+
+  defp get_invalid_trips_error_message({:trips_with_invalid_blocks, _}),
+    do: "Some trips have invalid or missing block IDs."
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹💅🏻🇵🇱 [HASTUS Import] Include check for presence of block_id](https://app.asana.com/1/15492006741476/project/584764604969369/task/1210329320359088?focus=true)

When gtfs_creator parses a HASTUS export, the build will fail if any revenue trip has an empty `block_id`. We can catch this easily in Arrow. Added an extra piece of validation with support for a file download.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
