### PR TITLE
fix: Use service_date.end_date in Service.last_date/1

### DIFF
--- a/lib/arrow/hastus/service.ex
+++ b/lib/arrow/hastus/service.ex
@@ -51,7 +51,7 @@ defmodule Arrow.Hastus.Service do
     service = Arrow.Repo.preload(service, :service_dates)
 
     service.service_dates
-    |> Enum.map(& &1.start_date)
+    |> Enum.map(& &1.end_date)
     |> Enum.max(Date)
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** -

Fixes presentation of derived limit end dates. Oops!

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
