### PR TITLE
fix: Adjust font and text wrapping of disruption description.

### DIFF
--- a/lib/arrow_web/components/disruption_components.ex
+++ b/lib/arrow_web/components/disruption_components.ex
@@ -60,7 +60,7 @@ defmodule ArrowWeb.DisruptionComponents do
       <div class="flex flex-row">
         <div class="flex-grow">
           <h4>Description</h4>
-          <pre>{@disruption.description}</pre>
+          <div style="white-space: pre-wrap;">{@disruption.description}</div>
         </div>
         <div class="flex flex-col flex-shrink justify-end">
           <.link


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹💅🏻🇵🇱 [Create/Edit Disruption] Fix wrapping + fonts in disruption fundamentals ](https://app.asana.com/1/15492006741476/project/584764604969369/task/1210329320359079?focus=true)

The original intent of the `pre` tags was to preserve new lines. If we use `white-space: pre-wrap` instead, we still preserve new lines while also wrapping long text and maintaining a consistent font.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
