### PR TITLE
feedback:refactor: derive `schedule_service_types` from `@service_type_to_workbook_abbreviation`

### DIFF
--- a/lib/arrow/disruptions/replacement_service.ex
+++ b/lib/arrow/disruptions/replacement_service.ex
@@ -114,8 +114,10 @@ defmodule Arrow.Disruptions.ReplacementService do
     |> Enum.map(&add_timetable/1)
   end
 
+  @schedule_service_types Map.keys(@service_type_to_workbook_abbreviation)
+
   @spec schedule_service_types :: list(atom())
-  def schedule_service_types, do: [:weekday, :friday, :saturday, :sunday]
+  def schedule_service_types, do: @schedule_service_types
 
   @spec first_last_trip_times(t(), list(atom())) :: %{
           atom() => %{

--- a/lib/arrow/disruptions/replacement_service.ex
+++ b/lib/arrow/disruptions/replacement_service.ex
@@ -19,13 +19,6 @@ defmodule Arrow.Disruptions.ReplacementService do
   @type timetable ::
           %{direction_id() => list(stop_time()), direction_id() => list(stop_time())} | nil
 
-  @service_type_to_workbook_abbreviation %{
-    :weekday => "WKDY",
-    :friday => "FRI",
-    :sunday => "SUN",
-    :saturday => "SAT"
-  }
-
   typed_schema "replacement_services" do
     field :reason, :string
     field :start_date, :date
@@ -114,13 +107,20 @@ defmodule Arrow.Disruptions.ReplacementService do
     |> Enum.map(&add_timetable/1)
   end
 
-  @schedule_service_types Map.keys(@service_type_to_workbook_abbreviation)
+  @service_type_to_workbook_abbreviation [
+    weekday: "WKDY",
+    friday: "FRI",
+    sunday: "SUN",
+    saturday: "SAT"
+  ]
+
+  @schedule_service_types Keyword.keys(@service_type_to_workbook_abbreviation)
 
   @spec schedule_service_types :: list(atom())
   def schedule_service_types, do: @schedule_service_types
 
   defp service_type_to_workbook_abbreviation(schedule_service_type),
-    do: Map.get(@service_type_to_workbook_abbreviation, schedule_service_type)
+    do: Keyword.get(@service_type_to_workbook_abbreviation, schedule_service_type)
 
   @spec first_last_trip_times(t(), list(atom())) :: %{
           atom() => %{

--- a/lib/arrow/disruptions/replacement_service.ex
+++ b/lib/arrow/disruptions/replacement_service.ex
@@ -119,6 +119,9 @@ defmodule Arrow.Disruptions.ReplacementService do
   @spec schedule_service_types :: list(atom())
   def schedule_service_types, do: @schedule_service_types
 
+  defp service_type_to_workbook_abbreviation(schedule_service_type),
+    do: Map.get(@service_type_to_workbook_abbreviation, schedule_service_type)
+
   @spec first_last_trip_times(t(), list(atom())) :: %{
           atom() => %{
             first_trips: %{0 => String.t(), 1 => String.t()},
@@ -131,7 +134,7 @@ defmodule Arrow.Disruptions.ReplacementService do
       ) do
     schedule_service_types
     |> Enum.map(fn service_type ->
-      service_type_abbreviation = Map.get(@service_type_to_workbook_abbreviation, service_type)
+      service_type_abbreviation = service_type_to_workbook_abbreviation(service_type)
 
       day_of_week_data =
         Map.get(
@@ -154,7 +157,7 @@ defmodule Arrow.Disruptions.ReplacementService do
          %__MODULE__{source_workbook_data: workbook_data} = replacement_service,
          service_type_atom
        ) do
-    service_type_abbreviation = Map.get(@service_type_to_workbook_abbreviation, service_type_atom)
+    service_type_abbreviation = service_type_to_workbook_abbreviation(service_type_atom)
 
     if day_of_week_data =
          Map.get(workbook_data, workbook_column_from_day_of_week(service_type_abbreviation)) do


### PR DESCRIPTION
Context: [#1297 (comment)](https://github.com/mbta/arrow/pull/1297#discussion_r2301036851)
Follows-onto: #1297

#### Summary of Changes
I really liked [@jzimbel-mbta's suggestion](https://github.com/mbta/arrow/pull/1297#discussion_r2301036851) but ran into some test failures in the `ArrowWeb.TimetableControllerTest` "simply" implementing it.

I found that this was due to how the `day_of_week` is determined when it is not specified in the query parameters. Because map key ordering is not specified in Elixir, this ended up _also_ changing the order of the tabs on the timetable view.

So this PR sorts the available days on the Controller.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
