### PR TITLE
Upgrade `nodejs` to 24.16.0.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.18.1-otp-27
 erlang 27.2
-nodejs 23.11.0
+nodejs 24.16.0


### PR DESCRIPTION
**Asana Ticket:** none

24.16.0 is the newest LTS release. Our current version, 23.11.0, is also an LTS release but is nearing EOL.