### PR TITLE
feat: validate that all trips have at least one stop time

### DIFF
--- a/lib/arrow/trainsformer/export_upload.ex
+++ b/lib/arrow/trainsformer/export_upload.ex
@@ -191,7 +191,8 @@ defmodule Arrow.Trainsformer.ExportUpload do
         validate_unique_service_ids(trips),
         validate_one_of_north_south_stations(stop_ids),
         validate_one_or_all_routes_from_one_side(trips),
-        validate_transfers(transfers, stop_times)
+        validate_transfers(transfers, stop_times),
+        validate_trips_in_stop_times(trips, stop_times)
       ]
       |> Enum.reject(&(&1 == :ok))
 
@@ -511,6 +512,31 @@ defmodule Arrow.Trainsformer.ExportUpload do
           gettext("Multiple routes not north or southside."),
           items: trainsformer_route_ids
         )
+    end
+  end
+
+  def validate_trips_in_stop_times(trips, stop_times) do
+    stop_time_trip_ids = MapSet.new(stop_times, & &1.trip_id)
+
+    trip_ids_missing_stop_times =
+      trips
+      |> Enum.filter(fn trip -> not MapSet.member?(stop_time_trip_ids, trip.trip_id) end)
+      |> Enum.map(& &1.trip_id)
+
+    num_trips_missing_stop_times = length(trip_ids_missing_stop_times)
+
+    if num_trips_missing_stop_times == 0 do
+      :ok
+    else
+      new_error(
+        :trips_missing_stop_times,
+        ngettext(
+          "Export contains a trip with no corresponding stop times.",
+          "Export contains %{count} trips with no corresponding stop times.",
+          num_trips_missing_stop_times
+        ),
+        items: trip_ids_missing_stop_times
+      )
     end
   end
 

--- a/test/arrow/trainsformer/export_upload_test.exs
+++ b/test/arrow/trainsformer/export_upload_test.exs
@@ -659,6 +659,97 @@ defmodule Arrow.Trainsformer.ExportUploadTest do
                  ]
                )
     end
+
+    test "returns an error if multiple trip IDs are missing from stop times" do
+      expected_trip_ids_with_missing_stop_times = [
+        "ERMLTieJob-819522-2f65",
+        "ERMLTieJob-819522-000"
+      ]
+
+      assert {:error,
+              {:trips_missing_stop_times,
+               {
+                 "Export contains 2 trips with no corresponding stop times.",
+                 [items: ^expected_trip_ids_with_missing_stop_times]
+               }}} =
+               ExportUpload.validate_trips_in_stop_times(
+                 [
+                   %{
+                     service_id: "FALL 2025-NORTHWKD-Weekday-21A",
+                     route_id: "CR-Haverhill",
+                     trip_id: "ERMLTieJob-819522-2f65"
+                   },
+                   %{
+                     service_id: "FALL 2025-NORTHWKD-Weekday-21A",
+                     route_id: "CR-Haverhill",
+                     trip_id: "ERMLTieJob-819522-000"
+                   },
+                   %{
+                     service_id: "FALL 2025-NORTHWKD-Weekday-21A",
+                     route_id: "CR-Haverhill",
+                     trip_id: "ERMLTieJob-819523-266"
+                   }
+                 ],
+                 [
+                   %{
+                     departure_time: "17:35:00",
+                     arrival_time: "17:35:00",
+                     stop_id: "BNT-0000",
+                     stop_sequence: "00",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:07:00",
+                     arrival_time: "18:07:00",
+                     stop_id: "WR-0205-02",
+                     stop_sequence: "10",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:12:00",
+                     arrival_time: "18:12:00",
+                     stop_id: "WR-0228-02",
+                     stop_sequence: "20",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:19:00",
+                     arrival_time: "18:19:00",
+                     stop_id: "WR-0264-02",
+                     stop_sequence: "30",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:28:00",
+                     arrival_time: "18:28:00",
+                     stop_id: "WR-0325-01",
+                     stop_sequence: "40",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:37:00",
+                     arrival_time: "18:37:00",
+                     stop_id: "WR-0329-01",
+                     stop_sequence: "50",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "17:40:00",
+                     arrival_time: "17:40:00",
+                     stop_id: "BNT-0000",
+                     stop_sequence: "00",
+                     trip_id: "ERMLTieJob-819522-001"
+                   },
+                   %{
+                     departure_time: "17:30:00",
+                     arrival_time: "17:30:00",
+                     stop_id: "WR-0329-01",
+                     stop_sequence: "00",
+                     trip_id: "ERMLTieJob-819523-266"
+                   }
+                 ]
+               )
+    end
   end
 
   describe "schedule_data_from_zip/3" do

