### PR TITLE
feat: delete exports from S3 on clicking delete

### DIFF
--- a/lib/arrow/hastus/export_upload.ex
+++ b/lib/arrow/hastus/export_upload.ex
@@ -103,6 +103,15 @@ defmodule Arrow.Hastus.ExportUpload do
     end
   end
 
+  @spec delete_from_s3(String.t()) :: {:ok, binary() | {:error, term()}}
+  def delete_from_s3(s3_path) do
+    if Application.fetch_env!(:arrow, :hastus_export_storage_enabled?) do
+      do_delete(s3_path)
+    else
+      {:error, :disabled}
+    end
+  end
+
   # Detects service IDs in the export that are duplicates of existing
   # service IDs in hastus_services.
   # If any such service IDs exist, edits the export so that they are
@@ -212,6 +221,21 @@ defmodule Arrow.Hastus.ExportUpload do
 
     case apply(mod, fun, [upload_op]) do
       {:ok, _} -> {:ok, Path.join(["s3://", s3_bucket, path])}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp do_delete(s3_path) do
+    s3_uri = URI.parse(s3_path)
+    s3_bucket = s3_uri.host
+    s3_path = s3_uri.path
+
+    delete_op = ExAws.S3.delete_object(s3_bucket, s3_path)
+
+    {mod, fun} = Application.fetch_env!(:arrow, :hastus_export_storage_request_fn)
+
+    case apply(mod, fun, [delete_op]) do
+      {:ok, %{body: body}} -> {:ok, body}
       {:error, _} = error -> error
     end
   end

--- a/lib/arrow/trainsformer/export_upload.ex
+++ b/lib/arrow/trainsformer/export_upload.ex
@@ -565,6 +565,15 @@ defmodule Arrow.Trainsformer.ExportUpload do
     end
   end
 
