### PR TITLE
fix: resolve map not rendering when editing disruption by removing an…

### DIFF
--- a/lib/arrow_web/components/edit_replacement_service_form.ex
+++ b/lib/arrow_web/components/edit_replacement_service_form.ex
@@ -18,17 +18,7 @@ defmodule ArrowWeb.EditReplacementServiceForm do
 
   def render(assigns) do
     ~H"""
-    <div
-      class="mt-3 overflow-hidden"
-      style="display: none"
-      phx-mounted={
-        JS.show(transition: {"ease-in duration-300", "max-h-0", "max-h-screen"}, time: 300)
-        |> JS.focus()
-      }
-      phx-remove={
-        JS.hide(transition: {"ease-out duration-300", "max-h-screen", "max-h-0"}, time: 300)
-      }
-    >
+    <div class="mt-3 overflow-hidden">
       <.simple_form
         :if={!is_nil(@form)}
         for={@form}


### PR DESCRIPTION
…imation

#### Summary of changes
**Asana Ticket:** [🏹🐛 [Edit Disruption] Map doesn't render in edit/manage activation](https://app.asana.com/1/15492006741476/project/1204473309455397/task/1210426646201372?focus=true)

It seems Leaflet does not like being drawn on when hidden. I think we were getting away with this when creating the replacement service because we recompute the map bounds as part of rerendering, but I think while hidden, it thought the map was much smaller than it was, and didn't realize the area it needed to draw suddenly became much larger. I did spend a little time playing with this, but the level of effort required to save the animation didn't seem worth it.