--- a/test/arrow/trainsformer/export_upload_test.exs
+++ b/test/arrow/trainsformer/export_upload_test.exs
@@ -538,6 +538,129 @@ defmodule Arrow.Trainsformer.ExportUploadTest do
     end
   end
 
+  describe "validate_trips_in_stop_times/2" do
+    test "returns ok if all trip IDs exist in stop times" do
+      assert :ok =
+               ExportUpload.validate_trips_in_stop_times(
+                 [
+                   %{
+                     service_id: "FALL 2025-NORTHWKD-Weekday-21A",
+                     route_id: "CR-Haverhill",
+                     trip_id: "ERMLTieJob-819522-265"
+                   }
+                 ],
+                 [
+                   %{
+                     departure_time: "17:35:00",
+                     arrival_time: "17:35:00",
+                     stop_id: "BNT-0000",
+                     stop_sequence: "00",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:07:00",
+                     arrival_time: "18:07:00",
+                     stop_id: "WR-0205-02",
+                     stop_sequence: "10",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:12:00",
+                     arrival_time: "18:12:00",
+                     stop_id: "WR-0228-02",
+                     stop_sequence: "20",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:19:00",
+                     arrival_time: "18:19:00",
+                     stop_id: "WR-0264-02",
+                     stop_sequence: "30",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:28:00",
+                     arrival_time: "18:28:00",
+                     stop_id: "WR-0325-01",
+                     stop_sequence: "40",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:37:00",
+                     arrival_time: "18:37:00",
+                     stop_id: "WR-0329-01",
+                     stop_sequence: "50",
+                     trip_id: "ERMLTieJob-819522-265"
+                   }
+                 ]
+               )
+    end
+
+    test "returns an error if any trip IDs are missing from stop times" do
+      expected_trip_ids_with_missing_stop_times = ["ERMLTieJob-819522-2f65"]
+
+      assert {:error,
+              {:trips_missing_stop_times,
+               {
+                 "Export contains a trip with no corresponding stop times.",
+                 [items: ^expected_trip_ids_with_missing_stop_times]
+               }}} =
+               ExportUpload.validate_trips_in_stop_times(
+                 [
+                   %{
+                     service_id: "FALL 2025-NORTHWKD-Weekday-21A",
+                     route_id: "CR-Haverhill",
+                     trip_id: "ERMLTieJob-819522-2f65"
+                   }
+                 ],
+                 [
+                   %{
+                     departure_time: "17:35:00",
+                     arrival_time: "17:35:00",
+                     stop_id: "BNT-0000",
+                     stop_sequence: "00",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:07:00",
+                     arrival_time: "18:07:00",
+                     stop_id: "WR-0205-02",
+                     stop_sequence: "10",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:12:00",
+                     arrival_time: "18:12:00",
+                     stop_id: "WR-0228-02",
+                     stop_sequence: "20",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:19:00",
+                     arrival_time: "18:19:00",
+                     stop_id: "WR-0264-02",
+                     stop_sequence: "30",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:28:00",
+                     arrival_time: "18:28:00",
+                     stop_id: "WR-0325-01",
+                     stop_sequence: "40",
+                     trip_id: "ERMLTieJob-819522-265"
+                   },
+                   %{
+                     departure_time: "18:37:00",
+                     arrival_time: "18:37:00",
+                     stop_id: "WR-0329-01",
+                     stop_sequence: "50",
+                     trip_id: "ERMLTieJob-819522-265"
+                   }
+                 ]
+               )
+    end
+  end
+
   describe "schedule_data_from_zip/3" do
     @tag export: "valid_export.zip"
     test "extracts schedule data", %{export: export} do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹Trainsformer: Validate that trips in trips.txt have stop times in stop_times.txt](https://app.asana.com/1/15492006741476/project/584764604969369/task/1213871986323903?focus=true)

Adds an additional validation to `export_upload.ex` to check that each trip in an export has at least one corresponding stop time. If an export contains a trip without any stop times, the `gtfs_creator` build will fail downstream so this prevents creating disruptions which cause that failure. Uploading a Trainsformer export that fails this validation renders an error that shows which trip IDs are invalid. 

<img width="1419" height="325" alt="Screenshot 2026-04-28 at 11 26 50 AM" src="https://github.com/user-attachments/assets/36565dfe-f2b5-4a6c-ae96-b48e964a43db" />

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
