### PR TITLE
feat: don't warn if transfers at Braintree missing

### DIFF
--- a/lib/arrow/trainsformer/export_upload.ex
+++ b/lib/arrow/trainsformer/export_upload.ex
@@ -371,7 +371,9 @@ defmodule Arrow.Trainsformer.ExportUpload do
               # South Station
               "NEC-2287",
               # Foxboro
-              "FS-0049-S"
+              "FS-0049-S",
+              # Braintree
+              "MM-0109-S"
             ],
             &1
           )
@@ -388,8 +390,8 @@ defmodule Arrow.Trainsformer.ExportUpload do
       new_warning(
         :trips_missing_transfers,
         ngettext(
-          "A train trip that does not serve North Station, South Station, or Foxboro lacks a transfer.",
-          "%{count} train trips that do not serve North Station, South Station, or Foxboro lack transfers.",
+          "A train trip that does not serve North Station, South Station, Foxboro, or Braintree lacks a transfer.",
+          "%{count} train trips that do not serve North Station, South Station, Foxboro, or Braintree lack transfers.",
           MapSet.size(trips_needing_transfers_without_transfers)
         ),
         items: trips_needing_transfers_without_transfers

--- a/test/arrow/trainsformer/export_upload_test.exs
+++ b/test/arrow/trainsformer/export_upload_test.exs
@@ -499,7 +499,7 @@ defmodule Arrow.Trainsformer.ExportUploadTest do
       assert {:warning,
               {:trips_missing_transfers,
                {
-                 "A train trip that does not serve North Station, South Station, or Foxboro lacks a transfer.",
+                 "A train trip that does not serve North Station, South Station, Foxboro, or Braintree lacks a transfer.",
                  [items: ^expected_trips_with_missing_transfers]
                }}} =
                ExportUpload.validate_transfers(

--- a/test/integration/disruptionsv2/trainsformer_export_section_test.exs
+++ b/test/integration/disruptionsv2/trainsformer_export_section_test.exs
@@ -234,7 +234,7 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
       path: "test/support/fixtures/trainsformer/invalid_export_missing_transfers.zip"
     )
     |> assert_text(
-      "A train trip that does not serve North Station, South Station, or Foxboro lacks a transfer."
+      "A train trip that does not serve North Station, South Station, Foxboro, or Braintree lacks a transfer."
     )
     |> assert_text("Dec14PatsGame-781225-9731")
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹🐛 Lack of transfers logic allows for trains stopping at Braintree without a transfer](https://app.asana.com/1/15492006741476/project/584764604969369/task/1213341844380518?focus=true)

The ticket mentions maybe also linking to the schedule view of the appropriate line / direction from the warning text. Unfortunately, the schedule view requires already having a Trainsformer export ID to work with, but the warning is shown before we actually save / create the Trainsformer export record. As such, it would require a lot of refactoring to make that work, and in the end I don't think it's worth the effort given the small benefit it would provide.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
