### PR TITLE
fix: show CR disruptions in calendar view

### DIFF
--- a/lib/arrow/trainsformer/service_date_day_of_week.ex
+++ b/lib/arrow/trainsformer/service_date_day_of_week.ex
@@ -6,6 +6,8 @@ defmodule Arrow.Trainsformer.ServiceDateDayOfWeek do
 
   @derive {Jason.Encoder, only: [:day_name]}
 
+  @type day_name :: Arrow.Util.DayOfWeek.day_name()
+
   typed_schema "service_date_days_of_week" do
     field :day_name, Ecto.Enum, values: Arrow.Util.DayOfWeek.day_name_values()
     belongs_to :service_date, Arrow.Trainsformer.ServiceDate, on_replace: :delete
@@ -19,5 +21,12 @@ defmodule Arrow.Trainsformer.ServiceDateDayOfWeek do
     |> cast(attrs, [:day_name])
     |> validate_required([:day_name])
     |> assoc_constraint(:service_date)
+  end
+
+  @spec day_number(t() | day_name) :: 1..7
+  def day_number(%__MODULE__{} = dow), do: day_number(dow.day_name)
+
+  for {name, number} <- Arrow.Util.DayOfWeek.day_name_values() do
+    def day_number(unquote(name)), do: unquote(number)
   end
 end

--- a/lib/arrow_web/controllers/disruption_v2_html/calendar.ex
+++ b/lib/arrow_web/controllers/disruption_v2_html/calendar.ex
@@ -120,8 +120,6 @@ defmodule ArrowWeb.DisruptionV2View.Calendar do
        ) do
     day_numbers = MapSet.new(days_of_week, &ServiceDateDayOfWeek.day_number/1)
 
-    dbg()
-
     Date.range(start_date, end_date)
     |> Enum.filter(&(Date.day_of_week(&1) in day_numbers))
     |> Enum.chunk_while([], &chunk_dates/2, &chunk_dates/1)

--- a/lib/arrow_web/controllers/disruption_v2_html/calendar.ex
+++ b/lib/arrow_web/controllers/disruption_v2_html/calendar.ex
@@ -6,6 +6,7 @@ defmodule ArrowWeb.DisruptionV2View.Calendar do
   alias Arrow.Shuttles.Shuttle
   alias ArrowWeb.Endpoint
   alias ArrowWeb.Router.Helpers, as: Routes