+  @spec delete_from_s3(String.t()) :: {:ok, binary() | {:error, term()}}
+  def delete_from_s3(s3_path) do
+    if Application.fetch_env!(:arrow, :trainsformer_export_storage_enabled?) do
+      do_delete(s3_path)
+    else
+      {:error, :disabled}
+    end
+  end
+
   @type stop_time_info :: %{
           arrival_time: String.t(),
           departure_time: String.t(),
@@ -668,6 +677,21 @@ defmodule Arrow.Trainsformer.ExportUpload do
     {mod, fun} = Application.fetch_env!(:arrow, :trainsformer_export_storage_request_fn)
 
     case apply(mod, fun, [download_op]) do
+      {:ok, %{body: body}} -> {:ok, body}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp do_delete(s3_path) do
+    s3_uri = URI.parse(s3_path)
+    s3_bucket = s3_uri.host
+    s3_path = s3_uri.path
+
+    delete_op = ExAws.S3.delete_object(s3_bucket, s3_path)
+
+    {mod, fun} = Application.fetch_env!(:arrow, :trainsformer_export_storage_request_fn)
+
+    case apply(mod, fun, [delete_op]) do
       {:ok, %{body: body}} -> {:ok, body}
       {:error, _} = error -> error
     end

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -5,8 +5,10 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
   alias Arrow.Disruptions.{DisruptionV2, Limit, ReplacementService}
   alias Arrow.Hastus
   alias Arrow.Hastus.Export, as: HastusExport
+  alias Arrow.Hastus.ExportUpload, as: HastusExportUpload
   alias Arrow.Trainsformer
   alias Arrow.Trainsformer.Export, as: TrainsformerExport
+  alias Arrow.Trainsformer.ExportUpload, as: TrainsformerExportUpload
   alias ArrowWeb.DisruptionComponents
 
   @impl true
@@ -115,21 +117,29 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
     {parsed_id, _} = Integer.parse(export_id)
     export = Hastus.get_export!(parsed_id)
 
-    case Hastus.delete_export(export) do
-      {:ok, _} ->
-        disruption = %{
-          socket.assigns.disruption
-          | hastus_exports:
-              Enum.reject(socket.assigns.disruption.hastus_exports, &(&1.id == parsed_id))
-        }
+    with {:ok, _} <- HastusExportUpload.delete_from_s3(export.s3_path),
+         {:ok, _} <- Hastus.delete_export(export) do
+      disruption = %{
+        socket.assigns.disruption
+        | hastus_exports:
+            Enum.reject(socket.assigns.disruption.hastus_exports, &(&1.id == parsed_id))
+      }
 
-        {:noreply,
-         socket
-         |> assign(:disruption, disruption)
-         |> put_flash(:info, "Export deleted successfully")}
-
+      {:noreply,
+       socket
+       |> assign(:disruption, disruption)
+       |> put_flash(:info, "Export deleted successfully")}
+    else
       {:error, %Ecto.Changeset{} = _changeset} ->
         {:noreply, put_flash(socket, :error, "Error when deleting export!")}
+
+      {:error, _} ->
+        {:noreply,
+         socket
+         |> update(
+           :errors,
+           &[{:error, {:s3_delete_failed, {"Failed to delete export in S3", []}}} | &1]
+         )}
     end
   end
 
@@ -137,21 +147,29 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
     {parsed_id, _} = Integer.parse(export_id)
     export = Trainsformer.get_export!(parsed_id)
 
-    case Trainsformer.delete_export(export) do
-      {:ok, _} ->
-        disruption = %{
-          socket.assigns.disruption
-          | trainsformer_exports:
-              Enum.reject(socket.assigns.disruption.trainsformer_exports, &(&1.id == parsed_id))
-        }
+    with {:ok, _} <- TrainsformerExportUpload.delete_from_s3(export.s3_path),
+         {:ok, _} <- Trainsformer.delete_export(export) do
+      disruption = %{
+        socket.assigns.disruption
+        | trainsformer_exports:
+            Enum.reject(socket.assigns.disruption.trainsformer_exports, &(&1.id == parsed_id))
+      }
 
-        {:noreply,
-         socket
-         |> assign(:disruption, disruption)
-         |> put_flash(:info, "Export deleted successfully")}
-
+      {:noreply,
+       socket
+       |> assign(:disruption, disruption)
+       |> put_flash(:info, "Export deleted successfully")}
+    else
       {:error, %Ecto.Changeset{} = _changeset} ->
         {:noreply, put_flash(socket, :error, "Error when deleting export!")}
+
+      {:error, _} ->
+        {:noreply,
+         socket
+         |> update(
+           :errors,
+           &[{:error, {:s3_delete_failed, {"Failed to delete export in S3", []}}} | &1]
+         )}
     end
   end
 

--- a/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
+++ b/lib/arrow_web/live/disruption_v2_live/disruption_v2_view_live.ex
@@ -134,12 +134,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
         {:noreply, put_flash(socket, :error, "Error when deleting export!")}
 
       {:error, _} ->
-        {:noreply,
-         socket
-         |> update(
-           :errors,
-           &[{:error, {:s3_delete_failed, {"Failed to delete export in S3", []}}} | &1]
-         )}
+        {:noreply, put_flash(socket, :error, "Failed to delete export in S3")}
     end
   end
 
@@ -164,12 +159,7 @@ defmodule ArrowWeb.DisruptionV2ViewLive do
         {:noreply, put_flash(socket, :error, "Error when deleting export!")}
 
       {:error, _} ->
-        {:noreply,
-         socket
-         |> update(
-           :errors,
-           &[{:error, {:s3_delete_failed, {"Failed to delete export in S3", []}}} | &1]
-         )}
+        {:noreply, put_flash(socket, :error, "Failed to delete export in S3")}
     end
   end
 

--- a/test/arrow/hastus/export_upload_test.exs
+++ b/test/arrow/hastus/export_upload_test.exs
@@ -692,4 +692,21 @@ defmodule Arrow.Hastus.ExportUploadTest do
                ~r/s3:\/\/mbta-arrow\/hastus-export-uploads\/\d+_export\.v2\.final_disruption_12345\.zip/
     end
   end
+
+  describe "delete_from_s3/1" do
+    test "delete is disabled" do
+      assert {:error, :disabled} = ExportUpload.delete_from_s3("filename")
+    end
+
+    test "deletes uploaded file" do
+      reassign_env(:hastus_export_storage_enabled?, true)
+
+      upload_result = ExportUpload.upload_to_s3("file content", "export.zip", "12345")
+      {:ok, path} = upload_result
+
+      delete_result = ExportUpload.delete_from_s3(path)
+
+      assert {:ok, _} = delete_result
+    end
+  end
 end

--- a/test/arrow/trainsformer/export_upload_test.exs
+++ b/test/arrow/trainsformer/export_upload_test.exs
@@ -126,6 +126,23 @@ defmodule Arrow.Trainsformer.ExportUploadTest do
     end
   end
 
+  describe "delete_from_s3/1" do
+    test "delete is disabled" do
+      assert {:error, :disabled} = ExportUpload.delete_from_s3("filename")
+    end
+
+    test "deletes uploaded file" do
+      reassign_env(:trainsformer_export_storage_enabled?, true)
+
+      upload_result = ExportUpload.upload_to_s3("file content", "export.zip", "12345")
+      {:ok, path} = upload_result
+
+      delete_result = ExportUpload.delete_from_s3(path)
+
+      assert {:ok, _} = delete_result
+    end
+  end
+
   describe "validate_stop_ids_in_gtfs/4" do
     defmodule FakeRepo do
       def all(_) do

--- a/test/integration/disruptionsv2/hastus_export_section_test.exs
+++ b/test/integration/disruptionsv2/hastus_export_section_test.exs
@@ -8,6 +8,24 @@ defmodule Arrow.Integration.Disruptionsv2.HastusExportSectionTest do
 
   @moduletag :integration
 
+  defmodule FakeRequestWithValidExport do
+    @export_dir "test/support/fixtures/hastus"
+
+    def request(_) do
+      {:ok, %{body: File.read!("#{@export_dir}/valid_export.zip")}}
+    end
+  end
+
+  setup do
+    reassign_env(
+      :hastus_export_storage_request_fn,
+      {Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest.FakeRequestWithValidExport,
+       :request}
+    )
+
+    reassign_env(:hastus_export_storage_enabled?, true)
+  end
+
   feature "can upload a HASTUS export", %{session: session} do
     disruption = disruption_v2_fixture()
     line = insert(:gtfs_line, id: "line-Blue")

--- a/test/integration/disruptionsv2/hastus_export_section_test.exs
+++ b/test/integration/disruptionsv2/hastus_export_section_test.exs
@@ -5,6 +5,7 @@ defmodule Arrow.Integration.Disruptionsv2.HastusExportSectionTest do
   import Wallaby.Query
   import Arrow.{DisruptionsFixtures, HastusFixtures}
   import Arrow.Factory
+  import Test.Support.Helpers
 
   @moduletag :integration
 

--- a/test/integration/disruptionsv2/hastus_export_section_test.exs
+++ b/test/integration/disruptionsv2/hastus_export_section_test.exs
@@ -20,7 +20,7 @@ defmodule Arrow.Integration.Disruptionsv2.HastusExportSectionTest do
   setup do
     reassign_env(
       :hastus_export_storage_request_fn,
-      {Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest.FakeRequestWithValidExport,
+      {Arrow.Integration.Disruptionsv2.HastusExportSectionTest.FakeRequestWithValidExport,
        :request}
     )
 

--- a/test/integration/disruptionsv2/trainsformer_export_section_test.exs
+++ b/test/integration/disruptionsv2/trainsformer_export_section_test.exs
@@ -9,6 +9,14 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
 
   @moduletag :integration
 
+  defmodule FakeRequestWithValidExport do
+    @export_dir "test/support/fixtures/trainsformer"
+
+    def request(_) do
+      {:ok, %{body: File.read!("#{@export_dir}/valid_export.zip")}}
+    end
+  end
+
   setup do
     stops = [
       "NEC-2287",
@@ -26,6 +34,14 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
     for stop <- stops do
       insert(:gtfs_stop, id: stop, name: stop, lat: 0, lon: 0, municipality: "Boston")
     end
+
+    reassign_env(
+      :trainsformer_export_storage_request_fn,
+      {Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest.FakeRequestWithValidExport,
+       :request}
+    )
+
+    reassign_env(:trainsformer_export_storage_enabled?, true)
 
     :ok
   end
@@ -49,14 +65,6 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
   end
 
   feature "can view a timetable and toggle directions", %{session: session} do
-    reassign_env(
-      :trainsformer_export_storage_request_fn,
-      {Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest.FakeRequestWithValidExport,
-       :request}
-    )
-
-    reassign_env(:trainsformer_export_storage_enabled?, true)
-
     disruption = disruption_v2_fixture(%{mode: :commuter_rail})
 
     session
@@ -290,14 +298,6 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
     accept_prompt(session, fn s ->
       s |> click(text("Cancel")) |> assert_text("Upload Trainsformer export")
     end)
-  end
-
-  defmodule FakeRequestWithValidExport do
-    @export_dir "test/support/fixtures/trainsformer"
-
-    def request(_) do
-      {:ok, %{body: File.read!("#{@export_dir}/valid_export.zip")}}
-    end
   end
 
   feature "can edit an existing Trainsformer export", %{session: session} do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹🚆Delete trainsformer exports that have been uploaded to S3](https://app.asana.com/1/15492006741476/project/584764604969369/task/1213125718572393?focus=true)

Deletes Trainsformer and HASTUS exports from S3 when an export is deleted by a user. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
