### PR TITLE
chore: update warning for missing route in trainsformer export

### DIFF
--- a/lib/arrow/trainsformer/export_upload.ex
+++ b/lib/arrow/trainsformer/export_upload.ex
@@ -487,8 +487,8 @@ defmodule Arrow.Trainsformer.ExportUpload do
         new_warning(
           :missing_routes,
           ngettext(
-            "Export is missing a Southside route.",
-            "Export is missing %{count} Southside routes.",
+            "Export is missing a Southside route. Service will be removed from this route.",
+            "Export is missing %{count} Southside routes. Service will be removed from these routes.",
             num_southside_routes_missing
           ),
           items: southside_routes_missing
@@ -498,8 +498,8 @@ defmodule Arrow.Trainsformer.ExportUpload do
         new_warning(
           :missing_routes,
           ngettext(
-            "Export is missing a Northside route.",
-            "Export is missing %{count} Northside routes.",
+            "Export is missing a Northside route. Service will be removed from this route.",
+            "Export is missing %{count} Northside routes. Service will be removed from these routes.",
             num_northside_routes_missing
           ),
           items: northside_routes_missing

--- a/lib/arrow/trainsformer/export_upload.ex
+++ b/lib/arrow/trainsformer/export_upload.ex
@@ -487,8 +487,8 @@ defmodule Arrow.Trainsformer.ExportUpload do
         new_warning(
           :missing_routes,
           ngettext(
-            "Export is missing a Southside route. Service will be removed from this route.",
-            "Export is missing %{count} Southside routes. Service will be removed from these routes.",
+            "Export is missing a South-Side route. Service will be removed from this route.",
+            "Export is missing %{count} South-Side routes. Service will be removed from these routes.",
             num_southside_routes_missing
           ),
           items: southside_routes_missing
@@ -498,8 +498,8 @@ defmodule Arrow.Trainsformer.ExportUpload do
         new_warning(
           :missing_routes,
           ngettext(
-            "Export is missing a Northside route. Service will be removed from this route.",
-            "Export is missing %{count} Northside routes. Service will be removed from these routes.",
+            "Export is missing a North-Side route. Service will be removed from this route.",
+            "Export is missing %{count} North-Side routes. Service will be removed from these routes.",
             num_northside_routes_missing
           ),
           items: northside_routes_missing
@@ -509,7 +509,7 @@ defmodule Arrow.Trainsformer.ExportUpload do
       true ->
         new_warning(
           :invalid_routes,
-          gettext("Multiple routes not north or southside."),
+          gettext("Multiple routes not north or south-side."),
           items: trainsformer_route_ids
         )
     end

--- a/test/arrow/trainsformer/export_upload_test.exs
+++ b/test/arrow/trainsformer/export_upload_test.exs
@@ -361,7 +361,7 @@ defmodule Arrow.Trainsformer.ExportUploadTest do
                {
                  :missing_routes,
                  {
-                   "Export is missing 2 Northside routes.",
+                   "Export is missing 2 Northside routes. Service will be removed from these routes.",
                    [items: ["CR-Fitchburg", "CR-Lowell"]]
                  }
                }
@@ -386,7 +386,7 @@ defmodule Arrow.Trainsformer.ExportUploadTest do
                {
                  :missing_routes,
                  {
-                   "Export is missing 6 Southside routes.",
+                   "Export is missing 6 Southside routes. Service will be removed from these routes.",
                    [
                      items: [
                        "CR-Greenbush",

--- a/test/arrow/trainsformer/export_upload_test.exs
+++ b/test/arrow/trainsformer/export_upload_test.exs
@@ -303,7 +303,7 @@ defmodule Arrow.Trainsformer.ExportUploadTest do
   end
 
   describe "validate_one_or_all_routes_from_one_side/3" do
-    test "returns empty error route lists if all Northside routes have a trip" do
+    test "returns empty error route lists if all North-Side routes have a trip" do
       assert :ok =
                ExportUpload.validate_one_or_all_routes_from_one_side([
                  %{
@@ -329,7 +329,7 @@ defmodule Arrow.Trainsformer.ExportUploadTest do
                ])
     end
 
-    test "returns empty error route lists if exactly one Northside route has a trip" do
+    test "returns empty error route lists if exactly one North-Side route has a trip" do
       assert :ok =
                ExportUpload.validate_one_or_all_routes_from_one_side([
                  %{
@@ -355,13 +355,13 @@ defmodule Arrow.Trainsformer.ExportUploadTest do
                ])
     end
 
-    test "returns missing routes if more than one but not all Northside routes have a trip" do
+    test "returns missing routes if more than one but not all North-Side routes have a trip" do
       assert {
                :warning,
                {
                  :missing_routes,
                  {
-                   "Export is missing 2 Northside routes. Service will be removed from these routes.",
+                   "Export is missing 2 North-Side routes. Service will be removed from these routes.",
                    [items: ["CR-Fitchburg", "CR-Lowell"]]
                  }
                }
@@ -380,13 +380,13 @@ defmodule Arrow.Trainsformer.ExportUploadTest do
                ])
     end
 
-    test "returns missing routes if more than one but not all Southside routes have a trip" do
+    test "returns missing routes if more than one but not all South-Side routes have a trip" do
       assert {
                :warning,
                {
                  :missing_routes,
                  {
-                   "Export is missing 6 Southside routes. Service will be removed from these routes.",
+                   "Export is missing 6 South-Side routes. Service will be removed from these routes.",
                    [
                      items: [
                        "CR-Greenbush",
@@ -433,7 +433,7 @@ defmodule Arrow.Trainsformer.ExportUploadTest do
     test "returns invalid routes for multiple routes not in either side's required list" do
       assert {:warning,
               {:invalid_routes,
-               {"Multiple routes not north or southside.", [items: ["CR-Foxboro", "CR-Nowhere"]]}}} =
+               {"Multiple routes not north or south-side.", [items: ["CR-Foxboro", "CR-Nowhere"]]}}} =
                ExportUpload.validate_one_or_all_routes_from_one_side([
                  %{
                    route_id: "CR-Foxboro",

--- a/test/integration/disruptionsv2/trainsformer_export_section_test.exs
+++ b/test/integration/disruptionsv2/trainsformer_export_section_test.exs
@@ -212,11 +212,11 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
     |> attach_file(file_field("trainsformer_export", visible: false),
       path: "test/support/fixtures/trainsformer/invalid_export_missing_south_side_routes.zip"
     )
-    |> assert_text("Export is missing 4 Southside routes.")
+    |> assert_text("Export is missing 4 South-Side routes.")
     |> assert_text("CR-Greenbush")
   end
 
-  feature "shows warning for trainsformer export containing multiple routes that are neither north nor southside",
+  feature "shows warning for trainsformer export containing multiple routes that are neither north nor south-side",
           %{
             session: session
           } do
@@ -229,7 +229,7 @@ defmodule Arrow.Integration.Disruptionsv2.TrainsformerExportSectionTest do
     |> attach_file(file_field("trainsformer_export", visible: false),
       path: "test/support/fixtures/trainsformer/invalid_export_multiple_no_side_routes.zip"
     )
-    |> assert_text("Multiple routes not north or southside.")
+    |> assert_text("Multiple routes not north or south-side.")
     |> assert_text("CR-Nowhere")
     |> assert_text("CR-Foxboro")
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹Trainsformer exports that omit routes should remove service for those routes](https://app.asana.com/1/15492006741476/project/584764604969369/task/1214816640252067?focus=true)

Updates the copy of the warning that displays when a trainsformer export is uploaded to arrow that is missing one or more northside or southside routes. Once https://github.com/mbta/gtfs_creator/pull/3432 is merged, uploading an export with missing routes will remove service from those routes when the GTFS is built.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
