### PR TITLE
fix: trainsformer export validation error

### DIFF
--- a/lib/arrow_web/components/edit_trainsformer_export_form.ex
+++ b/lib/arrow_web/components/edit_trainsformer_export_form.ex
@@ -401,9 +401,9 @@ defmodule ArrowWeb.EditTrainsformerExportForm do
     uploaded_file_routes = socket.assigns.uploaded_file_routes
 
     export_params =
-      if not is_nil(uploaded_file_routes),
-        do: Map.put(export_params, "routes", uploaded_file_routes),
-        else: export_params
+      if is_nil(uploaded_file_routes),
+        do: export_params,
+        else: Map.put(export_params, "routes", uploaded_file_routes)
 
     form =
       socket.assigns.export

--- a/lib/arrow_web/components/edit_trainsformer_export_form.ex
+++ b/lib/arrow_web/components/edit_trainsformer_export_form.ex
@@ -398,6 +398,8 @@ defmodule ArrowWeb.EditTrainsformerExportForm do
 
   @impl true
   def handle_event("validate", %{"export" => export_params}, socket) do
+    export_params = Map.put(export_params, "routes", socket.assigns.uploaded_file_routes)
+
     form =
       socket.assigns.export
       |> Trainsformer.change_export(export_params)

--- a/lib/arrow_web/components/edit_trainsformer_export_form.ex
+++ b/lib/arrow_web/components/edit_trainsformer_export_form.ex
@@ -398,7 +398,12 @@ defmodule ArrowWeb.EditTrainsformerExportForm do
 
   @impl true
   def handle_event("validate", %{"export" => export_params}, socket) do
-    export_params = Map.put(export_params, "routes", socket.assigns.uploaded_file_routes)
+    uploaded_file_routes = socket.assigns.uploaded_file_routes
+
+    export_params =
+      if not is_nil(uploaded_file_routes),
+        do: Map.put(export_params, "routes", uploaded_file_routes),
+        else: export_params
 
     form =
       socket.assigns.export

--- a/test/integration/disruptionsv2/trainsformer_export_section_test.exs
+++ b/test/integration/disruptionsv2/trainsformer_export_section_test.exs
@@ -365,4 +365,23 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
     |> refute_has(text("01/30/2026"))
     |> refute_has(text("02/05/2026"))
   end
+
+  feature "can edit an uploaded Trainsformer export before saving", %{session: session} do
+    disruption = disruption_v2_fixture(%{mode: :commuter_rail})
+
+    session
+    |> visit("/disruptions/#{disruption.id}")
+    |> click(text("Upload Trainsformer export"))
+    |> assert_text("Upload Trainsformer .zip")
+    |> attach_file(file_field("trainsformer_export", visible: false),
+      path: "test/support/fixtures/trainsformer/valid_export.zip"
+    )
+    |> assert_text("Successfully imported export valid_export.zip!")
+    |> click(Query.checkbox("Wednesday"))
+    |> fill_in(
+      Query.fillable_field("End Date"),
+      with: "03/17/2026"
+    )
+    |> refute_has(text("Export must contain at least one route"))
+  end
 end

--- a/test/integration/disruptionsv2/trainsformer_export_section_test.exs
+++ b/test/integration/disruptionsv2/trainsformer_export_section_test.exs
@@ -366,7 +366,7 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
     |> refute_has(text("02/05/2026"))
   end
 
-  feature "can edit an uploaded Trainsformer export before saving", %{session: session} do
+  feature "can edit an uploaded but unsaved Trainsformer export", %{session: session} do
     disruption = disruption_v2_fixture(%{mode: :commuter_rail})
 
     session


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 🐛 Fix "Export must contain at least one route" error for Arrow CR export uploads](https://app.asana.com/1/15492006741476/project/584764604969369/task/1213622246441608?focus=true)

Fixes an issue where the "Export must contain at least one route" error appeared when editing the Trainsformer export form before clicking save. This includes the routes in the `export_params` passed to `Trainsformer.change_export()`. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