+  alias Arrow.Trainsformer.{ServiceDate, ServiceDateDayOfWeek}
 
   @doc """
   Generates props for `DisruptionCalendar`, which has the same interface as `FullCalendar`.
@@ -18,17 +19,25 @@ defmodule ArrowWeb.DisruptionV2View.Calendar do
     Enum.flat_map(disruptions, &events/1)
   end
 
-  defp events(%DisruptionV2{limits: [], replacement_services: []}), do: []
+  defp events(%DisruptionV2{limits: [], replacement_services: [], trainsformer_exports: []}),
+    do: []
 
   defp events(%DisruptionV2{
          id: id,
          title: title,
          limits: limits,
          replacement_services: replacement_services,
+         trainsformer_exports: trainsformer_exports,
          status: status
        }) do
+    trainsformer_service_dates =
+      Enum.flat_map(trainsformer_exports, fn export ->
+        Enum.flat_map(export.services, & &1.service_dates)
+      end)
+
     Enum.flat_map(limits, &events(id, &1, title, status)) ++
-      Enum.flat_map(replacement_services, &events(id, &1, title, status))
+      Enum.flat_map(replacement_services, &events(id, &1, title, status)) ++
+      Enum.flat_map(trainsformer_service_dates, &events(id, &1, title, status))
   end
 
   defp events(
@@ -92,6 +101,43 @@ defmodule ArrowWeb.DisruptionV2View.Calendar do
           # end date is treated as exclusive
           end: Date.add(event_end, 1),
           url: Routes.disruption_v2_view_path(Endpoint, :edit, disruption_id),
+          extendedProps: %{
+            statusOrder: if(status == :approved, do: 0, else: 1)
+          }
+        }
+    end)
+  end
+
+  defp events(
+         disruption_id,
+         %ServiceDate{
+           start_date: start_date,
+           end_date: end_date,
+           service_date_days_of_week: days_of_week
+         },
+         event_title,
+         status
+       ) do
+    day_numbers = MapSet.new(days_of_week, &ServiceDateDayOfWeek.day_number/1)
+
+    dbg()
+
+    Date.range(start_date, end_date)
+    |> Enum.filter(&(Date.day_of_week(&1) in day_numbers))
+    |> Enum.chunk_while([], &chunk_dates/2, &chunk_dates/1)
+    |> Enum.map(&{List.last(&1), List.first(&1)})
+    |> Enum.map(fn
+      {nil, nil} ->
+        %{}
+
+      {event_start, event_end} ->
+        %{
+          title: event_title,
+          classNames: "kind-commuter-rail status-#{status_class(status)}",
+          start: event_start,
+          # end date is treated as exclusive
+          end: Date.add(event_end, 1),
+          url: Routes.disruption_v2_view_path(Endpoint, :show, disruption_id),
           extendedProps: %{
             statusOrder: if(status == :approved, do: 0, else: 1)
           }

--- a/test/arrow_web/views/disruption_v2_view/calendar_test.exs
+++ b/test/arrow_web/views/disruption_v2_view/calendar_test.exs
@@ -5,6 +5,7 @@ defmodule ArrowWeb.DisruptionV2View.CalendarTest do
   alias Arrow.Limits.LimitDayOfWeek
   alias Arrow.Shuttles.Shuttle
   alias ArrowWeb.DisruptionV2View.Calendar, as: DCalendar
+  alias Arrow.Trainsformer.{Export, Service, ServiceDate, ServiceDateDayOfWeek}
 
   describe "props/1" do
     test "converts a list of Disruptions to DisruptionCalendar props" do
@@ -39,6 +40,7 @@ defmodule ArrowWeb.DisruptionV2View.CalendarTest do
             shuttle: %Shuttle{disrupted_route_id: "Blue"}
           }
         ],
+        trainsformer_exports: [],
         status: :approved
       }
 
@@ -81,6 +83,72 @@ defmodule ArrowWeb.DisruptionV2View.CalendarTest do
           start: ~D[2021-02-01],
           end: ~D[2021-03-01],
           url: "/disruptions/123/edit",
+          extendedProps: %{statusOrder: 0}
+        }
+      ]
+
+      assert DCalendar.props([disruption]) == %{events: expected_events}
+    end
+
+    test "converts a list with a CR disruption to DisruptionCalendar props" do
+      disruption = %DisruptionV2{
+        id: 321,
+        title: "CR Disruption",
+        limits: [],
+        replacement_services: [],
+        trainsformer_exports: [
+          %Export{
+            services: [
+              %Service{
+                service_dates: [
+                  %ServiceDate{
+                    start_date: ~D[2026-04-01],
+                    end_date: ~D[2026-05-01],
+                    service_date_days_of_week: [
+                      %ServiceDateDayOfWeek{
+                        day_name: :saturday
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        status: :approved
+      }
+
+      expected_events = [
+        %{
+          start: ~D[2026-04-04],
+          title: "CR Disruption",
+          end: ~D[2026-04-05],
+          url: "/disruptions/321",
+          classNames: "kind-commuter-rail status-approved",
+          extendedProps: %{statusOrder: 0}
+        },
+        %{
+          start: ~D[2026-04-11],
+          title: "CR Disruption",
+          end: ~D[2026-04-12],
+          url: "/disruptions/321",
+          classNames: "kind-commuter-rail status-approved",
+          extendedProps: %{statusOrder: 0}
+        },
+        %{
+          start: ~D[2026-04-18],
+          title: "CR Disruption",
+          end: ~D[2026-04-19],
+          url: "/disruptions/321",
+          classNames: "kind-commuter-rail status-approved",
+          extendedProps: %{statusOrder: 0}
+        },
+        %{
+          start: ~D[2026-04-25],
+          title: "CR Disruption",
+          end: ~D[2026-04-26],
+          url: "/disruptions/321",
+          classNames: "kind-commuter-rail status-approved",
           extendedProps: %{statusOrder: 0}
         }
       ]

--- a/test/integration/disruptions_v2_test.exs
+++ b/test/integration/disruptions_v2_test.exs
@@ -46,11 +46,22 @@ defmodule Arrow.Integration.DisruptionsV2Test do
   } do
     disruption_v2_cr_fixture()
 
+    today = Calendar.strftime(DateTime.utc_now(), "%m/%d/%y")
+
     session
     |> visit("/")
     |> click(link("include past"))
-    |> assert_text("01/26/26")
-    |> assert_text("01/27/26")
+    |> assert_text(today)
+    |> assert_text(today)
+  end
+
+  feature "shows CR disruption in calendar view", %{session: session} do
+    disruption_v2_cr_fixture()
+
+    session
+    |> visit("/")
+    |> click(link("⬒ calendar view"))
+    |> assert_text("cr disruption")
   end
 
   defp create_disruption(limit_attrs, replacement_service_attrs) do

--- a/test/support/fixtures/disruptions_fixtures.ex
+++ b/test/support/fixtures/disruptions_fixtures.ex
@@ -75,8 +75,17 @@ defmodule Arrow.DisruptionsFixtures do
                 name: "SPRING2025-SOUTHSS-Weekend-31A",
                 service_dates: [
                   %{
-                    "start_date" => "2026-01-26",
-                    "end_date" => "2026-01-27"
+                    "service_date_days_of_week" => [
+                      "sunday",
+                      "monday",
+                      "tuesday",
+                      "wednesday",
+                      "thursday",
+                      "friday",
+                      "saturday"
+                    ],
+                    "start_date" => Calendar.strftime(DateTime.utc_now(), "%Y-%m-%d"),
+                    "end_date" => Calendar.strftime(DateTime.utc_now(), "%Y-%m-%d")
                   }
                 ]
               }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 🐛  CR disruptions are not rendered in calendar view](https://app.asana.com/1/15492006741476/project/584764604969369/task/1214051967486268?focus=true)

CR disruptions aren't currently being rendered in the calendar view of the main disruptions page. This adds an additional case in `calendar.ex` to parse the service dates for Trainsformer exports in a given disruption into calendar events. 

<img width="1415" height="722" alt="Screenshot 2026-04-14 at 3 39 56 PM" src="https://github.com/user-attachments/assets/744a9698-9383-423d-879c-a4e19797e385" />

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
