### PR TITLE
feat: add API endpoint for accessing shapes

### DIFF
--- a/lib/arrow_web/controllers/api/shapes_controller.ex
+++ b/lib/arrow_web/controllers/api/shapes_controller.ex
@@ -1,0 +1,11 @@
+defmodule ArrowWeb.API.ShapesController do
+  use ArrowWeb, :controller
+  alias Arrow.Shuttles
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, _params) do
+    data = Shuttles.list_shapes()
+
+    render(conn, "index.json-api", data: data)
+  end
+end

--- a/lib/arrow_web/controllers/api_json/shapes_view.ex
+++ b/lib/arrow_web/controllers/api_json/shapes_view.ex
@@ -1,0 +1,20 @@
+defmodule ArrowWeb.API.ShapesView do
+  use ArrowWeb, :html
+  use JaSerializer.PhoenixView
+
+  attributes([:name, :bucket, :path, :prefix, :download_url, :inserted_at, :updated_at])
+
+  def download_url(shape, _conn) do
+    enabled? = Application.get_env(:arrow, :shape_storage_enabled?)
+    basic_url = "https://#{shape.bucket}.s3.amazonaws.com/#{shape.path}"
+
+    if enabled? do
+      case ExAws.S3.presigned_url(ExAws.Config.new(:s3), :get, shape.bucket, shape.path, []) do
+        {:ok, url} -> url
+        {:error, _} -> basic_url
+      end
+    else
+      basic_url
+    end
+  end
+end

--- a/lib/arrow_web/router.ex
+++ b/lib/arrow_web/router.ex
@@ -119,6 +119,7 @@ defmodule ArrowWeb.Router do
     get("/disruptions", DisruptionController, :index)
     get("/adjustments", AdjustmentController, :index)
     get("/shuttle-stops", StopsController, :index)
+    get("/shapes", ShapesController, :index)
 
     get "/service-schedules", ServiceScheduleController, :index
   end

--- a/test/arrow_web/controllers/api/shapes_controller_test.exs
+++ b/test/arrow_web/controllers/api/shapes_controller_test.exs
@@ -1,0 +1,57 @@
+defmodule ArrowWeb.API.ShapesControllerTest do
+  use ArrowWeb.ConnCase
+  import Arrow.ShuttlesFixtures
+  import Test.Support.Helpers
+
+  describe "index/2" do
+    @tag :authenticated_admin
+    test "includes all shapes", %{conn: conn} do
+      shape1 = s3_mocked_shape_fixture(%{name: "shape1-S"})
+      shape2 = s3_mocked_shape_fixture(%{name: "shape2-S"})
+      shape3 = s3_mocked_shape_fixture(%{name: "shape3-S"})
+
+      res = json_response(get(conn, "/api/shapes"), 200)
+
+      assert %{
+               "data" => data,
+               "jsonapi" => %{"version" => "1.0"}
+             } = res
+
+      assert Enum.count(data) == 3
+
+      shape_ids = data |> Enum.map(fn %{"id" => id} -> String.to_integer(id) end) |> MapSet.new()
+      assert shape_ids == MapSet.new([shape1.id, shape2.id, shape3.id])
+    end
+
+    @tag :authenticated_admin
+    test "includes download_url field for each shape", %{conn: conn} do
+      reassign_env(:shape_storage_enabled?, true)
+
+      _shape =
+        s3_mocked_shape_fixture(%{
+          name: "TestToStation-S",
+          bucket: "test-bucket",
+          path: "shapes/TestToStation-S.kml",
+          prefix: "shapes/"
+        })
+
+      res = json_response(get(conn, "/api/shapes"), 200)
+
+      assert %{"data" => [shape_data]} = res
+
+      assert %{
+               "attributes" => %{
+                 "download_url" => download_url,
+                 "name" => "TestToStation-S",
+                 "bucket" => "test-bucket",
+                 "path" => "shapes/TestToStation-S.kml",
+                 "prefix" => "shapes/"
+               }
+             } = shape_data
+
+      assert String.contains?(download_url, "s3.amazonaws.com")
+      assert String.contains?(download_url, "test-bucket")
+      assert String.contains?(download_url, "TestToStation-S.kml")
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Regular sync of Arrow Stops & Shapes from prod to dev](https://app.asana.com/1/15492006741476/project/584764604969369/task/1210252044451003?focus=true)

PR 1 of 2 for this feature. Arrow doesn't currently have an API endpoint for fetching all shapes, and Arrow dev won't have access to Arrow-prods' S3 bucket. This adds an endpoint for listing all shapes, including presigned URLs that dev will be able to use in order to obtain said shape(s).
