### PR TITLE
feat: render full shuttle name in list instead of disabled input

### DIFF
--- a/lib/arrow_web/controllers/shape_html.ex
+++ b/lib/arrow_web/controllers/shape_html.ex
@@ -6,6 +6,20 @@ defmodule ArrowWeb.ShapeView do
   alias Arrow.Shuttles.Stop, as: ArrowStop
   alias Phoenix.Controller
 
+  @colors [
+    "da291c",
+    "003da5",
+    "ffc72c",
+    "00843d",
+    "ed8b00",
+    "7c878e",
+    "494f5c",
+    "003383",
+    "80276c",
+    "008eaa",
+    "52bbc5"
+  ]
+
   embed_templates "shape_html/*"
 
   @doc """
@@ -101,4 +115,8 @@ defmodule ArrowWeb.ShapeView do
   end
 
   defp render_route_stops(_), do: []
+
+  attr :colors, :list, default: @colors
+
+  def select(assigns)
 end

--- a/lib/arrow_web/controllers/shape_html/select.html.heex
+++ b/lib/arrow_web/controllers/shape_html/select.html.heex
@@ -36,7 +36,7 @@
           <span class="flex align-items-center">Via</span>
           <.input field={f_nested[:suffix]} class="flex align-items-center mt-3" />
           <div class="flex align-items-center pt-[23px]">
-            <.input field={f_nested[:save]} type="checkbox"/>
+            <.input field={f_nested[:save]} type="checkbox" />
           </div>
           <div class="hidden">
             <.input

--- a/lib/arrow_web/controllers/shape_html/select.html.heex
+++ b/lib/arrow_web/controllers/shape_html/select.html.heex
@@ -26,13 +26,18 @@
           as={:shapes}
           skip_hidden={true}
         >
-          <.input field={f_nested[:name]} class="flex align-items-center" disabled />
-          <.input field={f_nested[:start_location]} class="flex align-items-center" />
-          <span>To</span>
-          <.input field={f_nested[:end_location]} class="flex align-items-center" />
-          <span>Via</span>
-          <.input field={f_nested[:suffix]} class="flex align-items-center" />
-          <.input field={f_nested[:save]} type="checkbox" />
+          <span class="text-sm my-auto">
+            <div class={"legend-square color-#{Enum.at(@colors, f_nested.index)}"}></div>
+            {input_value(f_nested, :name)}
+          </span>
+          <.input field={f_nested[:start_location]} class="flex align-items-center mt-3" />
+          <span class="flex align-items-center">To</span>
+          <.input field={f_nested[:end_location]} class="flex align-items-center mt-3" />
+          <span class="flex align-items-center">Via</span>
+          <.input field={f_nested[:suffix]} class="flex align-items-center mt-3" />
+          <div class="flex align-items-center pt-[23px]">
+            <.input field={f_nested[:save]} type="checkbox"/>
+          </div>
           <div class="hidden">
             <.input
               field={f_nested[:coordinates]}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🏹 Don't truncate shape names when uploading KML](https://app.asana.com/1/15492006741476/project/584764604969369/task/1214394281054114?focus=true)

Rather than rendering the shuttle name in a disabled input when uploading shuttle KML files, renders the full name of the shuttle in the list along with the legend square with the corresponding color used on the map rendered above the list. 

Before:
<img width="1423" height="623" alt="Screenshot 2026-07-27 at 2 34 50 PM" src="https://github.com/user-attachments/assets/caf49cd0-ff28-474d-b677-ab0bf129968c" />


After:
<img width="1423" height="648" alt="Screenshot 2026-07-27 at 2 45 38 PM" src="https://github.com/user-attachments/assets/360ecca0-0959-428e-aa92-2a765f487e9f" />


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes.
