### PR TITLE
feat: add validation for day of week checkboxes when editing a Trainsformer export

### DIFF
--- a/lib/arrow/trainsformer/service_date.ex
+++ b/lib/arrow/trainsformer/service_date.ex
@@ -19,7 +19,9 @@ defmodule Arrow.Trainsformer.ServiceDate do
     with %{"service_date_days_of_week" => sddow} <- attrs,
          [_ | _] <- sddow do
       formatted_days =
-        Enum.map(sddow, fn day ->
+        sddow
+        |> Enum.filter(&(&1 != ""))
+        |> Enum.map(fn day ->
           %{
             "day_name" => day
           }
@@ -40,6 +42,7 @@ defmodule Arrow.Trainsformer.ServiceDate do
     |> cast_assoc(:service_date_days_of_week, with: &ServiceDateDayOfWeek.changeset/2)
     |> validate_required([:start_date, :end_date])
     |> Arrow.Util.Validation.validate_start_date_before_end_date()
+    |> validate_length(:service_date_days_of_week, min: 1)
     |> assoc_constraint(:service)
   end
 end

--- a/lib/arrow_web/components/core_components.ex
+++ b/lib/arrow_web/components/core_components.ex
@@ -340,6 +340,7 @@ defmodule ArrowWeb.CoreComponents do
     ~H"""
     <div class="mt-1">
       <div class="grid grid-cols-2 gap-1 text-sm items-baseline">
+        <input type="hidden" name={@name} value="" />
         <div :for={{label, value} <- @options}>
           <label for={"#{@name}-#{value}"}>
             <input

--- a/lib/arrow_web/components/edit_trainsformer_export_form.ex
+++ b/lib/arrow_web/components/edit_trainsformer_export_form.ex
@@ -188,6 +188,7 @@ defmodule ArrowWeb.EditTrainsformerExportForm do
                                 end
                               }
                             />
+                            <.errors field={f_date[:service_date_days_of_week]} always_show />
                           </div>
                         </div>
                         <div class="col">

--- a/test/integration/disruptionsv2/trainsformer_export_section_test.exs
+++ b/test/integration/disruptionsv2/trainsformer_export_section_test.exs
@@ -41,6 +41,7 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
       path: "test/support/fixtures/trainsformer/valid_export.zip"
     )
     |> assert_text("Successfully imported export valid_export.zip!")
+    |> click(Query.checkbox("Wednesday"))
     |> click(Query.css("#save-export-button"))
     |> assert_text("CR-Foxboro")
     |> assert_text("SPRING2025-SOUTHSS-Weekend-66")
@@ -64,6 +65,7 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
     |> attach_file(file_field("trainsformer_export", visible: false),
       path: "test/support/fixtures/trainsformer/valid_export.zip"
     )
+    |> click(Query.checkbox("Wednesday"))
     |> click(Query.css("#save-export-button"))
     |> click(link("Timetable"))
     # Back Bay station
@@ -129,6 +131,7 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
       |> attach_file(file_field("trainsformer_export", visible: false),
         path: "test/support/fixtures/trainsformer/valid_export.zip"
       )
+      |> click(Query.checkbox("Wednesday"))
       |> click(Query.css("#save-export-button"))
 
     # new disruption
@@ -383,5 +386,23 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
       with: "03/17/2026"
     )
     |> refute_has(text("Export must contain at least one route"))
+  end
+
+  feature "shows error when no days of week are selected", %{session: session} do
+    disruption = disruption_v2_fixture(%{mode: :commuter_rail})
+
+    session
+    |> visit("/disruptions/#{disruption.id}")
+    |> click(text("Upload Trainsformer export"))
+    |> assert_text("Upload Trainsformer .zip")
+    |> attach_file(file_field("trainsformer_export", visible: false),
+      path: "test/support/fixtures/trainsformer/valid_export.zip"
+    )
+    |> assert_text("Successfully imported export valid_export.zip!")
+    |> fill_in(
+      Query.fillable_field("End Date"),
+      with: "01/28/2026"
+    )
+    |> assert_text("should have at least 1 item(s)")
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹🐛 Fix day of week selector behavior](https://app.asana.com/1/15492006741476/project/584764604969369/task/1213737218843301?focus=true)

After a lot of wrangling to try to get the days of week checkboxes to disable depending on the selected dates, I decided to just limit the scope of this ticket to fixing the broken checkbox behavior and showing an error if none are selected. The main issue was needing to include a hidden checkbox with an empty value so that the form state would support a state of none selected. This empty value then gets filtered out in the changeset, which also includes a validation for the length of the list of days of week. The errors are also rendered in the export upload form to surface the validation error if it is present.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
