### PR TITLE
fix: CR disruptions have start and end dates in list view

### DIFF
--- a/lib/arrow/disruptions.ex
+++ b/lib/arrow/disruptions.ex
@@ -383,7 +383,7 @@ defmodule Arrow.Disruptions do
   def start_end_dates(%DisruptionV2{
         limits: limits,
         replacement_services: replacement_services,
-        hastus_exports: hastus_exports
+        hastus_exports: [_ | _] = hastus_exports
       }) do
     hastus_service_dates =
       Enum.flat_map(hastus_exports, fn export ->
@@ -407,5 +407,40 @@ defmodule Arrow.Disruptions do
 
       {min_date, max_date}
     end
+  end
+
+  def start_end_dates(%DisruptionV2{
+        limits: limits,
+        trainsformer_exports: [_ | _] = trainsformer_exports
+      }) do
+    trainsformer_service_dates =
+      Enum.flat_map(trainsformer_exports, fn export ->
+        export.services
+        |> Enum.flat_map(& &1.service_dates)
+      end)
+
+    if limits == [] and trainsformer_service_dates == [] do
+      {nil, nil}
+    else
+      min_date =
+        (limits ++ trainsformer_service_dates)
+        |> Enum.map(& &1.start_date)
+        |> Enum.min(Date, fn -> ~D[9999-12-31] end)
+
+      max_date =
+        (limits ++ trainsformer_service_dates)
+        |> Enum.map(& &1.end_date)
+        |> Enum.max(Date, fn -> ~D[0000-01-01] end)
+
+      {min_date, max_date}
+    end
+  end
+
+  def start_end_dates(%DisruptionV2{
+        limits: limits,
+        trainsformer_exports: [],
+        hastus_exports: []
+      }) do
+    {nil, nil}
   end
 end

--- a/lib/arrow/disruptions.ex
+++ b/lib/arrow/disruptions.ex
@@ -395,8 +395,7 @@ defmodule Arrow.Disruptions do
 
     trainsformer_service_dates =
       Enum.flat_map(trainsformer_exports, fn export ->
-        export.services
-        |> Enum.flat_map(& &1.service_dates)
+        Enum.flat_map(export.services, & &1.service_dates)
       end)
 
     if limits == [] and replacement_services == [] and hastus_service_dates == [] and

--- a/lib/arrow/disruptions.ex
+++ b/lib/arrow/disruptions.ex
@@ -383,7 +383,8 @@ defmodule Arrow.Disruptions do
   def start_end_dates(%DisruptionV2{
         limits: limits,
         replacement_services: replacement_services,
-        hastus_exports: [_ | _] = hastus_exports
+        hastus_exports: hastus_exports,
+        trainsformer_exports: trainsformer_exports
       }) do
     hastus_service_dates =
       Enum.flat_map(hastus_exports, fn export ->
@@ -392,55 +393,27 @@ defmodule Arrow.Disruptions do
         |> Enum.flat_map(& &1.service_dates)
       end)
 
-    if limits == [] and replacement_services == [] and hastus_service_dates == [] do
-      {nil, nil}
-    else
-      min_date =
-        (limits ++ replacement_services ++ hastus_service_dates)
-        |> Enum.map(& &1.start_date)
-        |> Enum.min(Date, fn -> ~D[9999-12-31] end)
-
-      max_date =
-        (limits ++ replacement_services ++ hastus_service_dates)
-        |> Enum.map(& &1.end_date)
-        |> Enum.max(Date, fn -> ~D[0000-01-01] end)
-
-      {min_date, max_date}
-    end
-  end
-
-  def start_end_dates(%DisruptionV2{
-        limits: limits,
-        trainsformer_exports: [_ | _] = trainsformer_exports
-      }) do
     trainsformer_service_dates =
       Enum.flat_map(trainsformer_exports, fn export ->
         export.services
         |> Enum.flat_map(& &1.service_dates)
       end)
 
-    if limits == [] and trainsformer_service_dates == [] do
+    if limits == [] and replacement_services == [] and hastus_service_dates == [] and
+         trainsformer_service_dates == [] do
       {nil, nil}
     else
       min_date =
-        (limits ++ trainsformer_service_dates)
+        (limits ++ replacement_services ++ hastus_service_dates ++ trainsformer_service_dates)
         |> Enum.map(& &1.start_date)
         |> Enum.min(Date, fn -> ~D[9999-12-31] end)
 
       max_date =
-        (limits ++ trainsformer_service_dates)
+        (limits ++ replacement_services ++ hastus_service_dates ++ trainsformer_service_dates)
         |> Enum.map(& &1.end_date)
         |> Enum.max(Date, fn -> ~D[0000-01-01] end)
 
       {min_date, max_date}
     end
-  end
-
-  def start_end_dates(%DisruptionV2{
-        limits: limits,
-        trainsformer_exports: [],
-        hastus_exports: []
-      }) do
-    {nil, nil}
   end
 end

--- a/lib/arrow/shuttles/shuttle.ex
+++ b/lib/arrow/shuttles/shuttle.ex
@@ -92,7 +92,14 @@ defmodule Arrow.Shuttles.Shuttle do
           join: s in assoc(d, :shuttles),
           where: s.id == ^shuttle_id,
           where: d.status == :approved,
-          preload: [:limits, :replacement_services, hastus_exports: [services: [:service_dates]]]
+          preload: [
+            :limits,
+            :replacement_services,
+            hastus_exports: [
+              services: [:service_dates]
+            ],
+            trainsformer_exports: [services: [:service_dates]]
+          ]
         )
         |> Repo.all()
         |> Enum.filter(fn d ->

--- a/lib/arrow_web/controllers/disruption_v2_controller/index.ex
+++ b/lib/arrow_web/controllers/disruption_v2_controller/index.ex
@@ -74,7 +74,8 @@ defmodule ArrowWeb.DisruptionV2Controller.Index do
   defp apply_kinds_filter(disruption, %Filters{kinds: kinds}) do
     kind_routes = kinds |> Enum.map(&@disruption_kind_routes[&1]) |> List.flatten()
 
-    Enum.any?(disruption.limits, fn limit -> limit.route.id in kind_routes end)
+    Enum.any?(disruption.limits, fn limit -> limit.route.id in kind_routes end) or
+      MapSet.member?(kinds, disruption.mode)
   end
 
   defp apply_only_approved_filter(disruption, %Filters{only_approved?: true}),

--- a/test/arrow_web/controllers/disruption_v2_controller_test.exs
+++ b/test/arrow_web/controllers/disruption_v2_controller_test.exs
@@ -48,7 +48,7 @@ defmodule ArrowWeb.DisruptionV2ControllerTest do
 
       resp = conn |> get(~p"/?kinds[]=commuter_rail") |> html_response(200)
 
-      resp =~ "Test CR disruption"
+      assert resp =~ "Test CR disruption"
     end
 
     @tag :authenticated

--- a/test/arrow_web/controllers/disruption_v2_controller_test.exs
+++ b/test/arrow_web/controllers/disruption_v2_controller_test.exs
@@ -41,6 +41,17 @@ defmodule ArrowWeb.DisruptionV2ControllerTest do
     end
 
     @tag :authenticated
+    test "list CR disruptions that match the kinds filter", %{conn: conn} do
+      insert(:limit,
+        disruption: build(:disruption_v2, title: "Test CR disruption", mode: "commuter_rail")
+      )
+
+      resp = conn |> get(~p"/?kinds[]=commuter_rail") |> html_response(200)
+
+      resp =~ "Test CR disruption"
+    end
+
+    @tag :authenticated
     test "lists only disruptions that satisfy the only_approved filter", %{conn: conn} do
       route = insert(:gtfs_route)
 

--- a/test/integration/disruptions_v2_test.exs
+++ b/test/integration/disruptions_v2_test.exs
@@ -41,6 +41,18 @@ defmodule Arrow.Integration.DisruptionsV2Test do
     |> assert_text("N/A")
   end
 
+  feature "shows start and end dates for CR disruptions with a trainsformer export", %{
+    session: session
+  } do
+    disruption_v2_cr_fixture()
+
+    session
+    |> visit("/")
+    |> click(link("include past"))
+    |> assert_text("01/26/26")
+    |> assert_text("01/27/26")
+  end
+
   defp create_disruption(limit_attrs, replacement_service_attrs) do
     disruption_v2 = disruption_v2_fixture()
     limit = limit_fixture(Map.put_new(limit_attrs, :disruption_id, disruption_v2.id))

--- a/test/support/fixtures/disruptions_fixtures.ex
+++ b/test/support/fixtures/disruptions_fixtures.ex
@@ -52,4 +52,40 @@ defmodule Arrow.DisruptionsFixtures do
 
     replacement_service
   end
+
+  @doc """
+  Generate a disruption_v2 for CR.
+  """
+  def disruption_v2_cr_fixture(attrs \\ %{}) do
+    {:ok, disruption_v2} =
+      attrs
+      |> Enum.into(%{
+        title: "cr disruption",
+        mode: "commuter_rail",
+        status: :approved,
+        description: "super disruptive",
+        limits: [],
+        replacement_services: [],
+        trainsformer_exports: [
+          %{
+            s3_path: "s3://mbta-arrow/test/trainsformer-export-uploads/export.zip",
+            routes: [%{route_id: "CR-Worcester"}],
+            services: [
+              %{
+                name: "SPRING2025-SOUTHSS-Weekend-31A",
+                service_dates: [
+                  %{
+                    "start_date" => "2026-01-26",
+                    "end_date" => "2026-01-27"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      })
+      |> Arrow.Disruptions.create_disruption_v2()
+
+    disruption_v2
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹🐛 CR disruptions should have start and end dates in larger disruptions list page](https://app.asana.com/1/15492006741476/project/584764604969369/task/1213583843147174?focus=true)

The start and end dates for CR disruptions were not getting rendered in the disruptions list view page. Instead, the start date and end date were both listed as N/A. This adds an extra case to handle deriving the start and end dates for disruptions with a Trainsformer export. 

Also, I noticed that the CR filter at the top of the page was not working either so I added a fix to filter for CR if a disruption's `mode` attribute is set to `:commuter_rail`.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
